### PR TITLE
feat: implement pricing adapter state management hooks

### DIFF
--- a/src/queries/__tests__/use-pricing-adapter.test.ts
+++ b/src/queries/__tests__/use-pricing-adapter.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import {
+  usePricingAdapterConfig,
+  useSavePricingAdapterConfig,
+  useDisablePricingAdapter,
+  usePricingHistory,
+  useTriggerPricingSync,
+  usePricingPreview,
+} from '../use-pricing-adapter';
+import { pricingAdapterApi } from '@/api/pricing-adapter.api';
+import type { PricingAdapterConfig, PricingHistoryPagedResponse, PricingPreviewResponse } from '@/types';
+
+vi.mock('@/api/pricing-adapter.api');
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const PROPERTY_ID = 'prop-abc';
+
+const mockConfig: PricingAdapterConfig = {
+  propertyId: PROPERTY_ID,
+  isEnabled: true,
+  adaptationFrequency: 'daily',
+  includeSeasonality: true,
+  includePublicHolidays: false,
+  lastAdaptedAt: null,
+  nextScheduledRunAt: '2026-05-12T02:00:00Z',
+  createdAt: '2026-05-11T00:00:00Z',
+  updatedAt: '2026-05-11T00:00:00Z',
+};
+
+const mockHistory: PricingHistoryPagedResponse = {
+  items: [],
+  total: 0,
+  page: 1,
+};
+
+const mockPreview: PricingPreviewResponse = {
+  prices: [{ date: '2026-05-12', suggestedPrice: 115, basePrice: 100, reason: 'Weekend' }],
+};
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('usePricingAdapterConfig', () => {
+  it('fetches config for a given propertyId', async () => {
+    vi.mocked(pricingAdapterApi.getConfig).mockResolvedValueOnce(mockConfig);
+
+    const { result } = renderHook(() => usePricingAdapterConfig(PROPERTY_ID), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(pricingAdapterApi.getConfig).toHaveBeenCalledWith(PROPERTY_ID);
+    expect(result.current.data).toEqual(mockConfig);
+  });
+
+  it('does not fetch when propertyId is empty', () => {
+    const { result } = renderHook(() => usePricingAdapterConfig(''), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(pricingAdapterApi.getConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSavePricingAdapterConfig', () => {
+  it('calls saveConfig and invalidates cache on success', async () => {
+    vi.mocked(pricingAdapterApi.saveConfig).mockResolvedValueOnce(mockConfig);
+
+    const { result } = renderHook(() => useSavePricingAdapterConfig(PROPERTY_ID), {
+      wrapper: makeWrapper(),
+    });
+    const req = { isEnabled: true, adaptationFrequency: 'daily' as const, includeSeasonality: true, includePublicHolidays: false };
+
+    await act(async () => {
+      result.current.mutate(req);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(pricingAdapterApi.saveConfig).toHaveBeenCalledWith(PROPERTY_ID, req);
+  });
+});
+
+describe('useDisablePricingAdapter', () => {
+  it('calls disableConfig on mutate', async () => {
+    vi.mocked(pricingAdapterApi.disableConfig).mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useDisablePricingAdapter(PROPERTY_ID), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(pricingAdapterApi.disableConfig).toHaveBeenCalledWith(PROPERTY_ID);
+  });
+
+  it('rolls back optimistic update on error', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(['pricing-adapter', 'config', PROPERTY_ID], mockConfig);
+
+    vi.mocked(pricingAdapterApi.disableConfig).mockRejectedValueOnce(new Error('Network error'));
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+
+    const { result } = renderHook(() => useDisablePricingAdapter(PROPERTY_ID), { wrapper });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const restored = client.getQueryData(['pricing-adapter', 'config', PROPERTY_ID]);
+    expect(restored).toEqual(mockConfig);
+  });
+});
+
+describe('usePricingHistory', () => {
+  it('fetches history with params', async () => {
+    vi.mocked(pricingAdapterApi.getHistory).mockResolvedValueOnce(mockHistory);
+    const params = { page: 1, pageSize: 20 };
+
+    const { result } = renderHook(() => usePricingHistory(PROPERTY_ID, params), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(pricingAdapterApi.getHistory).toHaveBeenCalledWith(PROPERTY_ID, params);
+  });
+});
+
+describe('useTriggerPricingSync', () => {
+  it('calls triggerSync and returns jobId', async () => {
+    vi.mocked(pricingAdapterApi.triggerSync).mockResolvedValueOnce({ jobId: 'job-1' });
+
+    const { result } = renderHook(() => useTriggerPricingSync(PROPERTY_ID), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.jobId).toBe('job-1');
+  });
+});
+
+describe('usePricingPreview', () => {
+  it('fetches preview prices', async () => {
+    vi.mocked(pricingAdapterApi.getPreview).mockResolvedValueOnce(mockPreview);
+
+    const { result } = renderHook(() => usePricingPreview(PROPERTY_ID), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.prices).toHaveLength(1);
+  });
+});

--- a/src/queries/use-pricing-adapter.ts
+++ b/src/queries/use-pricing-adapter.ts
@@ -1,0 +1,97 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { pricingAdapterApi } from '@/api/pricing-adapter.api';
+import type {
+  SavePricingAdapterConfigRequest,
+  PricingHistoryQueryParams,
+} from '@/types';
+import { toast } from 'sonner';
+
+const PRICING_KEY = 'pricing-adapter';
+
+export function usePricingAdapterConfig(propertyId: string) {
+  return useQuery({
+    queryKey: [PRICING_KEY, 'config', propertyId],
+    queryFn: () => pricingAdapterApi.getConfig(propertyId),
+    enabled: !!propertyId,
+  });
+}
+
+export function useSavePricingAdapterConfig(propertyId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: SavePricingAdapterConfigRequest) =>
+      pricingAdapterApi.saveConfig(propertyId, data),
+    onMutate: async (data) => {
+      await queryClient.cancelQueries({ queryKey: [PRICING_KEY, 'config', propertyId] });
+      const previous = queryClient.getQueryData([PRICING_KEY, 'config', propertyId]);
+      queryClient.setQueryData([PRICING_KEY, 'config', propertyId], (old: any) =>
+        old ? { ...old, ...data } : old
+      );
+      return { previous };
+    },
+    onError: (_err, _data, context) => {
+      queryClient.setQueryData([PRICING_KEY, 'config', propertyId], context?.previous);
+      toast.error('Failed to save pricing configuration');
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PRICING_KEY, 'config', propertyId] });
+      toast.success('Pricing configuration saved');
+    },
+  });
+}
+
+export function useDisablePricingAdapter(propertyId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => pricingAdapterApi.disableConfig(propertyId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: [PRICING_KEY, 'config', propertyId] });
+      const previous = queryClient.getQueryData([PRICING_KEY, 'config', propertyId]);
+      queryClient.setQueryData([PRICING_KEY, 'config', propertyId], (old: any) =>
+        old ? { ...old, isEnabled: false } : old
+      );
+      return { previous };
+    },
+    onError: (_err, _data, context) => {
+      queryClient.setQueryData([PRICING_KEY, 'config', propertyId], context?.previous);
+      toast.error('Failed to disable AI pricing');
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PRICING_KEY, 'config', propertyId] });
+      toast.success('AI pricing disabled');
+    },
+  });
+}
+
+export function usePricingHistory(propertyId: string, params?: PricingHistoryQueryParams) {
+  return useQuery({
+    queryKey: [PRICING_KEY, 'history', propertyId, params],
+    queryFn: () => pricingAdapterApi.getHistory(propertyId, params),
+    enabled: !!propertyId,
+  });
+}
+
+export function useTriggerPricingSync(propertyId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => pricingAdapterApi.triggerSync(propertyId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PRICING_KEY, 'history', propertyId] });
+      toast.success('Pricing sync started — history will update shortly');
+    },
+    onError: () => {
+      toast.error('Failed to trigger pricing sync');
+    },
+  });
+}
+
+export function usePricingPreview(propertyId: string) {
+  return useQuery({
+    queryKey: [PRICING_KEY, 'preview', propertyId],
+    queryFn: () => pricingAdapterApi.getPreview(propertyId),
+    enabled: !!propertyId,
+  });
+}


### PR DESCRIPTION
## Summary

- Added `src/queries/use-pricing-adapter.ts` following the existing React Query + sonner pattern (see `use-ota.ts`, `use-properties.ts`)
- 6 typed hooks:
  - `usePricingAdapterConfig(propertyId)` — GET config
  - `useSavePricingAdapterConfig(propertyId)` — POST config with **optimistic update** (immediately reflects new values in cache, rolls back on error)
  - `useDisablePricingAdapter(propertyId)` — DELETE config with **optimistic update** (sets `isEnabled: false` immediately, rolls back on error)
  - `usePricingHistory(propertyId, params?)` — GET paginated history
  - `useTriggerPricingSync(propertyId)` — POST sync (enqueues Hangfire job, invalidates history)
  - `usePricingPreview(propertyId)` — GET 90-day price preview
- All mutations: success/error toast via sonner; cache invalidation on success
- `enabled: !!propertyId` guard on all queries

## Test Plan
- [x] `npm test` → 15 tests pass (7 from #58 + 8 new), 0 failed
- [ ] Optimistic rollback: `useDisablePricingAdapter` rollback test covers error path

Closes #59
Part of: casazen/backend#116

🤖 Generated with [Claude Code](https://claude.com/claude-code)