### PR TITLE
feat: add TypeScript types and API client for pricing-adapter endpoints

### DIFF
--- a/src/api/__tests__/pricingAdapter.test.ts
+++ b/src/api/__tests__/pricingAdapter.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createOrUpdatePricingAdapterConfig,
+  getPricingAdapterConfig,
+  deletePricingAdapterConfig,
+  getPricingHistory,
+  triggerPricingSync,
+  getPricingPreview,
+} from '../pricingAdapter';
+import { ApiClient } from '../client';
+import type {
+  PricingAdapterConfigDto,
+  PricingHistoryPageDto,
+  PricingPreviewDto,
+} from '@/types/pricing';
+
+vi.mock('../client');
+
+const PROPERTY_ID = 'prop-123';
+
+const mockConfig: PricingAdapterConfigDto = {
+  propertyId: PROPERTY_ID,
+  isEnabled: true,
+  adaptationFrequency: 'daily',
+  includeSeasonality: true,
+  includePublicHolidays: false,
+  lastAdaptedAt: null,
+  nextScheduledRunAt: '2026-05-12T02:00:00Z',
+};
+
+const mockHistory: PricingHistoryPageDto = {
+  items: [
+    {
+      id: 'hist-1',
+      adaptationDate: '2026-05-10T02:00:00Z',
+      previousPrice: 100,
+      newPrice: 120,
+      changeReason: 'Seasonal peak detected',
+      aiConfidence: 0.87,
+      syncStatus: 'synced',
+    },
+  ],
+  total: 1,
+  page: 1,
+};
+
+const mockPreview: PricingPreviewDto = {
+  prices: [
+    { date: '2026-05-12', suggestedPrice: 115, basePrice: 100, reason: 'Weekend uplift' },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('pricingAdapter API client', () => {
+  describe('createOrUpdatePricingAdapterConfig', () => {
+    it('calls POST /pricing-adapter/config/:propertyId with request body', async () => {
+      vi.mocked(ApiClient.post).mockResolvedValueOnce(mockConfig);
+      const req = {
+        isEnabled: true,
+        adaptationFrequency: 'daily' as const,
+        includeSeasonality: true,
+        includePublicHolidays: false,
+      };
+
+      const result = await createOrUpdatePricingAdapterConfig(PROPERTY_ID, req);
+
+      expect(ApiClient.post).toHaveBeenCalledWith(
+        `/pricing-adapter/config/${PROPERTY_ID}`,
+        req
+      );
+      expect(result).toEqual(mockConfig);
+    });
+  });
+
+  describe('getPricingAdapterConfig', () => {
+    it('calls GET /pricing-adapter/config/:propertyId', async () => {
+      vi.mocked(ApiClient.get).mockResolvedValueOnce(mockConfig);
+
+      const result = await getPricingAdapterConfig(PROPERTY_ID);
+
+      expect(ApiClient.get).toHaveBeenCalledWith(
+        `/pricing-adapter/config/${PROPERTY_ID}`
+      );
+      expect(result).toEqual(mockConfig);
+    });
+  });
+
+  describe('deletePricingAdapterConfig', () => {
+    it('calls DELETE /pricing-adapter/config/:propertyId and returns void', async () => {
+      vi.mocked(ApiClient.delete).mockResolvedValueOnce(undefined);
+
+      await deletePricingAdapterConfig(PROPERTY_ID);
+
+      expect(ApiClient.delete).toHaveBeenCalledWith(
+        `/pricing-adapter/config/${PROPERTY_ID}`
+      );
+    });
+  });
+
+  describe('getPricingHistory', () => {
+    it('calls GET /pricing-adapter/history/:propertyId without filters', async () => {
+      vi.mocked(ApiClient.get).mockResolvedValueOnce(mockHistory);
+
+      const result = await getPricingHistory(PROPERTY_ID);
+
+      expect(ApiClient.get).toHaveBeenCalledWith(
+        `/pricing-adapter/history/${PROPERTY_ID}`,
+        undefined
+      );
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+
+    it('forwards filter params to GET /pricing-adapter/history/:propertyId', async () => {
+      vi.mocked(ApiClient.get).mockResolvedValueOnce(mockHistory);
+      const filters = { page: 2, pageSize: 20, from: '2026-01-01', to: '2026-05-01' };
+
+      await getPricingHistory(PROPERTY_ID, filters);
+
+      expect(ApiClient.get).toHaveBeenCalledWith(
+        `/pricing-adapter/history/${PROPERTY_ID}`,
+        filters
+      );
+    });
+  });
+
+  describe('triggerPricingSync', () => {
+    it('calls POST /pricing-adapter/sync/:propertyId and returns jobId', async () => {
+      vi.mocked(ApiClient.post).mockResolvedValueOnce({ jobId: 'job-abc' });
+
+      const result = await triggerPricingSync(PROPERTY_ID);
+
+      expect(ApiClient.post).toHaveBeenCalledWith(
+        `/pricing-adapter/sync/${PROPERTY_ID}`
+      );
+      expect(result.jobId).toBe('job-abc');
+    });
+  });
+
+  describe('getPricingPreview', () => {
+    it('calls GET /pricing-adapter/preview/:propertyId', async () => {
+      vi.mocked(ApiClient.get).mockResolvedValueOnce(mockPreview);
+
+      const result = await getPricingPreview(PROPERTY_ID);
+
+      expect(ApiClient.get).toHaveBeenCalledWith(
+        `/pricing-adapter/preview/${PROPERTY_ID}`
+      );
+      expect(result.prices).toHaveLength(1);
+      expect(result.prices[0].date).toBe('2026-05-12');
+    });
+  });
+});

--- a/src/api/pricingAdapter.ts
+++ b/src/api/pricingAdapter.ts
@@ -1,0 +1,48 @@
+import { ApiClient } from './client';
+import type {
+  PricingAdapterConfigDto,
+  CreateOrUpdatePricingAdapterConfigRequest,
+  PricingHistoryPageDto,
+  PricingHistoryFilters,
+  PricingPreviewDto,
+} from '@/types/pricing';
+
+const BASE = '/pricing-adapter';
+
+export function createOrUpdatePricingAdapterConfig(
+  propertyId: string,
+  config: CreateOrUpdatePricingAdapterConfigRequest
+): Promise<PricingAdapterConfigDto> {
+  return ApiClient.post<PricingAdapterConfigDto>(`${BASE}/config/${propertyId}`, config);
+}
+
+export function getPricingAdapterConfig(
+  propertyId: string
+): Promise<PricingAdapterConfigDto> {
+  return ApiClient.get<PricingAdapterConfigDto>(`${BASE}/config/${propertyId}`);
+}
+
+export function deletePricingAdapterConfig(
+  propertyId: string
+): Promise<void> {
+  return ApiClient.delete<void>(`${BASE}/config/${propertyId}`);
+}
+
+export function getPricingHistory(
+  propertyId: string,
+  filters?: PricingHistoryFilters
+): Promise<PricingHistoryPageDto> {
+  return ApiClient.get<PricingHistoryPageDto>(`${BASE}/history/${propertyId}`, filters);
+}
+
+export function triggerPricingSync(
+  propertyId: string
+): Promise<{ jobId: string }> {
+  return ApiClient.post<{ jobId: string }>(`${BASE}/sync/${propertyId}`);
+}
+
+export function getPricingPreview(
+  propertyId: string
+): Promise<PricingPreviewDto> {
+  return ApiClient.get<PricingPreviewDto>(`${BASE}/preview/${propertyId}`);
+}

--- a/src/types/pricing.ts
+++ b/src/types/pricing.ts
@@ -1,0 +1,50 @@
+export interface PricingAdapterConfigDto {
+  propertyId: string;
+  isEnabled: boolean;
+  adaptationFrequency: 'daily' | 'weekly';
+  includeSeasonality: boolean;
+  includePublicHolidays: boolean;
+  lastAdaptedAt: string | null;
+  nextScheduledRunAt: string;
+}
+
+export interface PricingHistoryItemDto {
+  id: string;
+  adaptationDate: string;
+  previousPrice: number;
+  newPrice: number;
+  changeReason: string;
+  aiConfidence: number;
+  syncStatus: 'pending' | 'synced' | 'failed';
+}
+
+export interface PricingHistoryPageDto {
+  items: PricingHistoryItemDto[];
+  total: number;
+  page: number;
+}
+
+export interface PricingPreviewItemDto {
+  date: string;
+  suggestedPrice: number;
+  basePrice: number;
+  reason: string;
+}
+
+export interface PricingPreviewDto {
+  prices: PricingPreviewItemDto[];
+}
+
+export interface CreateOrUpdatePricingAdapterConfigRequest {
+  isEnabled: boolean;
+  adaptationFrequency: 'daily' | 'weekly';
+  includeSeasonality: boolean;
+  includePublicHolidays: boolean;
+}
+
+export interface PricingHistoryFilters {
+  from?: string;
+  to?: string;
+  page?: number;
+  pageSize?: number;
+}


### PR DESCRIPTION
## Summary

- Define all pricing-adapter TypeScript interfaces in `src/types/pricing.ts`: `PricingAdapterConfigDto`, `PricingHistoryItemDto`, `PricingHistoryPageDto`, `PricingPreviewItemDto`, `PricingPreviewDto`, `CreateOrUpdatePricingAdapterConfigRequest`, and `PricingHistoryFilters`
- Implement 6 API client functions in `src/api/pricingAdapter.ts` using the existing `ApiClient` HTTP wrapper
- Add unit tests for all 6 functions covering correct endpoint URLs, request bodies, and return types

## Test Plan

- [x] Unit tests pass (7/7) — `src/api/__tests__/pricingAdapter.test.ts`
- [x] Full test suite passes (37/37)
- [x] TypeScript compilation passes

Closes #54
Part of: casazen/backend#116