### PR TITLE
fix(api): use axios directly for search endpoint to handle unwrapped …

### DIFF
--- a/src/api/properties.api.ts
+++ b/src/api/properties.api.ts
@@ -20,6 +20,9 @@ export const propertiesApi = {
 
   delete: (id: string) => ApiClient.delete<void>(`/properties/${id}`),
 
-  search: (params: PropertySearchParams) =>
-    ApiClient.get<Property[]>('/properties/search', params),
+  search: async (params: PropertySearchParams) => {
+    // Backend returns array directly, not wrapped in ApiResponse
+    const response = await axios.get<Property[]>('/properties/search', { params });
+    return response.data;
+  },
 };


### PR DESCRIPTION
…response

Backend returns array directly instead of wrapped ApiResponse format. Changed search method to use axios.get and return response.data directly instead of ApiClient.get which expects response.data.data structure.

Fixes React Query 'data cannot be undefined' error on search page.