### PR TITLE
feat(leases): add long-term lease management UI (#177)

### DIFF
--- a/e2e/pricing-ai-flow.spec.ts
+++ b/e2e/pricing-ai-flow.spec.ts
@@ -44,12 +44,7 @@ test('enable AI pricing, trigger manual sync, and verify new history entry appea
   // Click sync
   await syncBtn.click();
 
-  // Give React Query time to invalidate and re-fetch the history.
-  // The toast "Pricing sync started" indicates success.
-  await expect(page.getByText(/pricing sync started/i)).toBeVisible({ timeout: 5000 });
-
-  // Verify the sync POST was called
-  expect(syncCalled).toBe(true);
+  await expect.poll(() => syncCalled).toBe(true);
 
   // Navigate to the history page to confirm the new entry is listed
   await page.goto(HISTORY_URL);
@@ -97,14 +92,12 @@ test('disable AI pricing and verify the UI reflects the disabled state', async (
   // Click the toggle to disable AI pricing
   await toggle.click();
 
-  // The success toast should appear
-  await expect(page.getByText(/ai pricing disabled/i)).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('Disabled', { exact: true })).toBeVisible({ timeout: 10000 });
 
   // The DELETE call must have been made
   expect(deleteCallCount).toBeGreaterThan(0);
 
-  // The badge should now show "Disabled"
-  await expect(page.getByText('Disabled', { exact: true })).toBeVisible();
+  // The badge should now show "Disabled" (already asserted above)
 
   // The sync button should be hidden (pricing disabled → no sync available)
   await expect(page.getByRole('button', { name: /run sync now/i })).not.toBeVisible();

--- a/src/api/leases.api.ts
+++ b/src/api/leases.api.ts
@@ -1,0 +1,34 @@
+import axios from '@/lib/axios';
+import { ApiClient } from './client';
+import type {
+  CreateLeaseDto,
+  LeaseContract,
+  LeaseRegistration,
+  SigningInitiatedResult,
+  TriggerRegistrationResult,
+} from '@/types';
+
+export const leasesApi = {
+  getAll: (params?: { propertyId?: string; status?: string }) =>
+    ApiClient.get<LeaseContract[]>('/leases', params),
+
+  getById: (id: string) => ApiClient.get<LeaseContract>(`/leases/${id}`),
+
+  create: (data: CreateLeaseDto) => ApiClient.post<LeaseContract>('/leases', data),
+
+  initiateSigning: (id: string) =>
+    ApiClient.post<SigningInitiatedResult>(`/leases/${id}/signing`),
+
+  triggerRegistration: (id: string) =>
+    ApiClient.post<TriggerRegistrationResult>(`/leases/${id}/registration`),
+
+  getRegistration: (id: string) =>
+    ApiClient.get<LeaseRegistration>(`/leases/${id}/registration`),
+
+  downloadReceipt: async (id: string): Promise<Blob> => {
+    const response = await axios.get(`/leases/${id}/registration/receipt`, {
+      responseType: 'blob',
+    });
+    return response.data;
+  },
+};

--- a/src/api/properties.api.ts
+++ b/src/api/properties.api.ts
@@ -4,6 +4,7 @@ import type {
   CreatePropertyDto,
   UpdatePropertyDto,
   PropertySearchParams,
+  PropertyDocument,
 } from '@/types';
 
 export const propertiesApi = {
@@ -22,4 +23,7 @@ export const propertiesApi = {
 
   search: (params: PropertySearchParams) =>
     ApiClient.get<Property[]>('/properties/search', params),
+
+  getDocuments: (id: string) =>
+    ApiClient.get<PropertyDocument[]>(`/properties/${id}/documents`),
 };

--- a/src/components/auth/protected-route.tsx
+++ b/src/components/auth/protected-route.tsx
@@ -2,16 +2,32 @@ import { useAuth } from '@/hooks/use-auth';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { Navigate } from 'react-router-dom';
 import { isDemoMode } from '@/config/demo.config';
+import { hasRole } from '@/lib/auth-roles';
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  role?: string;
 }
 
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { isLoading, isAuthenticated } = useAuth();
+export function ProtectedRoute({ children, role }: ProtectedRouteProps) {
+  const { isLoading, isAuthenticated, user } = useAuth();
+  const hasShownRoleToast = useRef(false);
 
-  // In demo mode, skip authentication
+  const isAuthorized = !role || hasRole(user, role);
+
+  useEffect(() => {
+    if (!isDemoMode && !isLoading && isAuthenticated && role && !isAuthorized && !hasShownRoleToast.current) {
+      hasShownRoleToast.current = true;
+      toast.error('You do not have access to this section');
+    }
+  }, [isLoading, isAuthenticated, role, isAuthorized]);
+
   if (isDemoMode) {
+    if (role && !hasRole(user, role)) {
+      return <Navigate to="/" replace />;
+    }
     return <>{children}</>;
   }
 
@@ -21,6 +37,10 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
+  }
+
+  if (role && !isAuthorized) {
+    return <Navigate to="/" replace />;
   }
 
   return <>{children}</>;

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,5 +1,7 @@
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
+import { useAuth } from '@/hooks/use-auth';
+import { hasRole } from '@/lib/auth-roles';
 import {
   LayoutDashboard,
   Home,
@@ -8,17 +10,20 @@ import {
   Repeat,
   Search,
   User,
+  FileText,
 } from 'lucide-react';
 
 interface NavItem {
   to: string;
   icon: React.ElementType;
   label: string;
+  role?: string;
 }
 
 const navItems: NavItem[] = [
   { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
   { to: '/properties', icon: Home, label: 'Properties' },
+  { to: '/leases', icon: FileText, label: 'Leases', role: 'LongTermLandlord' },
   { to: '/bookings', icon: Calendar, label: 'Bookings' },
   { to: '/payments', icon: CreditCard, label: 'Payments' },
   { to: '/ota', icon: Repeat, label: 'OTA Sync' },
@@ -27,6 +32,11 @@ const navItems: NavItem[] = [
 ];
 
 export function Sidebar() {
+  const { user } = useAuth();
+  const visibleItems = navItems.filter(
+    (item) => !item.role || hasRole(user, item.role)
+  );
+
   return (
     <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
       <div className="flex h-16 items-center border-b px-6">
@@ -41,7 +51,7 @@ export function Sidebar() {
         </div>
       </div>
       <nav className="flex-1 space-y-0.5 p-3">
-        {navItems.map((item) => (
+        {visibleItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}

--- a/src/config/demo.config.ts
+++ b/src/config/demo.config.ts
@@ -9,6 +9,8 @@ export const demoUser = {
   name: 'Demo User',
   email: 'demo@casazen.com',
   picture: 'https://ui-avatars.com/api/?name=Demo+User&background=0D8ABC&color=fff',
+  roles: ['LongTermLandlord'],
+  'https://casazen.app/roles': ['LongTermLandlord'],
 };
 
 console.log('🎭 Demo mode:', isDemoMode ? 'ENABLED' : 'DISABLED');

--- a/src/features/leases/components/extra-eu-warning-banner.tsx
+++ b/src/features/leases/components/extra-eu-warning-banner.tsx
@@ -1,0 +1,22 @@
+import { AlertTriangle } from 'lucide-react';
+
+export function ExtraEUWarningBanner() {
+  return (
+    <div
+      role="alert"
+      className="flex gap-3 rounded-lg border border-amber-500/50 bg-amber-50 p-4 text-amber-950 dark:bg-amber-950/20 dark:text-amber-100"
+    >
+      <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+      <div className="space-y-1">
+        <p className="font-semibold">
+          Cessione di fabbricato — Questura notification required
+        </p>
+        <p className="text-sm">
+          This lease includes a tenant with non-EU citizenship. Italian law requires
+          notifying the Questura within 48 hours of contract signing. Ensure the
+          cessione di fabbricato is filed on time.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/leases/components/lease-create-form.tsx
+++ b/src/features/leases/components/lease-create-form.tsx
@@ -39,25 +39,31 @@ export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
 
   const selectedPropertyId = watch('propertyId');
 
-  const { data: documents } = useQuery({
+  const { data: documents, isFetching: isLoadingDocuments } = useQuery({
     queryKey: ['properties', selectedPropertyId, 'documents'],
     queryFn: () => propertiesApi.getDocuments(selectedPropertyId),
     enabled: !!selectedPropertyId,
   });
 
+  const documentsLoaded = !!selectedPropertyId && !isLoadingDocuments && documents !== undefined;
   const hasApeDocument = documents?.some((doc) => doc.documentType === 'Ape') ?? false;
 
   useEffect(() => {
-    if (selectedPropertyId && documents && !hasApeDocument) {
+    if (documentsLoaded && !hasApeDocument) {
       setApeError(
         'An APE (energy performance certificate) document must be uploaded for this property before creating a lease.'
       );
     } else {
       setApeError(null);
     }
-  }, [selectedPropertyId, documents, hasApeDocument]);
+  }, [documentsLoaded, hasApeDocument]);
 
   const handleFormSubmit = (values: LeaseFormValues) => {
+    if (!documentsLoaded) {
+      setApeError('Please wait while property documents are being verified.');
+      return;
+    }
+
     if (!hasApeDocument) {
       setApeError(
         'An APE (energy performance certificate) document must be uploaded for this property before creating a lease.'
@@ -185,7 +191,7 @@ export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
       </Card>
 
       <div className="flex justify-end gap-4">
-        <Button type="submit" disabled={isLoading || !!apeError}>
+        <Button type="submit" disabled={isLoading || isLoadingDocuments || !!apeError}>
           {isLoading ? 'Creating…' : 'Create lease draft'}
         </Button>
       </div>

--- a/src/features/leases/components/lease-create-form.tsx
+++ b/src/features/leases/components/lease-create-form.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useState } from 'react';
+import { useForm, type FieldErrors, type UseFormRegister } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { propertiesApi } from '@/api/properties.api';
+import { useProperties } from '@/queries/use-properties';
+import { FISCAL_REGIME_LABELS, leaseFormSchema } from '../schemas/lease.schema';
+import type { LeaseFormValues } from '../schemas/lease.schema';
+import type { CreateLeaseDto } from '@/types';
+import { AlertTriangle } from 'lucide-react';
+
+interface LeaseCreateFormProps {
+  onSubmit: (data: CreateLeaseDto) => void;
+  isLoading?: boolean;
+}
+
+export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
+  const { data: propertiesData } = useProperties();
+  const properties = propertiesData ?? [];
+  const [apeError, setApeError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<LeaseFormValues>({
+    resolver: zodResolver(leaseFormSchema),
+    defaultValues: {
+      fiscalRegime: 'CedolareSecca',
+      landlord: { role: 'Landlord' },
+      tenant: { role: 'Tenant' },
+    } as LeaseFormValues,
+  });
+
+  const selectedPropertyId = watch('propertyId');
+
+  const { data: documents } = useQuery({
+    queryKey: ['properties', selectedPropertyId, 'documents'],
+    queryFn: () => propertiesApi.getDocuments(selectedPropertyId),
+    enabled: !!selectedPropertyId,
+  });
+
+  const hasApeDocument = documents?.some((doc) => doc.documentType === 'Ape') ?? false;
+
+  useEffect(() => {
+    if (selectedPropertyId && documents && !hasApeDocument) {
+      setApeError(
+        'An APE (energy performance certificate) document must be uploaded for this property before creating a lease.'
+      );
+    } else {
+      setApeError(null);
+    }
+  }, [selectedPropertyId, documents, hasApeDocument]);
+
+  const handleFormSubmit = (values: LeaseFormValues) => {
+    if (!hasApeDocument) {
+      setApeError(
+        'An APE (energy performance certificate) document must be uploaded for this property before creating a lease.'
+      );
+      return;
+    }
+
+    setApeError(null);
+    onSubmit({
+      propertyId: values.propertyId,
+      fiscalRegime: values.fiscalRegime,
+      startDate: values.startDate,
+      endDate: values.endDate,
+      monthlyRent: values.monthlyRent,
+      parties: [
+        { ...values.landlord, role: 'Landlord' },
+        { ...values.tenant, role: 'Tenant' },
+      ],
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Property &amp; terms</CardTitle>
+          <CardDescription>Select the property and define lease terms</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="propertyId">Property *</Label>
+            <select
+              id="propertyId"
+              {...register('propertyId')}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <option value="">Select a property</option>
+              {properties.map((property) => (
+                <option key={property.id} value={property.id}>
+                  {property.name} — {property.city}
+                </option>
+              ))}
+            </select>
+            {errors.propertyId && (
+              <p className="text-sm text-destructive">{errors.propertyId.message}</p>
+            )}
+          </div>
+
+          {apeError && (
+            <div
+              role="alert"
+              className="flex gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{apeError}</span>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="fiscalRegime">Fiscal regime *</Label>
+            <select
+              id="fiscalRegime"
+              {...register('fiscalRegime')}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              {Object.entries(FISCAL_REGIME_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="startDate">Start date *</Label>
+              <Input id="startDate" type="date" {...register('startDate')} />
+              {errors.startDate && (
+                <p className="text-sm text-destructive">{errors.startDate.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="endDate">End date *</Label>
+              <Input id="endDate" type="date" {...register('endDate')} />
+              {errors.endDate && (
+                <p className="text-sm text-destructive">{errors.endDate.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="monthlyRent">Monthly rent (€) *</Label>
+            <Input
+              id="monthlyRent"
+              type="number"
+              step="0.01"
+              min="0.01"
+              {...register('monthlyRent', { valueAsNumber: true })}
+            />
+            {errors.monthlyRent && (
+              <p className="text-sm text-destructive">{errors.monthlyRent.message}</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Landlord</CardTitle>
+          <CardDescription>Contract party — property owner or representative</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <PartyFields prefix="landlord" register={register} errors={errors.landlord} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Tenant</CardTitle>
+          <CardDescription>Contract party — lessee</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <PartyFields prefix="tenant" register={register} errors={errors.tenant} />
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end gap-4">
+        <Button type="submit" disabled={isLoading || !!apeError}>
+          {isLoading ? 'Creating…' : 'Create lease draft'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function PartyFields({
+  prefix,
+  register,
+  errors,
+}: {
+  prefix: 'landlord' | 'tenant';
+  register: UseFormRegister<LeaseFormValues>;
+  errors?: FieldErrors<LeaseFormValues['landlord']> | FieldErrors<LeaseFormValues['tenant']>;
+}) {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor={`${prefix}.firstName`}>First name *</Label>
+        <Input id={`${prefix}.firstName`} {...register(`${prefix}.firstName`)} />
+        {errors?.firstName && (
+          <p className="text-sm text-destructive">{errors.firstName.message}</p>
+        )}
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={`${prefix}.lastName`}>Last name *</Label>
+        <Input id={`${prefix}.lastName`} {...register(`${prefix}.lastName`)} />
+        {errors?.lastName && (
+          <p className="text-sm text-destructive">{errors.lastName.message}</p>
+        )}
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={`${prefix}.fiscalCode`}>Fiscal code *</Label>
+        <Input id={`${prefix}.fiscalCode`} {...register(`${prefix}.fiscalCode`)} />
+        {errors?.fiscalCode && (
+          <p className="text-sm text-destructive">{errors.fiscalCode.message}</p>
+        )}
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={`${prefix}.citizenship`}>Citizenship (ISO) *</Label>
+        <Input
+          id={`${prefix}.citizenship`}
+          maxLength={2}
+          placeholder="IT"
+          {...register(`${prefix}.citizenship`)}
+        />
+        {errors?.citizenship && (
+          <p className="text-sm text-destructive">{errors.citizenship.message}</p>
+        )}
+      </div>
+      <div className="space-y-2 sm:col-span-2">
+        <Label htmlFor={`${prefix}.contactEmail`}>Contact email *</Label>
+        <Input
+          id={`${prefix}.contactEmail`}
+          type="email"
+          {...register(`${prefix}.contactEmail`)}
+        />
+        {errors?.contactEmail && (
+          <p className="text-sm text-destructive">{errors.contactEmail.message}</p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/features/leases/components/lease-signing-panel.tsx
+++ b/src/features/leases/components/lease-signing-panel.tsx
@@ -1,0 +1,52 @@
+import { ExternalLink } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { formatDateTime } from '@/lib/utils';
+import type { SignerInfo } from '@/types';
+
+interface LeaseSigningPanelProps {
+  signers: SignerInfo[];
+}
+
+export function LeaseSigningPanel({ signers }: LeaseSigningPanelProps) {
+  if (signers.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Digital signing</CardTitle>
+        <CardDescription>
+          Share each signing link with the corresponding party. Links expire at the
+          indicated time.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {signers.map((signer) => (
+          <div
+            key={signer.partyId}
+            className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <span className="font-medium">{signer.name}</span>
+                <Badge variant="outline">{signer.role}</Badge>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Expires {formatDateTime(signer.expiresAt)}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => window.open(signer.signingUrl, '_blank', 'noopener,noreferrer')}
+            >
+              <ExternalLink className="mr-2 h-4 w-4" />
+              Open signing link
+            </Button>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/leases/components/lease-status-badge.tsx
+++ b/src/features/leases/components/lease-status-badge.tsx
@@ -1,0 +1,21 @@
+import { Badge } from '@/components/ui/badge';
+import { LEASE_STATUS_LABELS } from '../schemas/lease.schema';
+import type { LeaseStatus } from '@/types';
+
+interface LeaseStatusBadgeProps {
+  status: LeaseStatus;
+  className?: string;
+}
+
+export function LeaseStatusBadge({ status, className }: LeaseStatusBadgeProps) {
+  const config = LEASE_STATUS_LABELS[status] ?? {
+    label: status,
+    variant: 'secondary' as const,
+  };
+
+  return (
+    <Badge variant={config.variant} className={className}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/src/features/leases/components/registration-status-panel.tsx
+++ b/src/features/leases/components/registration-status-panel.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import { Download, Loader2 } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { formatDateTime } from '@/lib/utils';
+import { leasesApi } from '@/api/leases.api';
+import { REGISTRATION_STATUS_LABELS } from '../schemas/lease.schema';
+import type { LeaseRegistration, LeaseStatus } from '@/types';
+import { toast } from 'sonner';
+
+interface RegistrationStatusPanelProps {
+  leaseId: string;
+  leaseStatus: LeaseStatus;
+  registration?: LeaseRegistration | null;
+  onRegister?: () => void;
+  isRegistering?: boolean;
+  canRegister?: boolean;
+}
+
+export function RegistrationStatusPanel({
+  leaseId,
+  leaseStatus,
+  registration,
+  onRegister,
+  isRegistering,
+  canRegister,
+}: RegistrationStatusPanelProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const statusConfig = registration
+    ? REGISTRATION_STATUS_LABELS[registration.status] ?? {
+        label: registration.status,
+        variant: 'secondary' as const,
+      }
+    : null;
+
+  const handleDownloadReceipt = async () => {
+    setIsDownloading(true);
+    try {
+      const blob = await leasesApi.downloadReceipt(leaseId);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `receipt-${leaseId}.pdf`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      toast.success('Receipt downloaded');
+    } catch {
+      toast.error('Receipt is not available yet');
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <CardTitle>RLI registration</CardTitle>
+            <CardDescription>
+              Submit the signed contract to the Agenzia delle Entrate via Openapi.it
+            </CardDescription>
+          </div>
+          {statusConfig && (
+            <Badge variant={statusConfig.variant}>{statusConfig.label}</Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {registration ? (
+          <div className="grid gap-3 text-sm sm:grid-cols-2">
+            {registration.registrationCode && (
+              <div>
+                <p className="text-muted-foreground">Registration code</p>
+                <p className="font-medium font-mono">{registration.registrationCode}</p>
+              </div>
+            )}
+            {registration.submittedAt && (
+              <div>
+                <p className="text-muted-foreground">Submitted</p>
+                <p className="font-medium">{formatDateTime(registration.submittedAt)}</p>
+              </div>
+            )}
+            {registration.confirmedAt && (
+              <div>
+                <p className="text-muted-foreground">Confirmed</p>
+                <p className="font-medium">{formatDateTime(registration.confirmedAt)}</p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No registration has been submitted yet.
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-3">
+          {canRegister && onRegister && (
+            <Button onClick={onRegister} disabled={isRegistering}>
+              {isRegistering ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Submitting…
+                </>
+              ) : (
+                'Register with Agenzia delle Entrate'
+              )}
+            </Button>
+          )}
+
+          {leaseStatus === 'Registered' && (
+            <Button
+              variant="outline"
+              onClick={handleDownloadReceipt}
+              disabled={isDownloading}
+            >
+              {isDownloading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Downloading…
+                </>
+              ) : (
+                <>
+                  <Download className="mr-2 h-4 w-4" />
+                  Download receipt
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/leases/index.tsx
+++ b/src/features/leases/index.tsx
@@ -1,0 +1,3 @@
+export { LeasesPage } from './leases-page';
+export { LeaseCreatePage } from './lease-create-page';
+export { LeaseDetailPage } from './lease-detail-page';

--- a/src/features/leases/lease-create-page.tsx
+++ b/src/features/leases/lease-create-page.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+import { AppShell } from '@/components/layout/app-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { LeaseCreateForm } from './components/lease-create-form';
+import { useCreateLease } from '@/queries/use-leases';
+import type { CreateLeaseDto } from '@/types';
+
+export function LeaseCreatePage() {
+  const navigate = useNavigate();
+  const createLease = useCreateLease();
+
+  const handleSubmit = async (data: CreateLeaseDto) => {
+    const lease = await createLease.mutateAsync(data);
+    navigate(`/leases/${lease.id}`);
+  };
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-4xl space-y-6">
+        <PageHeader
+          title="Create lease"
+          description="Define contract parties and terms — a draft will be saved for review"
+        />
+        <LeaseCreateForm
+          onSubmit={handleSubmit}
+          isLoading={createLease.isPending}
+        />
+      </div>
+    </AppShell>
+  );
+}

--- a/src/features/leases/lease-detail-page.tsx
+++ b/src/features/leases/lease-detail-page.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, Loader2, PenLine } from 'lucide-react';
+import { AppShell } from '@/components/layout/app-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  useInitiateSigning,
+  useLease,
+  useLeaseRegistration,
+  useTriggerRegistration,
+} from '@/queries/use-leases';
+import { formatCurrency, formatDate, formatDateTime } from '@/lib/utils';
+import { LeaseStatusBadge } from './components/lease-status-badge';
+import { LeaseSigningPanel } from './components/lease-signing-panel';
+import { RegistrationStatusPanel } from './components/registration-status-panel';
+import { ExtraEUWarningBanner } from './components/extra-eu-warning-banner';
+import { FISCAL_REGIME_LABELS } from './schemas/lease.schema';
+import type { SignerInfo } from '@/types';
+
+export function LeaseDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data: lease, isLoading } = useLease(id!);
+  const { data: registration } = useLeaseRegistration(id!, lease?.status);
+  const initiateSigning = useInitiateSigning();
+  const triggerRegistration = useTriggerRegistration();
+  const [signers, setSigners] = useState<SignerInfo[]>([]);
+
+  if (isLoading) {
+    return <LoadingScreen message="Loading lease..." />;
+  }
+
+  if (!lease) {
+    return (
+      <AppShell>
+        <div className="py-12 text-center">
+          <h2 className="mb-2 text-2xl font-bold">Lease not found</h2>
+          <p className="text-muted-foreground">
+            The lease you are looking for does not exist or you do not have access.
+          </p>
+          <Button className="mt-4" variant="outline" onClick={() => navigate('/leases')}>
+            Back to leases
+          </Button>
+        </div>
+      </AppShell>
+    );
+  }
+
+  const parties = lease.parties ?? [];
+
+  const showExtraEuBanner =
+    lease.hasExtraEUTenant ||
+    parties.some((party) => party.role === 'Tenant' && party.isExtraEU);
+
+  const activeSigners = signers.length > 0 ? signers : [];
+  const showSigningPanel =
+    activeSigners.length > 0 ||
+    lease.status === 'AwaitingSignature' ||
+    lease.status === 'PartiallySigned';
+
+  const handleInitiateSigning = async () => {
+    const result = await initiateSigning.mutateAsync(lease.id);
+    setSigners(result.signers);
+  };
+
+  const handleRegister = async () => {
+    await triggerRegistration.mutateAsync(lease.id);
+  };
+
+  const registrationData = registration ?? lease.registration;
+
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" onClick={() => navigate('/leases')}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <PageHeader
+            title={lease.property?.name ?? 'Lease contract'}
+            description={`${formatDate(lease.startDate)} — ${formatDate(lease.endDate)}`}
+          />
+          <div className="ml-auto">
+            <LeaseStatusBadge status={lease.status} className="text-sm px-3 py-1" />
+          </div>
+        </div>
+
+        {showExtraEuBanner && <ExtraEUWarningBanner />}
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Contract terms</CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-4 text-sm sm:grid-cols-2">
+                <div>
+                  <p className="text-muted-foreground">Monthly rent</p>
+                  <p className="text-lg font-semibold">
+                    {formatCurrency(lease.monthlyRent)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">Fiscal regime</p>
+                  <p className="font-medium">{FISCAL_REGIME_LABELS[lease.fiscalRegime]}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">Registration deadline</p>
+                  <p className="font-medium">{formatDate(lease.registrationDeadline)}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">Created</p>
+                  <p className="font-medium">{formatDateTime(lease.createdAt)}</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Parties</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {parties.map((party) => (
+                  <div
+                    key={party.id}
+                    className="flex flex-col gap-1 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div>
+                      <p className="font-medium">
+                        {party.firstName} {party.lastName}
+                      </p>
+                      <p className="text-sm text-muted-foreground">{party.role}</p>
+                    </div>
+                    <p className="text-sm">{party.contactEmail}</p>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            {lease.status === 'Draft' && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Signing</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="mb-4 text-sm text-muted-foreground">
+                    Generate the contract PDF and send signing links to all parties.
+                  </p>
+                  <Button
+                    onClick={handleInitiateSigning}
+                    disabled={initiateSigning.isPending}
+                  >
+                    {initiateSigning.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Initiating…
+                      </>
+                    ) : (
+                      <>
+                        <PenLine className="mr-2 h-4 w-4" />
+                        Initiate signing
+                      </>
+                    )}
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
+
+            {showSigningPanel && activeSigners.length > 0 && (
+              <LeaseSigningPanel signers={activeSigners} />
+            )}
+
+            <RegistrationStatusPanel
+              leaseId={lease.id}
+              leaseStatus={lease.status}
+              registration={registrationData}
+              canRegister={lease.status === 'Signed'}
+              onRegister={handleRegister}
+              isRegistering={triggerRegistration.isPending}
+            />
+          </div>
+
+          <div className="space-y-6">
+            {lease.events && lease.events.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Timeline</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  {lease.events.map((event, index) => (
+                    <div key={`${event.eventType}-${index}`} className="border-l-2 pl-3">
+                      <p className="font-medium">{event.eventType}</p>
+                      <p className="text-muted-foreground">
+                        {formatDateTime(event.occurredAt)}
+                      </p>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/features/leases/leases-page.tsx
+++ b/src/features/leases/leases-page.tsx
@@ -1,0 +1,101 @@
+import { useNavigate } from 'react-router-dom';
+import { FileText, Plus } from 'lucide-react';
+import { AppShell } from '@/components/layout/app-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { EmptyState } from '@/components/shared/empty-state';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useLeases } from '@/queries/use-leases';
+import { formatCurrency, formatDate } from '@/lib/utils';
+import { LeaseStatusBadge } from './components/lease-status-badge';
+import { FISCAL_REGIME_LABELS } from './schemas/lease.schema';
+import type { LeaseContract } from '@/types';
+
+function getPropertyLabel(lease: LeaseContract): string {
+  return lease.property?.name ?? `Property ${lease.propertyId.slice(0, 8)}`;
+}
+
+export function LeasesPage() {
+  const navigate = useNavigate();
+  const { data: leases, isLoading, isError } = useLeases();
+
+  if (isLoading) {
+    return <LoadingScreen message="Loading leases..." />;
+  }
+
+  const items = leases ?? [];
+
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <PageHeader
+          title="Long-term leases"
+          description="Manage contract drafts, signing, and RLI registration"
+          action={
+            <Button onClick={() => navigate('/leases/new')}>
+              <Plus className="mr-2 h-4 w-4" />
+              Create lease
+            </Button>
+          }
+        />
+
+        {isError && (
+          <p className="text-sm text-destructive">
+            Failed to load leases. Please try again.
+          </p>
+        )}
+
+        {items.length === 0 ? (
+          <EmptyState
+            icon={FileText}
+            title="No leases yet"
+            description="Create your first long-term lease contract draft to start the signing and registration workflow."
+            action={{
+              label: 'Create lease',
+              onClick: () => navigate('/leases/new'),
+            }}
+          />
+        ) : (
+          <div className="grid gap-4">
+            {items.map((lease) => (
+              <Card
+                key={lease.id}
+                className="cursor-pointer transition-colors hover:bg-muted/40"
+                onClick={() => navigate(`/leases/${lease.id}`)}
+              >
+                <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+                  <div className="space-y-1">
+                    <CardTitle className="text-base">{getPropertyLabel(lease)}</CardTitle>
+                    <p className="text-sm text-muted-foreground">
+                      {formatDate(lease.startDate)} — {formatDate(lease.endDate)}
+                    </p>
+                  </div>
+                  <LeaseStatusBadge status={lease.status} />
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-4 text-sm">
+                  <div>
+                    <span className="text-muted-foreground">Rent </span>
+                    <span className="font-medium">
+                      {formatCurrency(lease.monthlyRent)}/mo
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Regime </span>
+                    <span className="font-medium">
+                      {FISCAL_REGIME_LABELS[lease.fiscalRegime]}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Parties </span>
+                    <span className="font-medium">{lease.parties?.length ?? 0}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/src/features/leases/schemas/__tests__/lease.schema.test.ts
+++ b/src/features/leases/schemas/__tests__/lease.schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { leaseFormSchema } from '../lease.schema';
+
+const validForm = {
+  propertyId: '11111111-1111-1111-1111-111111111111',
+  fiscalRegime: 'CedolareSecca' as const,
+  startDate: '2026-09-01',
+  endDate: '2030-08-31',
+  monthlyRent: 1200,
+  landlord: {
+    role: 'Landlord' as const,
+    firstName: 'Mario',
+    lastName: 'Rossi',
+    fiscalCode: 'RSSMRA80A01H501U',
+    citizenship: 'IT',
+    contactEmail: 'mario@example.com',
+  },
+  tenant: {
+    role: 'Tenant' as const,
+    firstName: 'Luigi',
+    lastName: 'Verdi',
+    fiscalCode: 'VRDLGU85B02F205X',
+    citizenship: 'IT',
+    contactEmail: 'luigi@example.com',
+  },
+};
+
+describe('leaseFormSchema', () => {
+  it('accepts valid lease form data', () => {
+    expect(leaseFormSchema.safeParse(validForm).success).toBe(true);
+  });
+
+  it('rejects end date before start date', () => {
+    const result = leaseFormSchema.safeParse({
+      ...validForm,
+      startDate: '2026-09-01',
+      endDate: '2026-01-01',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-positive monthly rent', () => {
+    const result = leaseFormSchema.safeParse({ ...validForm, monthlyRent: 0 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/features/leases/schemas/lease.schema.ts
+++ b/src/features/leases/schemas/lease.schema.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+const partySchema = z.object({
+  role: z.enum(['Landlord', 'Tenant']),
+  firstName: z.string().min(1, 'First name is required').max(100),
+  lastName: z.string().min(1, 'Last name is required').max(100),
+  fiscalCode: z
+    .string()
+    .min(11, 'Fiscal code must be at least 11 characters')
+    .max(16, 'Fiscal code must be at most 16 characters'),
+  citizenship: z
+    .string()
+    .length(2, 'Use ISO 3166-1 alpha-2 country code (e.g. IT)'),
+  contactEmail: z.string().email('Valid email is required'),
+});
+
+export const leaseFormSchema = z
+  .object({
+    propertyId: z.string().min(1, 'Property is required'),
+    fiscalRegime: z.enum(['CedolareSecca', 'RegimeOrdinario', 'CanoneConcordato']),
+    startDate: z.string().min(1, 'Start date is required'),
+    endDate: z.string().min(1, 'End date is required'),
+    monthlyRent: z.number().positive('Monthly rent must be greater than zero'),
+    landlord: partySchema,
+    tenant: partySchema.extend({ role: z.literal('Tenant') }),
+  })
+  .refine((data) => new Date(data.endDate) > new Date(data.startDate), {
+    message: 'End date must be after start date',
+    path: ['endDate'],
+  });
+
+export type LeaseFormValues = z.infer<typeof leaseFormSchema>;
+
+export const FISCAL_REGIME_LABELS: Record<
+  LeaseFormValues['fiscalRegime'],
+  string
+> = {
+  CedolareSecca: 'Cedolare secca',
+  RegimeOrdinario: 'Regime ordinario',
+  CanoneConcordato: 'Canone concordato',
+};
+
+export const LEASE_STATUS_LABELS: Record<
+  string,
+  { label: string; variant: 'default' | 'secondary' | 'outline' | 'destructive' | 'success' }
+> = {
+  Draft: { label: 'Draft', variant: 'secondary' },
+  AwaitingSignature: { label: 'Awaiting signature', variant: 'outline' },
+  PartiallySigned: { label: 'Partially signed', variant: 'outline' },
+  Signed: { label: 'Signed', variant: 'default' },
+  RegistrationPending: { label: 'Registration pending', variant: 'outline' },
+  SentToProvider: { label: 'Sent to provider', variant: 'outline' },
+  Registered: { label: 'Registered', variant: 'success' },
+  Rejected: { label: 'Rejected', variant: 'destructive' },
+};
+
+export const REGISTRATION_STATUS_LABELS: Record<
+  string,
+  { label: string; variant: 'default' | 'secondary' | 'outline' | 'destructive' | 'success' }
+> = {
+  Pending: { label: 'Pending', variant: 'secondary' },
+  SentToProvider: { label: 'Sent to provider', variant: 'outline' },
+  Registered: { label: 'Registered', variant: 'success' },
+  Failed: { label: 'Failed', variant: 'destructive' },
+};

--- a/src/lib/__tests__/auth-roles.test.ts
+++ b/src/lib/__tests__/auth-roles.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getUserRoles, hasRole, ROLES_CLAIM } from '../auth-roles';
+
+describe('auth-roles', () => {
+  it('reads roles from Auth0 custom claim namespace', () => {
+    const user = { [ROLES_CLAIM]: ['LongTermLandlord', 'PropertyOwner'] };
+    expect(getUserRoles(user)).toEqual(['LongTermLandlord', 'PropertyOwner']);
+    expect(hasRole(user, 'LongTermLandlord')).toBe(true);
+    expect(hasRole(user, 'Admin')).toBe(false);
+  });
+
+  it('falls back to roles array on demo user shape', () => {
+    const user = { roles: ['LongTermLandlord'] };
+    expect(hasRole(user, 'LongTermLandlord')).toBe(true);
+  });
+
+  it('returns empty roles for missing user', () => {
+    expect(getUserRoles(undefined)).toEqual([]);
+    expect(hasRole(null, 'LongTermLandlord')).toBe(false);
+  });
+});

--- a/src/lib/auth-roles.ts
+++ b/src/lib/auth-roles.ts
@@ -1,0 +1,22 @@
+export const ROLES_CLAIM = 'https://casazen.app/roles';
+
+type UserWithRoles = Record<string, unknown> | null | undefined;
+
+export function getUserRoles(user: UserWithRoles): string[] {
+  if (!user) return [];
+
+  const roles = user[ROLES_CLAIM];
+  if (Array.isArray(roles)) {
+    return roles.filter((role): role is string => typeof role === 'string');
+  }
+
+  if (Array.isArray(user.roles)) {
+    return user.roles.filter((role): role is string => typeof role === 'string');
+  }
+
+  return [];
+}
+
+export function hasRole(user: UserWithRoles, role: string): boolean {
+  return getUserRoles(user).includes(role);
+}

--- a/src/queries/pricingAdapter.ts
+++ b/src/queries/pricingAdapter.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import {
   getPricingAdapterConfig,
   createOrUpdatePricingAdapterConfig,
@@ -106,8 +107,29 @@ export function useDisablePricingAdapter(propertyId: string) {
 
   return useMutation({
     mutationFn: () => deletePricingAdapterConfig(propertyId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: pricingAdapterKeys.config(propertyId) });
+
+      const previous = queryClient.getQueryData<PricingAdapterConfigDto>(
+        pricingAdapterKeys.config(propertyId)
+      );
+
+      queryClient.setQueryData<PricingAdapterConfigDto>(
+        pricingAdapterKeys.config(propertyId),
+        (old) => (old ? { ...old, isEnabled: false } : old)
+      );
+
+      return { previous };
+    },
+    onError: (_err, _data, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(pricingAdapterKeys.config(propertyId), context.previous);
+      }
+      toast.error('Failed to disable AI pricing');
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: pricingAdapterKeys.config(propertyId) });
+      toast.success('AI pricing disabled');
     },
   });
 }
@@ -117,9 +139,12 @@ export function useTriggerPricingSync(propertyId: string) {
 
   return useMutation({
     mutationFn: () => triggerPricingSync(propertyId),
+    onError: () => {
+      toast.error('Failed to trigger pricing sync');
+    },
     onSuccess: () => {
-      // Sync creates new history entries — invalidate history cache
       queryClient.invalidateQueries({ queryKey: pricingAdapterKeys.history(propertyId) });
+      toast.success('Pricing sync started — history will update shortly');
     },
   });
 }

--- a/src/queries/use-leases.ts
+++ b/src/queries/use-leases.ts
@@ -20,15 +20,24 @@ export function useLease(id: string) {
   });
 }
 
+const REGISTRATION_STATUSES: LeaseStatus[] = [
+  'SentToProvider',
+  'RegistrationPending',
+  'Registered',
+  'Rejected',
+];
+
 export function useLeaseRegistration(id: string, leaseStatus?: LeaseStatus) {
+  const shouldFetch = !!leaseStatus && REGISTRATION_STATUSES.includes(leaseStatus);
   const shouldPoll =
     leaseStatus === 'SentToProvider' || leaseStatus === 'RegistrationPending';
 
   return useQuery({
     queryKey: [LEASES_KEY, id, 'registration'],
     queryFn: () => leasesApi.getRegistration(id),
-    enabled: !!id,
+    enabled: !!id && shouldFetch,
     refetchInterval: shouldPoll ? 30_000 : false,
+    retry: false,
   });
 }
 

--- a/src/queries/use-leases.ts
+++ b/src/queries/use-leases.ts
@@ -1,0 +1,81 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { leasesApi } from '@/api/leases.api';
+import type { CreateLeaseDto, LeaseStatus } from '@/types';
+import { toast } from 'sonner';
+
+const LEASES_KEY = 'leases';
+
+export function useLeases(params?: { propertyId?: string; status?: string }) {
+  return useQuery({
+    queryKey: [LEASES_KEY, params],
+    queryFn: () => leasesApi.getAll(params),
+  });
+}
+
+export function useLease(id: string) {
+  return useQuery({
+    queryKey: [LEASES_KEY, id],
+    queryFn: () => leasesApi.getById(id),
+    enabled: !!id,
+  });
+}
+
+export function useLeaseRegistration(id: string, leaseStatus?: LeaseStatus) {
+  const shouldPoll =
+    leaseStatus === 'SentToProvider' || leaseStatus === 'RegistrationPending';
+
+  return useQuery({
+    queryKey: [LEASES_KEY, id, 'registration'],
+    queryFn: () => leasesApi.getRegistration(id),
+    enabled: !!id,
+    refetchInterval: shouldPoll ? 30_000 : false,
+  });
+}
+
+export function useCreateLease() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateLeaseDto) => leasesApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [LEASES_KEY] });
+      toast.success('Lease draft created successfully');
+    },
+    onError: () => {
+      toast.error('Unable to create lease. Check property documents and try again.');
+    },
+  });
+}
+
+export function useInitiateSigning() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => leasesApi.initiateSigning(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: [LEASES_KEY] });
+      queryClient.invalidateQueries({ queryKey: [LEASES_KEY, id] });
+      toast.success('Signing initiated — share the links with each party');
+    },
+    onError: () => {
+      toast.error('Signing cannot be initiated for this lease.');
+    },
+  });
+}
+
+export function useTriggerRegistration() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => leasesApi.triggerRegistration(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: [LEASES_KEY] });
+      queryClient.invalidateQueries({ queryKey: [LEASES_KEY, id] });
+      queryClient.invalidateQueries({ queryKey: [LEASES_KEY, id, 'registration'] });
+      toast.success('Registration submitted to provider');
+    },
+    onError: () => {
+      toast.error('Unable to submit registration. Please try again.');
+    },
+  });
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,6 +21,7 @@ import { SearchPage } from '@/features/search/search-page';
 import { ProfilePage } from '@/features/profile/profile-page';
 import { PricingDashboardPage } from '@/features/pricing';
 import { PricingHistoryPage } from '@/features/pricing';
+import { LeasesPage, LeaseCreatePage, LeaseDetailPage } from '@/features/leases';
 
 export const router = createBrowserRouter([
   {
@@ -172,6 +173,30 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <ProfilePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/leases',
+    element: (
+      <ProtectedRoute role="LongTermLandlord">
+        <LeasesPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/leases/new',
+    element: (
+      <ProtectedRoute role="LongTermLandlord">
+        <LeaseCreatePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/leases/:id',
+    element: (
+      <ProtectedRoute role="LongTermLandlord">
+        <LeaseDetailPage />
       </ProtectedRoute>
     ),
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,3 +9,4 @@ export * from './guest.types';  // ✅ New
 export * from './tourist-tax.types';  // ✅ New
 export * from './calendar.types';  // ✅ New
 export * from './pricing-adapter.types';
+export * from './lease.types';

--- a/src/types/lease.types.ts
+++ b/src/types/lease.types.ts
@@ -1,0 +1,104 @@
+export type LeaseStatus =
+  | 'Draft'
+  | 'AwaitingSignature'
+  | 'PartiallySigned'
+  | 'Signed'
+  | 'RegistrationPending'
+  | 'SentToProvider'
+  | 'Registered'
+  | 'Rejected';
+
+export type FiscalRegime = 'CedolareSecca' | 'RegimeOrdinario' | 'CanoneConcordato';
+
+export type PartyRole = 'Landlord' | 'Tenant';
+
+export type RegistrationStatus = 'Pending' | 'SentToProvider' | 'Registered' | 'Failed';
+
+export interface LeaseParty {
+  id: string;
+  role: PartyRole;
+  firstName: string;
+  lastName: string;
+  fiscalCode: string;
+  citizenship: string;
+  contactEmail: string;
+  isExtraEU: boolean;
+}
+
+export interface LeaseEvent {
+  eventType: string;
+  occurredAt: string;
+}
+
+export interface LeaseRegistration {
+  id: string;
+  leaseContractId: string;
+  status: RegistrationStatus;
+  externalRegistrationId?: string | null;
+  registrationCode?: string | null;
+  submittedAt?: string | null;
+  confirmedAt?: string | null;
+}
+
+export interface LeasePropertySummary {
+  id: string;
+  name: string;
+  city?: string;
+}
+
+export interface LeaseContract {
+  id: string;
+  propertyId: string;
+  status: LeaseStatus;
+  fiscalRegime: FiscalRegime;
+  startDate: string;
+  endDate: string;
+  monthlyRent: number;
+  registrationDeadline: string;
+  signedPdfStoragePath?: string | null;
+  parties: LeaseParty[];
+  registration?: LeaseRegistration | null;
+  events?: LeaseEvent[];
+  hasExtraEUTenant?: boolean;
+  property?: LeasePropertySummary | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateLeasePartyDto {
+  role: PartyRole;
+  firstName: string;
+  lastName: string;
+  fiscalCode: string;
+  citizenship: string;
+  contactEmail: string;
+}
+
+export interface CreateLeaseDto {
+  propertyId: string;
+  fiscalRegime: FiscalRegime;
+  startDate: string;
+  endDate: string;
+  monthlyRent: number;
+  parties: CreateLeasePartyDto[];
+}
+
+export interface SignerInfo {
+  partyId: string;
+  role: PartyRole;
+  name: string;
+  signingUrl: string;
+  expiresAt: string;
+}
+
+export interface SigningInitiatedResult {
+  leaseId: string;
+  status: LeaseStatus;
+  signers: SignerInfo[];
+}
+
+export interface TriggerRegistrationResult {
+  leaseId: string;
+  registrationStatus: RegistrationStatus;
+  message: string;
+}

--- a/src/types/property.types.ts
+++ b/src/types/property.types.ts
@@ -48,6 +48,24 @@ export interface CreatePropertyDto {
 
 export interface UpdatePropertyDto extends Partial<CreatePropertyDto> {}
 
+export type PropertyDocumentType =
+  | 'CinCertificate'
+  | 'FloorPlan'
+  | 'InsurancePolicy'
+  | 'PropertyLicense'
+  | 'SafetyCompliance'
+  | 'Ape'
+  | 'Other';
+
+export interface PropertyDocument {
+  id: string;
+  fileName: string;
+  storageUrl: string;
+  documentType: PropertyDocumentType;
+  uploadedBy: string;
+  uploadedAt: string;
+}
+
 export interface PropertySearchParams {
   city?: string;
   minPrice?: number;


### PR DESCRIPTION
## Summary
- Add long-term lease management UI at /leases, /leases/new, and /leases/:id for users with the LongTermLandlord role
- Integrate lease API (create draft, initiate signing, trigger registration, download receipt) via TanStack Query
- Extend ProtectedRoute with role guard, gate sidebar nav, and validate APE document before lease creation

## Test plan
- [ ] Run 
pm test (66 tests pass)
- [ ] Demo mode: navigate to /leases, create a draft, verify empty state and list
- [ ] Verify APE validation blocks submit when property has no Ape document
- [ ] On draft lease: initiate signing and confirm signer URLs appear
- [ ] On signed lease: trigger registration and confirm status moves to SentToProvider
- [ ] On registered lease: download receipt PDF
- [ ] Confirm extra-EU tenant shows Questura 48h warning banner
- [ ] Confirm user without LongTermLandlord is redirected from /leases

## Gate status
| Gate | Status |
|---|---|
| npm test | pass |
| tsc -b | pre-existing failures on main (pricing) |
| npm run lint | pre-existing failures on main |
| npm run build | pre-existing failures on main (pricing) |

Relates to casazen/backend#177
