### PR TITLE
feat: build pricing audit trail UI

### DIFF
--- a/src/features/pricing/__tests__/pricing-history-page.test.tsx
+++ b/src/features/pricing/__tests__/pricing-history-page.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { PricingHistoryPage } from '../pricing-history-page';
+import * as pricingQueries from '@/queries/use-pricing-adapter';
+import * as pricingApi from '@/api/pricing-adapter.api';
+import type { PricingHistoryPagedResponse } from '@/types';
+
+vi.mock('@/queries/use-pricing-adapter');
+vi.mock('@/api/pricing-adapter.api', () => ({
+  pricingAdapterApi: {
+    getHistory: vi.fn(),
+  },
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@/components/layout/app-shell', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => createElement('div', { 'data-testid': 'app-shell' }, children),
+}));
+vi.mock('@/components/layout/page-header', () => ({
+  PageHeader: ({ title }: { title: string }) => createElement('h1', null, title),
+}));
+
+const PROPERTY_ID = 'prop-test';
+
+const mockEntry = {
+  id: 'hist-1',
+  propertyId: PROPERTY_ID,
+  adaptationDate: '2026-05-10',
+  previousPrice: 100,
+  newPrice: 120,
+  changeReason: 'Weekend surge',
+  aiConfidence: 0.87,
+  otasSynced: 'airbnb,booking',
+  syncStatus: 'synced' as const,
+  createdAt: '2026-05-10T08:00:00Z',
+};
+
+const mockHistory: PricingHistoryPagedResponse = {
+  items: [mockEntry],
+  total: 1,
+  page: 1,
+};
+
+const mockHistoryMultiPage: PricingHistoryPagedResponse = {
+  items: [mockEntry],
+  total: 50,
+  page: 1,
+};
+
+function renderPage(propertyId = PROPERTY_ID) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(
+        MemoryRouter,
+        { initialEntries: [`/properties/${propertyId}/pricing/history`] },
+        createElement(Routes, null,
+          createElement(Route, {
+            path: '/properties/:id/pricing/history',
+            element: createElement(PricingHistoryPage),
+          })
+        )
+      )
+    )
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, 'URL', {
+    value: { createObjectURL: vi.fn(() => 'blob:fake'), revokeObjectURL: vi.fn() },
+    writable: true,
+  });
+});
+
+describe('PricingHistoryPage', () => {
+  it('shows loading state while fetching', () => {
+    vi.mocked(pricingQueries.usePricingHistory).mockReturnValue({ data: undefined, isLoading: true } as any);
+
+    renderPage();
+
+    expect(screen.getByTestId('history-loading')).toBeInTheDocument();
+  });
+
+  it('renders history rows when data is available', () => {
+    vi.mocked(pricingQueries.usePricingHistory).mockReturnValue({ data: mockHistory, isLoading: false } as any);
+
+    renderPage();
+
+    expect(screen.getByText('Weekend surge')).toBeInTheDocument();
+    expect(screen.getByText('87%')).toBeInTheDocument();
+    expect(screen.getByText('synced')).toBeInTheDocument();
+  });
+
+  it('shows empty state when history is empty', () => {
+    vi.mocked(pricingQueries.usePricingHistory).mockReturnValue({
+      data: { items: [], total: 0, page: 1 },
+      isLoading: false,
+    } as any);
+
+    renderPage();
+
+    expect(screen.getByTestId('history-empty')).toBeInTheDocument();
+  });
+
+  it('shows pagination controls when total exceeds page size', () => {
+    vi.mocked(pricingQueries.usePricingHistory).mockReturnValue({ data: mockHistoryMultiPage, isLoading: false } as any);
+
+    renderPage();
+
+    expect(screen.getByLabelText('Next page')).toBeInTheDocument();
+    expect(screen.getByLabelText('Previous page')).toBeInTheDocument();
+  });
+
+  it('calls export API with pageSize 1000 when export button is clicked', async () => {
+    vi.mocked(pricingQueries.usePricingHistory).mockReturnValue({ data: mockHistory, isLoading: false } as any);
+    vi.mocked(pricingApi.pricingAdapterApi.getHistory).mockResolvedValue(mockHistory);
+
+    renderPage();
+
+    const exportBtn = screen.getByTestId('export-btn');
+    fireEvent.click(exportBtn);
+
+    await waitFor(() =>
+      expect(pricingApi.pricingAdapterApi.getHistory).toHaveBeenCalledWith(
+        PROPERTY_ID,
+        expect.objectContaining({ pageSize: 1000, page: 1 })
+      )
+    );
+  });
+});

--- a/src/features/pricing/components/pricing-history-table.tsx
+++ b/src/features/pricing/components/pricing-history-table.tsx
@@ -1,0 +1,128 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatCurrency, formatDate } from '@/lib/utils';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { PricingHistoryPagedResponse, PricingOtaSyncStatus } from '@/types';
+
+const SYNC_STATUS_VARIANT: Record<PricingOtaSyncStatus, 'success' | 'warning' | 'destructive'> = {
+  synced: 'success',
+  partial: 'warning',
+  failed: 'destructive',
+};
+
+interface PricingHistoryTableProps {
+  data: PricingHistoryPagedResponse | undefined;
+  isLoading: boolean;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}
+
+export function PricingHistoryTable({
+  data,
+  isLoading,
+  page,
+  pageSize,
+  onPageChange,
+}: PricingHistoryTableProps) {
+  const totalPages = data ? Math.ceil(data.total / pageSize) : 0;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2" data-testid="history-loading">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data || data.items.length === 0) {
+    return (
+      <div className="py-12 text-center text-muted-foreground" data-testid="history-empty">
+        No price adaptation history found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="px-4 py-3 text-left font-medium">Date</th>
+              <th className="px-4 py-3 text-right font-medium">Prev Price</th>
+              <th className="px-4 py-3 text-right font-medium">New Price</th>
+              <th className="px-4 py-3 text-right font-medium">Δ%</th>
+              <th className="px-4 py-3 text-left font-medium">Reason</th>
+              <th className="px-4 py-3 text-right font-medium">Confidence</th>
+              <th className="px-4 py-3 text-left font-medium">OTA Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.items.map((entry) => {
+              const delta = entry.previousPrice > 0
+                ? ((entry.newPrice - entry.previousPrice) / entry.previousPrice) * 100
+                : 0;
+              return (
+                <tr key={entry.id} className="border-b last:border-0 hover:bg-muted/30">
+                  <td className="px-4 py-2 text-muted-foreground">
+                    {formatDate(entry.adaptationDate)}
+                  </td>
+                  <td className="px-4 py-2 text-right">{formatCurrency(entry.previousPrice)}</td>
+                  <td className="px-4 py-2 text-right font-medium">{formatCurrency(entry.newPrice)}</td>
+                  <td
+                    className={`px-4 py-2 text-right text-xs font-medium ${
+                      delta > 0 ? 'text-green-600' : delta < 0 ? 'text-red-500' : 'text-muted-foreground'
+                    }`}
+                  >
+                    {delta >= 0 ? '+' : ''}{delta.toFixed(1)}%
+                  </td>
+                  <td className="px-4 py-2 text-muted-foreground max-w-xs truncate">
+                    {entry.changeReason}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    {(entry.aiConfidence * 100).toFixed(0)}%
+                  </td>
+                  <td className="px-4 py-2">
+                    <Badge variant={SYNC_STATUS_VARIANT[entry.syncStatus]} className="capitalize">
+                      {entry.syncStatus}
+                    </Badge>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>Page {page} of {totalPages} ({data.total} entries)</span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(page - 1)}
+              disabled={page <= 1}
+              aria-label="Previous page"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(page + 1)}
+              disabled={page >= totalPages}
+              aria-label="Next page"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/pricing/index.tsx
+++ b/src/features/pricing/index.tsx
@@ -1,0 +1,1 @@
+export { PricingHistoryPage } from './pricing-history-page';

--- a/src/features/pricing/pricing-history-page.tsx
+++ b/src/features/pricing/pricing-history-page.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { AppShell } from '@/components/layout/app-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ArrowLeft, Download } from 'lucide-react';
+import { usePricingHistory } from '@/queries/use-pricing-adapter';
+import { pricingAdapterApi } from '@/api/pricing-adapter.api';
+import { formatDate } from '@/lib/utils';
+import { PricingHistoryTable } from './components/pricing-history-table';
+import type { PricingHistoryEntry } from '@/types';
+
+const PAGE_SIZE = 20;
+
+function buildCsv(items: PricingHistoryEntry[]): string {
+  const headers = ['Date', 'Previous Price', 'New Price', 'Delta%', 'Reason', 'AI Confidence', 'OTA Status'];
+  const rows = items.map((e) => {
+    const delta = e.previousPrice > 0
+      ? ((e.newPrice - e.previousPrice) / e.previousPrice) * 100
+      : 0;
+    return [
+      e.adaptationDate,
+      e.previousPrice,
+      e.newPrice,
+      delta.toFixed(1),
+      `"${e.changeReason.replace(/"/g, '""')}"`,
+      (e.aiConfidence * 100).toFixed(0) + '%',
+      e.syncStatus,
+    ].join(',');
+  });
+  return [headers.join(','), ...rows].join('\n');
+}
+
+function triggerCsvDownload(csv: string, filename: string) {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function PricingHistoryPage() {
+  const { id: propertyId } = useParams<{ id: string }>();
+  const [page, setPage] = useState(1);
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [isExporting, setIsExporting] = useState(false);
+
+  const queryParams = {
+    page,
+    pageSize: PAGE_SIZE,
+    ...(from && { from }),
+    ...(to && { to }),
+  };
+
+  const { data, isLoading } = usePricingHistory(propertyId!, queryParams);
+
+  function handleFromChange(value: string) {
+    setFrom(value);
+    setPage(1);
+  }
+
+  function handleToChange(value: string) {
+    setTo(value);
+    setPage(1);
+  }
+
+  async function handleExport() {
+    setIsExporting(true);
+    try {
+      const result = await pricingAdapterApi.getHistory(propertyId!, {
+        page: 1,
+        pageSize: 1000,
+        ...(from && { from }),
+        ...(to && { to }),
+      });
+      const csv = buildCsv(result.items);
+      const date = formatDate(new Date().toISOString(), 'yyyy-MM-dd');
+      triggerCsvDownload(csv, `pricing-history-${date}.csv`);
+    } finally {
+      setIsExporting(false);
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" asChild>
+            <Link to={`/properties/${propertyId}/pricing`} aria-label="Back to pricing">
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          <PageHeader
+            title="Pricing Audit Trail"
+            description="Full history of AI-driven price adaptations for compliance and review."
+          />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle>Price Adaptation History</CardTitle>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleExport}
+                disabled={isExporting}
+                data-testid="export-btn"
+              >
+                <Download className="mr-2 h-4 w-4" />
+                {isExporting ? 'Exporting...' : 'Export CSV'}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap gap-4">
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="filter-from">From</Label>
+                <Input
+                  id="filter-from"
+                  type="date"
+                  value={from}
+                  onChange={(e) => handleFromChange(e.target.value)}
+                  className="w-40"
+                  data-testid="filter-from"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="filter-to">To</Label>
+                <Input
+                  id="filter-to"
+                  type="date"
+                  value={to}
+                  onChange={(e) => handleToChange(e.target.value)}
+                  className="w-40"
+                  data-testid="filter-to"
+                />
+              </div>
+            </div>
+
+            <PricingHistoryTable
+              data={data}
+              isLoading={isLoading}
+              page={page}
+              pageSize={PAGE_SIZE}
+              onPageChange={setPage}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/features/pricing/pricing-history-page.tsx
+++ b/src/features/pricing/pricing-history-page.tsx
@@ -10,6 +10,7 @@ import { ArrowLeft, Download } from 'lucide-react';
 import { usePricingHistory } from '@/queries/use-pricing-adapter';
 import { pricingAdapterApi } from '@/api/pricing-adapter.api';
 import { formatDate } from '@/lib/utils';
+import { toast } from 'sonner';
 import { PricingHistoryTable } from './components/pricing-history-table';
 import type { PricingHistoryEntry } from '@/types';
 
@@ -82,6 +83,8 @@ export function PricingHistoryPage() {
       const csv = buildCsv(result.items);
       const date = formatDate(new Date().toISOString(), 'yyyy-MM-dd');
       triggerCsvDownload(csv, `pricing-history-${date}.csv`);
+    } catch {
+      toast.error('Failed to export pricing history');
     } finally {
       setIsExporting(false);
     }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,6 +19,7 @@ import { OtaPage } from '@/features/ota/ota-page';
 import { OtaSetupPage } from '@/features/ota/ota-setup-page';
 import { SearchPage } from '@/features/search/search-page';
 import { ProfilePage } from '@/features/profile/profile-page';
+import { PricingHistoryPage } from '@/features/pricing';
 
 export const router = createBrowserRouter([
   {
@@ -162,6 +163,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <ProfilePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/properties/:id/pricing/history',
+    element: (
+      <ProtectedRoute>
+        <PricingHistoryPage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
## Summary
- Add `PricingHistoryPage` at `/properties/:id/pricing/history` with paginated audit table
- Add `PricingHistoryTable` component: columns date, prev price, new price, Δ%, reason, AI confidence, OTA status
- Date range filters (from/to) reset pagination on change
- CSV export: fetches up to 1000 entries and downloads as `pricing-history-YYYY-MM-DD.csv` — required for cedolare secca compliance
- OTA status badges: synced (green), partial (yellow), failed (red)
- Register route in `src/routes/index.tsx`
- Add 5 unit tests: loading, rows rendered, empty state, pagination controls, export API call

## Notes
- `index.tsx` in this branch only exports `PricingHistoryPage`; will need a trivial merge conflict resolution when PR #65 (FE#60) merges first (adds `PricingDashboardPage` export)
- `aiConfidence` is treated as 0–1 probability, displayed as percentage

## Test Plan
- [ ] `npm test` — all 20 tests pass
- [ ] Navigate to `/properties/:id/pricing/history` — page renders with filters + table
- [ ] With no history → empty state message shown
- [ ] With data → rows render with correct Δ% and badge colors
- [ ] Changing date filters resets to page 1
- [ ] "Export CSV" downloads a `.csv` file with all matching history

Closes #61
Part of: casazen/backend#116