### PR TITLE
fix(build): resolve TypeScript errors blocking Vercel build

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@/lib/utils";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link";
   size?: "default" | "sm" | "lg" | "icon";
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", size = "default", ...props }, ref) => {
+  ({ className, variant = "default", size = "default", asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
     const variantStyles = {
       default: "bg-primary text-primary-foreground hover:bg-primary/90",
       destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
@@ -25,7 +28,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     };
 
     return (
-      <button
+      <Comp
         className={cn(
           "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
           variantStyles[variant],

--- a/src/features/pricing/components/pricing-config-card.tsx
+++ b/src/features/pricing/components/pricing-config-card.tsx
@@ -8,7 +8,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { Label } from '@/components/ui/label';
 import { RefreshCw, Save, Zap } from 'lucide-react';
 import { formatDateTime } from '@/lib/utils';
-import type { PricingAdapterConfig, SavePricingAdapterConfigRequest } from '@/types';
+import type { PricingAdapterConfig } from '@/types';
 import type { CreateOrUpdatePricingAdapterConfigRequest } from '@/types/pricing';
 
 interface PricingConfigCardProps {

--- a/src/features/pricing/components/pricing-preview-section.tsx
+++ b/src/features/pricing/components/pricing-preview-section.tsx
@@ -45,8 +45,8 @@ export function PricingPreviewSection({ prices }: PricingPreviewSectionProps) {
                 className="text-muted-foreground"
               />
               <Tooltip
-                formatter={(value: number, name: string) => [
-                  formatCurrency(value),
+                formatter={(value, name) => [
+                  formatCurrency(typeof value === 'number' ? value : 0),
                   name === 'suggested' ? 'AI price' : 'Base price',
                 ]}
                 labelFormatter={(label) => `Date: ${label}`}

--- a/src/features/pricing/pricing-dashboard-page.tsx
+++ b/src/features/pricing/pricing-dashboard-page.tsx
@@ -12,13 +12,13 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { BrainCircuit, ExternalLink } from 'lucide-react';
 import {
   usePricingAdapterConfig,
-  useUpdatePricingAdapterConfig,
+  useSavePricingAdapterConfig,
   useDisablePricingAdapter,
   useTriggerPricingSync,
   usePricingHistory,
   usePricingPreview,
-} from '@/queries/pricingAdapter';
-import type { CreateOrUpdatePricingAdapterConfigRequest } from '@/types/pricing';
+} from '@/queries/use-pricing-adapter';
+import type { SavePricingAdapterConfigRequest } from '@/types';
 import { PricingConfigCard } from './components/pricing-config-card';
 import { PricingHistoryTable } from './components/pricing-history-table';
 import { PricingPreviewSection } from './components/pricing-preview-section';
@@ -44,16 +44,16 @@ export function PricingDashboardPage() {
   const { data: history, isLoading: isLoadingHistory } = usePricingHistory(propertyId!, historyFilters);
   const { data: preview, isLoading: isLoadingPreview } = usePricingPreview(propertyId!);
 
-  const updateConfig = useUpdatePricingAdapterConfig(propertyId!);
+  const saveConfig = useSavePricingAdapterConfig(propertyId!);
   const disableConfig = useDisablePricingAdapter(propertyId!);
   const triggerSync = useTriggerPricingSync(propertyId!);
 
-  const isSaving = updateConfig.isPending || disableConfig.isPending;
+  const isSaving = saveConfig.isPending || disableConfig.isPending;
   const isSyncing = triggerSync.isPending;
 
   function handleToggle(enabled: boolean) {
     if (enabled) {
-      updateConfig.mutate({
+      saveConfig.mutate({
         isEnabled: true,
         adaptationFrequency: config?.adaptationFrequency ?? 'daily',
         includeSeasonality: config?.includeSeasonality ?? true,
@@ -64,8 +64,8 @@ export function PricingDashboardPage() {
     }
   }
 
-  function handleSave(data: CreateOrUpdatePricingAdapterConfigRequest) {
-    updateConfig.mutate(data);
+  function handleSave(data: SavePricingAdapterConfigRequest) {
+    saveConfig.mutate(data);
   }
 
   function handleFromChange(value: string) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 


### PR DESCRIPTION
## Summary
- Add `asChild` prop to `Button` component via `@radix-ui/react-slot` (used in `PricingDashboardPage` and `PricingHistoryPage`)
- Fix unused `SavePricingAdapterConfigRequest` import in `pricing-config-card.tsx`
- Fix Recharts `Tooltip` formatter value type (`ValueType` not `number`) in `pricing-preview-section.tsx`
- Switch `pricing-dashboard-page.tsx` from deprecated `@/queries/pricingAdapter` hooks to `@/queries/use-pricing-adapter` — fixes `PricingAdapterConfigDto` vs `PricingAdapterConfig` and `PricingHistoryPageDto` vs `PricingHistoryPagedResponse` mismatches
- Import `defineConfig` from `vitest/config` in `vite.config.ts` so `test` config property is valid under `tsc`

## Test plan
- [ ] `npm run build` passes with no TypeScript errors
- [ ] Vercel preview build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)