### PR TITLE
fix(auth): send correct audience so Auth0 issues JWT instead of opaque token

### DIFF
--- a/src/config/auth.config.ts
+++ b/src/config/auth.config.ts
@@ -1,8 +1,10 @@
+import { env } from './env.config';
+
 export const authConfig = {
-  domain: import.meta.env.VITE_AUTH0_DOMAIN || '',
-  clientId: import.meta.env.VITE_AUTH0_CLIENT_ID || '',
+  domain: env.auth0.domain,
+  clientId: env.auth0.clientId,
   authorizationParams: {
     redirect_uri: window.location.origin,
-    audience: import.meta.env.VITE_AUTH0_AUDIENCE || '',
+    audience: env.auth0.audience,
   },
 };

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -16,7 +16,11 @@ export function useAuth() {
   // Set up the access token getter for axios
   useEffect(() => {
     if (!isDemoMode) {
-      setAccessTokenGetter(getAccessTokenSilently);
+      setAccessTokenGetter(() =>
+        getAccessTokenSilently({
+          authorizationParams: { audience: import.meta.env.VITE_AUTH0_AUDIENCE || 'https://casazen-api' },
+        })
+      );
     }
   }, [getAccessTokenSilently]);
 


### PR DESCRIPTION
auth.config.ts was falling back to empty-string audience when
VITE_AUTH0_AUDIENCE was unset, causing Auth0 to issue an opaque token
that the backend rejects with 401. Replaced the duplicated env-var
reads with env.config.ts (which defaults to 'https://casazen-api').

Also pass the audience explicitly to getAccessTokenSilently so the
correct JWT is requested regardless of provider configuration.

Fixes #40

https://claude.ai/code/session_01B2vzmq4pVAHtppmZ3UCcXY