### PR TITLE
feat(ui): long-term UI layer separation (#182)

### DIFF
--- a/src/components/auth/__tests__/short-stay-layer-guard.test.tsx
+++ b/src/components/auth/__tests__/short-stay-layer-guard.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ShortStayLayerGuard } from '../short-stay-layer-guard';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-app-layer-context', () => ({
+  useAppLayerContext: vi.fn(),
+}));
+
+import { useAuth } from '@/hooks/use-auth';
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+
+function renderGuard(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route element={<ShortStayLayerGuard />}>
+          <Route path="/" element={<div>Short-stay content</div>} />
+          <Route path="/bookings" element={<div>Bookings</div>} />
+        </Route>
+        <Route path="/leases" element={<div>Leases</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ShortStayLayerGuard', () => {
+  it('redirects long-term-only users to /leases', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { roles: ['LongTermLandlord'] },
+    } as ReturnType<typeof useAuth>);
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'long-term',
+      effectiveLayer: 'long-term',
+      canSwitchLayer: false,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/leases',
+    });
+
+    renderGuard('/');
+    expect(screen.getByText('Leases')).toBeInTheDocument();
+  });
+
+  it('redirects dual-role users in long-term layer to /leases', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { roles: ['PropertyOwner', 'LongTermLandlord'] },
+    } as ReturnType<typeof useAuth>);
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'long-term',
+      effectiveLayer: 'long-term',
+      canSwitchLayer: true,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/leases',
+    });
+
+    renderGuard('/bookings');
+    expect(screen.getByText('Leases')).toBeInTheDocument();
+  });
+
+  it('allows dual-role users in short-stay layer', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { roles: ['PropertyOwner', 'LongTermLandlord'] },
+    } as ReturnType<typeof useAuth>);
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: true,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/',
+    });
+
+    renderGuard('/');
+    expect(screen.getByText('Short-stay content')).toBeInTheDocument();
+  });
+
+  it('allows property-owner-only users', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { roles: ['PropertyOwner'] },
+    } as ReturnType<typeof useAuth>);
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: false,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/',
+    });
+
+    renderGuard('/');
+    expect(screen.getByText('Short-stay content')).toBeInTheDocument();
+  });
+});

--- a/src/components/auth/short-stay-layer-guard.tsx
+++ b/src/components/auth/short-stay-layer-guard.tsx
@@ -1,0 +1,19 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '@/hooks/use-auth';
+import { isDualRole, isLongTermOnly } from '@/lib/auth-roles';
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+
+export function ShortStayLayerGuard() {
+  const { user } = useAuth();
+  const { activeLayer } = useAppLayerContext();
+
+  if (isLongTermOnly(user)) {
+    return <Navigate to="/leases" replace />;
+  }
+
+  if (isDualRole(user) && activeLayer === 'long-term') {
+    return <Navigate to="/leases" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/components/layout/__tests__/layer-switcher.test.tsx
+++ b/src/components/layout/__tests__/layer-switcher.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LayerSwitcher } from '../layer-switcher';
+
+vi.mock('@/hooks/use-app-layer-context', () => ({
+  useAppLayerContext: vi.fn(),
+}));
+
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+
+describe('LayerSwitcher', () => {
+  it('renders nothing when layer switching is disabled', () => {
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: false,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/',
+    });
+
+    const { container } = render(<LayerSwitcher />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders segmented control for dual-role users', () => {
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: true,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/',
+    });
+
+    render(<LayerSwitcher />);
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Short-stay' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Long-term' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('calls setLayer when a segment is clicked', () => {
+    const setLayer = vi.fn();
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: true,
+      setLayer,
+      getDefaultHomePath: () => '/',
+    });
+
+    render(<LayerSwitcher />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Long-term' }));
+    expect(setLayer).toHaveBeenCalledWith('long-term');
+  });
+});

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,7 +3,11 @@ import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useUiStore } from '@/store/ui-store';
 
-export function Header() {
+interface HeaderProps {
+  slotStart?: React.ReactNode;
+}
+
+export function Header({ slotStart }: HeaderProps) {
   const toggleSidebar = useUiStore((state) => state.toggleSidebar);
 
   return (
@@ -16,6 +20,7 @@ export function Header() {
       >
         <Menu className="h-5 w-5" />
       </Button>
+      {slotStart}
       <div className="flex-1" />
       <UserMenu />
     </header>

--- a/src/components/layout/layer-switcher.tsx
+++ b/src/components/layout/layer-switcher.tsx
@@ -1,0 +1,74 @@
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+import type { AppLayer } from '@/hooks/use-app-layer';
+import { cn } from '@/lib/utils';
+import { useCallback, useRef } from 'react';
+
+const LAYERS: { value: AppLayer; label: string }[] = [
+  { value: 'short-stay', label: 'Short-stay' },
+  { value: 'long-term', label: 'Long-term' },
+];
+
+export function LayerSwitcher() {
+  const { activeLayer, setLayer, canSwitchLayer } = useAppLayerContext();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const currentIndex = LAYERS.findIndex((layer) => layer.value === activeLayer);
+      if (currentIndex === -1) return;
+
+      let nextIndex = currentIndex;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        nextIndex = (currentIndex + 1) % LAYERS.length;
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        nextIndex = (currentIndex - 1 + LAYERS.length) % LAYERS.length;
+      } else {
+        return;
+      }
+
+      event.preventDefault();
+      const nextLayer = LAYERS[nextIndex].value;
+      setLayer(nextLayer);
+      tabRefs.current[nextIndex]?.focus();
+    },
+    [activeLayer, setLayer]
+  );
+
+  if (!canSwitchLayer) {
+    return null;
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Application layer"
+      className="ml-2 flex rounded-lg border bg-muted p-0.5"
+      onKeyDown={handleKeyDown}
+    >
+      {LAYERS.map((layer, index) => {
+        const isSelected = activeLayer === layer.value;
+        return (
+          <button
+            key={layer.value}
+            ref={(element) => {
+              tabRefs.current[index] = element;
+            }}
+            type="button"
+            role="tab"
+            aria-selected={isSelected}
+            tabIndex={isSelected ? 0 : -1}
+            className={cn(
+              'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+              isSelected
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+            onClick={() => setLayer(layer.value)}
+          >
+            {layer.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/layout/long-term-app-shell.tsx
+++ b/src/components/layout/long-term-app-shell.tsx
@@ -1,24 +1,25 @@
-import { Sidebar } from './sidebar';
+import { Outlet } from 'react-router-dom';
+import { LongTermSidebar } from './long-term-sidebar';
 import { Header } from './header';
 import { LayerSwitcher } from './layer-switcher';
 import { DemoBanner } from '@/components/shared/demo-banner';
 import { useAppLayerContext } from '@/hooks/use-app-layer-context';
 
-interface AppShellProps {
-  children: React.ReactNode;
+interface LongTermAppShellProps {
+  children?: React.ReactNode;
 }
 
-export function AppShell({ children }: AppShellProps) {
+export function LongTermAppShell({ children }: LongTermAppShellProps) {
   const { canSwitchLayer } = useAppLayerContext();
 
   return (
     <div className="flex h-screen overflow-hidden">
-      <Sidebar />
+      <LongTermSidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <DemoBanner />
         <Header slotStart={canSwitchLayer ? <LayerSwitcher /> : undefined} />
         <main className="flex-1 overflow-y-auto p-4 md:p-6">
-          {children}
+          {children ?? <Outlet />}
         </main>
       </div>
     </div>

--- a/src/components/layout/long-term-sidebar.tsx
+++ b/src/components/layout/long-term-sidebar.tsx
@@ -1,26 +1,13 @@
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import {
-  LayoutDashboard,
-  Home,
-  Calendar,
-  CreditCard,
-  Repeat,
-  Search,
-  User,
-} from 'lucide-react';
+import { FileText, Home, User } from 'lucide-react';
 
 const navItems = [
-  { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
-  { to: '/properties', icon: Home, label: 'Properties' },
-  { to: '/bookings', icon: Calendar, label: 'Bookings' },
-  { to: '/payments', icon: CreditCard, label: 'Payments' },
-  { to: '/ota', icon: Repeat, label: 'OTA Sync' },
-  { to: '/search', icon: Search, label: 'Search' },
+  { to: '/leases', icon: FileText, label: 'Leases' },
   { to: '/profile', icon: User, label: 'Profile' },
 ];
 
-export function Sidebar() {
+export function LongTermSidebar() {
   return (
     <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
       <div className="flex h-16 items-center border-b px-6">
@@ -30,7 +17,9 @@ export function Sidebar() {
           </div>
           <div className="flex flex-col leading-none">
             <span className="text-base font-bold tracking-tight">CASAZEN</span>
-            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">Property Manager</span>
+            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">
+              Long-Term Rental
+            </span>
           </div>
         </div>
       </div>
@@ -39,7 +28,7 @@ export function Sidebar() {
           <NavLink
             key={item.to}
             to={item.to}
-            end={item.to === '/'}
+            end={item.to === '/leases'}
             className={({ isActive }) =>
               cn(
                 'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',

--- a/src/contexts/app-layer-context.ts
+++ b/src/contexts/app-layer-context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { UseAppLayerReturn } from '@/hooks/use-app-layer';
+
+export const AppLayerContext = createContext<UseAppLayerReturn | null>(null);

--- a/src/contexts/app-layer-provider.tsx
+++ b/src/contexts/app-layer-provider.tsx
@@ -1,0 +1,9 @@
+import { useAppLayer } from '@/hooks/use-app-layer';
+import { AppLayerContext } from '@/contexts/app-layer-context';
+
+export function AppLayerProvider({ children }: { children: React.ReactNode }) {
+  const layerState = useAppLayer();
+  return (
+    <AppLayerContext.Provider value={layerState}>{children}</AppLayerContext.Provider>
+  );
+}

--- a/src/features/leases/lease-create-page.tsx
+++ b/src/features/leases/lease-create-page.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from 'react-router-dom';
-import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { LeaseCreateForm } from './components/lease-create-form';
 import { useCreateLease } from '@/queries/use-leases';
@@ -15,8 +14,7 @@ export function LeaseCreatePage() {
   };
 
   return (
-    <AppShell>
-      <div className="mx-auto max-w-4xl space-y-6">
+    <div className="mx-auto max-w-4xl space-y-6">
         <PageHeader
           title="Create lease"
           description="Define contract parties and terms — a draft will be saved for review"
@@ -25,7 +23,6 @@ export function LeaseCreatePage() {
           onSubmit={handleSubmit}
           isLoading={createLease.isPending}
         />
-      </div>
-    </AppShell>
+    </div>
   );
 }

--- a/src/features/leases/lease-detail-page.tsx
+++ b/src/features/leases/lease-detail-page.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, Loader2, PenLine } from 'lucide-react';
-import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { Button } from '@/components/ui/button';
@@ -35,17 +34,15 @@ export function LeaseDetailPage() {
 
   if (!lease) {
     return (
-      <AppShell>
-        <div className="py-12 text-center">
-          <h2 className="mb-2 text-2xl font-bold">Lease not found</h2>
-          <p className="text-muted-foreground">
-            The lease you are looking for does not exist or you do not have access.
-          </p>
-          <Button className="mt-4" variant="outline" onClick={() => navigate('/leases')}>
-            Back to leases
-          </Button>
-        </div>
-      </AppShell>
+      <div className="py-12 text-center">
+        <h2 className="mb-2 text-2xl font-bold">Lease not found</h2>
+        <p className="text-muted-foreground">
+          The lease you are looking for does not exist or you do not have access.
+        </p>
+        <Button className="mt-4" variant="outline" onClick={() => navigate('/leases')}>
+          Back to leases
+        </Button>
+      </div>
     );
   }
 
@@ -73,8 +70,7 @@ export function LeaseDetailPage() {
   const registrationData = registration ?? lease.registration;
 
   return (
-    <AppShell>
-      <div className="space-y-6">
+    <div className="space-y-6">
         <div className="flex items-center gap-3">
           <Button variant="ghost" size="icon" onClick={() => navigate('/leases')}>
             <ArrowLeft className="h-4 w-4" />
@@ -203,7 +199,6 @@ export function LeaseDetailPage() {
             )}
           </div>
         </div>
-      </div>
-    </AppShell>
+    </div>
   );
 }

--- a/src/features/leases/leases-page.tsx
+++ b/src/features/leases/leases-page.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from 'react-router-dom';
 import { FileText, Plus } from 'lucide-react';
-import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { EmptyState } from '@/components/shared/empty-state';
 import { LoadingScreen } from '@/components/shared/loading-screen';
@@ -27,8 +26,7 @@ export function LeasesPage() {
   const items = leases ?? [];
 
   return (
-    <AppShell>
-      <div className="space-y-6">
+    <div className="space-y-6">
         <PageHeader
           title="Long-term leases"
           description="Manage contract drafts, signing, and RLI registration"
@@ -95,7 +93,6 @@ export function LeasesPage() {
             ))}
           </div>
         )}
-      </div>
-    </AppShell>
+    </div>
   );
 }

--- a/src/features/profile/layer-aware-profile-page.tsx
+++ b/src/features/profile/layer-aware-profile-page.tsx
@@ -1,0 +1,43 @@
+import { AppShell } from '@/components/layout/app-shell';
+import { LongTermAppShell } from '@/components/layout/long-term-app-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+import { ProfileInfo } from './components/profile-info';
+import { useAuth } from '@/hooks/use-auth';
+
+function ProfileContent() {
+  const { isLoading, user } = useAuth();
+
+  if (isLoading || !user) {
+    return <LoadingScreen />;
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <PageHeader
+        title="My Profile"
+        description="View and manage your account information"
+      />
+      <ProfileInfo user={user} />
+    </div>
+  );
+}
+
+export function LayerAwareProfilePage() {
+  const { effectiveLayer } = useAppLayerContext();
+
+  if (effectiveLayer === 'long-term') {
+    return (
+      <LongTermAppShell>
+        <ProfileContent />
+      </LongTermAppShell>
+    );
+  }
+
+  return (
+    <AppShell>
+      <ProfileContent />
+    </AppShell>
+  );
+}

--- a/src/hooks/__tests__/use-app-layer.test.ts
+++ b/src/hooks/__tests__/use-app-layer.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ACTIVE_LAYER_STORAGE_KEY,
+  getDefaultHomePath,
+  resolveInitialLayer,
+} from '../use-app-layer';
+import { ROLE_LONG_TERM_LANDLORD, ROLE_PROPERTY_OWNER } from '@/lib/auth-roles';
+
+describe('use-app-layer helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns short-stay home for short-stay layer', () => {
+    expect(getDefaultHomePath('short-stay')).toBe('/');
+  });
+
+  it('returns leases home for long-term layer', () => {
+    expect(getDefaultHomePath('long-term')).toBe('/leases');
+  });
+
+  it('resolves short-stay-only users to short-stay layer', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER] };
+    expect(resolveInitialLayer(user)).toBe('short-stay');
+  });
+
+  it('resolves long-term-only users to long-term layer', () => {
+    const user = { roles: [ROLE_LONG_TERM_LANDLORD] };
+    expect(resolveInitialLayer(user)).toBe('long-term');
+  });
+
+  it('ignores localStorage for single-role users', () => {
+    localStorage.setItem(ACTIVE_LAYER_STORAGE_KEY, 'long-term');
+    const user = { roles: [ROLE_PROPERTY_OWNER] };
+    expect(resolveInitialLayer(user)).toBe('short-stay');
+  });
+
+  it('reads localStorage for dual-role users', () => {
+    localStorage.setItem(ACTIVE_LAYER_STORAGE_KEY, 'long-term');
+    const user = { roles: [ROLE_PROPERTY_OWNER, ROLE_LONG_TERM_LANDLORD] };
+    expect(resolveInitialLayer(user)).toBe('long-term');
+  });
+
+  it('defaults dual-role users to short-stay when no preference stored', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER, ROLE_LONG_TERM_LANDLORD] };
+    expect(resolveInitialLayer(user)).toBe('short-stay');
+  });
+});

--- a/src/hooks/use-app-layer-context.ts
+++ b/src/hooks/use-app-layer-context.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { AppLayerContext } from '@/contexts/app-layer-context';
+import type { UseAppLayerReturn } from '@/hooks/use-app-layer';
+
+export function useAppLayerContext(): UseAppLayerReturn {
+  const context = useContext(AppLayerContext);
+  if (!context) {
+    throw new Error('useAppLayerContext must be used within AppLayerProvider');
+  }
+  return context;
+}

--- a/src/hooks/use-app-layer.ts
+++ b/src/hooks/use-app-layer.ts
@@ -1,0 +1,136 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  isDualRole,
+  isLongTermOnly,
+  isShortStayOnly,
+  type UserWithRoles,
+} from '@/lib/auth-roles';
+
+export type AppLayer = 'short-stay' | 'long-term';
+
+export const ACTIVE_LAYER_STORAGE_KEY = 'casazen:active-layer';
+
+const SHORT_STAY_PATH_PREFIXES = [
+  '/',
+  '/properties',
+  '/bookings',
+  '/payments',
+  '/ota',
+  '/search',
+];
+
+export function getDefaultHomePath(layer: AppLayer = 'short-stay'): string {
+  return layer === 'long-term' ? '/leases' : '/';
+}
+
+export function resolveInitialLayer(user: UserWithRoles): AppLayer {
+  if (isShortStayOnly(user)) return 'short-stay';
+  if (isLongTermOnly(user)) return 'long-term';
+
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(ACTIVE_LAYER_STORAGE_KEY);
+    if (stored === 'long-term' || stored === 'short-stay') {
+      return stored;
+    }
+  }
+
+  return 'short-stay';
+}
+
+function readStoredLayer(): AppLayer {
+  if (typeof window === 'undefined') return 'short-stay';
+  const stored = localStorage.getItem(ACTIVE_LAYER_STORAGE_KEY);
+  return stored === 'long-term' ? 'long-term' : 'short-stay';
+}
+
+function persistLayer(layer: AppLayer): void {
+  localStorage.setItem(ACTIVE_LAYER_STORAGE_KEY, layer);
+}
+
+function isShortStayDeepLink(pathname: string): boolean {
+  if (pathname === '/') return true;
+  return SHORT_STAY_PATH_PREFIXES.some(
+    (prefix) => prefix !== '/' && (pathname === prefix || pathname.startsWith(`${prefix}/`))
+  );
+}
+
+function getPathLayer(pathname: string, canSwitchLayer: boolean): AppLayer | null {
+  if (!canSwitchLayer) return null;
+  if (pathname.startsWith('/leases')) return 'long-term';
+  if (isShortStayDeepLink(pathname)) return 'short-stay';
+  return null;
+}
+
+export interface UseAppLayerReturn {
+  activeLayer: AppLayer;
+  setLayer: (layer: AppLayer) => void;
+  effectiveLayer: AppLayer;
+  canSwitchLayer: boolean;
+  getDefaultHomePath: (layer?: AppLayer) => string;
+}
+
+export function useAppLayer(): UseAppLayerReturn {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const canSwitchLayer = isDualRole(user);
+
+  const forcedLayer = useMemo((): AppLayer | null => {
+    if (isShortStayOnly(user)) return 'short-stay';
+    if (isLongTermOnly(user)) return 'long-term';
+    return null;
+  }, [user]);
+
+  const pathLayer = useMemo(
+    () => getPathLayer(location.pathname, canSwitchLayer),
+    [canSwitchLayer, location.pathname]
+  );
+
+  const [storedLayer, setStoredLayer] = useState<AppLayer>(readStoredLayer);
+  const [prevPathLayer, setPrevPathLayer] = useState<AppLayer | null>(pathLayer);
+  const [prevForcedLayer, setPrevForcedLayer] = useState<AppLayer | null>(forcedLayer);
+
+  if (pathLayer !== prevPathLayer) {
+    setPrevPathLayer(pathLayer);
+    if (pathLayer) {
+      setStoredLayer(pathLayer);
+      persistLayer(pathLayer);
+    }
+  }
+
+  if (forcedLayer !== prevForcedLayer) {
+    setPrevForcedLayer(forcedLayer);
+    if (forcedLayer) {
+      setStoredLayer(forcedLayer);
+    }
+  }
+
+  const activeLayer = forcedLayer ?? pathLayer ?? storedLayer;
+  const effectiveLayer = forcedLayer ?? activeLayer;
+
+  const setLayer = useCallback(
+    (layer: AppLayer) => {
+      if (!canSwitchLayer) return;
+      setStoredLayer(layer);
+      persistLayer(layer);
+      navigate(getDefaultHomePath(layer), { replace: true });
+    },
+    [canSwitchLayer, navigate]
+  );
+
+  const getHomePath = useCallback(
+    (layer?: AppLayer) => getDefaultHomePath(layer ?? effectiveLayer),
+    [effectiveLayer]
+  );
+
+  return {
+    activeLayer,
+    setLayer,
+    effectiveLayer,
+    canSwitchLayer,
+    getDefaultHomePath: getHomePath,
+  };
+}

--- a/src/lib/__tests__/auth-roles.test.ts
+++ b/src/lib/__tests__/auth-roles.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { getUserRoles, hasRole, ROLES_CLAIM } from '../auth-roles';
+import {
+  getUserRoles,
+  hasRole,
+  isDualRole,
+  isLongTermOnly,
+  isShortStayOnly,
+  ROLES_CLAIM,
+  ROLE_LONG_TERM_LANDLORD,
+  ROLE_PROPERTY_OWNER,
+} from '../auth-roles';
 
 describe('auth-roles', () => {
   it('reads roles from Auth0 custom claim namespace', () => {
@@ -17,5 +26,26 @@ describe('auth-roles', () => {
   it('returns empty roles for missing user', () => {
     expect(getUserRoles(undefined)).toEqual([]);
     expect(hasRole(null, 'LongTermLandlord')).toBe(false);
+  });
+
+  it('identifies short-stay-only users', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER] };
+    expect(isShortStayOnly(user)).toBe(true);
+    expect(isLongTermOnly(user)).toBe(false);
+    expect(isDualRole(user)).toBe(false);
+  });
+
+  it('identifies long-term-only users', () => {
+    const user = { roles: [ROLE_LONG_TERM_LANDLORD] };
+    expect(isLongTermOnly(user)).toBe(true);
+    expect(isShortStayOnly(user)).toBe(false);
+    expect(isDualRole(user)).toBe(false);
+  });
+
+  it('identifies dual-role users', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER, ROLE_LONG_TERM_LANDLORD] };
+    expect(isDualRole(user)).toBe(true);
+    expect(isShortStayOnly(user)).toBe(false);
+    expect(isLongTermOnly(user)).toBe(false);
   });
 });

--- a/src/lib/auth-roles.ts
+++ b/src/lib/auth-roles.ts
@@ -1,6 +1,9 @@
 export const ROLES_CLAIM = 'https://casazen.app/roles';
 
-type UserWithRoles = Record<string, unknown> | null | undefined;
+export const ROLE_PROPERTY_OWNER = 'PropertyOwner';
+export const ROLE_LONG_TERM_LANDLORD = 'LongTermLandlord';
+
+export type UserWithRoles = Record<string, unknown> | null | undefined;
 
 export function getUserRoles(user: UserWithRoles): string[] {
   if (!user) return [];
@@ -19,4 +22,16 @@ export function getUserRoles(user: UserWithRoles): string[] {
 
 export function hasRole(user: UserWithRoles, role: string): boolean {
   return getUserRoles(user).includes(role);
+}
+
+export function isShortStayOnly(user: UserWithRoles): boolean {
+  return hasRole(user, ROLE_PROPERTY_OWNER) && !hasRole(user, ROLE_LONG_TERM_LANDLORD);
+}
+
+export function isLongTermOnly(user: UserWithRoles): boolean {
+  return hasRole(user, ROLE_LONG_TERM_LANDLORD) && !hasRole(user, ROLE_PROPERTY_OWNER);
+}
+
+export function isDualRole(user: UserWithRoles): boolean {
+  return hasRole(user, ROLE_PROPERTY_OWNER) && hasRole(user, ROLE_LONG_TERM_LANDLORD);
 }

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -3,17 +3,19 @@ import { useAuth } from '@/hooks/use-auth';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { getDefaultHomePath, resolveInitialLayer } from '@/hooks/use-app-layer';
 import { Home, LogIn } from 'lucide-react';
 
 export function LoginPage() {
-  const { isAuthenticated, login } = useAuth();
+  const { isAuthenticated, user, login } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (isAuthenticated) {
-      navigate('/');
+    if (isAuthenticated && user) {
+      const layer = resolveInitialLayer(user);
+      navigate(getDefaultHomePath(layer), { replace: true });
     }
-  }, [isAuthenticated, navigate]);
+  }, [isAuthenticated, user, navigate]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,8 @@
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 import { ProtectedRoute } from '@/components/auth/protected-route';
+import { ShortStayLayerGuard } from '@/components/auth/short-stay-layer-guard';
+import { LongTermAppShell } from '@/components/layout/long-term-app-shell';
+import { AppLayerProvider } from '@/contexts/app-layer-provider';
 import { LoginPage } from '@/pages/login-page';
 import { DashboardPage } from '@/features/dashboard/dashboard-page';
 import { PropertiesPage } from '@/features/properties/properties-page';
@@ -18,7 +21,7 @@ import { RevenuePage } from '@/features/payments/revenue-page';
 import { OtaPage } from '@/features/ota/ota-page';
 import { OtaSetupPage } from '@/features/ota/ota-setup-page';
 import { SearchPage } from '@/features/search/search-page';
-import { ProfilePage } from '@/features/profile/profile-page';
+import { LayerAwareProfilePage } from '@/features/profile/layer-aware-profile-page';
 import { PricingDashboardPage } from '@/features/pricing';
 import { PricingHistoryPage } from '@/features/pricing';
 import { LeasesPage, LeaseCreatePage, LeaseDetailPage } from '@/features/leases';
@@ -29,184 +32,121 @@ export const router = createBrowserRouter([
     element: <LoginPage />,
   },
   {
-    path: '/',
-    element: (
-      <ProtectedRoute>
-        <DashboardPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties',
-    element: (
-      <ProtectedRoute>
-        <PropertiesPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/create',
-    element: (
-      <ProtectedRoute>
-        <PropertyCreatePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/:id',
-    element: (
-      <ProtectedRoute>
-        <PropertyDetailPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/:id/edit',
-    element: (
-      <ProtectedRoute>
-        <PropertyEditPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/:id/pricing',
-    element: (
-      <ProtectedRoute>
-        <PricingDashboardPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings',
-    element: (
-      <ProtectedRoute>
-        <BookingsPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings/create',
-    element: (
-      <ProtectedRoute>
-        <BookingCreatePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings/calendar',
-    element: (
-      <ProtectedRoute>
-        <CalendarPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings/:id',
-    element: (
-      <ProtectedRoute>
-        <BookingDetailPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings/:id/edit',
-    element: (
-      <ProtectedRoute>
-        <BookingEditPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/payments',
-    element: (
-      <ProtectedRoute>
-        <PaymentsPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/payments/create',
-    element: (
-      <ProtectedRoute>
-        <PaymentCreatePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/payments/revenue',
-    element: (
-      <ProtectedRoute>
-        <RevenuePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/payments/:id',
-    element: (
-      <ProtectedRoute>
-        <PaymentDetailPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/ota',
-    element: (
-      <ProtectedRoute>
-        <OtaPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/ota/create',
-    element: (
-      <ProtectedRoute>
-        <OtaSetupPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
     path: '/search',
     element: <SearchPage />,
   },
   {
-    path: '/profile',
     element: (
       <ProtectedRoute>
-        <ProfilePage />
+        <AppLayerProvider>
+          <Outlet />
+        </AppLayerProvider>
       </ProtectedRoute>
     ),
-  },
-  {
-    path: '/leases',
-    element: (
-      <ProtectedRoute role="LongTermLandlord">
-        <LeasesPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/leases/new',
-    element: (
-      <ProtectedRoute role="LongTermLandlord">
-        <LeaseCreatePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/leases/:id',
-    element: (
-      <ProtectedRoute role="LongTermLandlord">
-        <LeaseDetailPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/:id/pricing/history',
-    element: (
-      <ProtectedRoute>
-        <PricingHistoryPage />
-      </ProtectedRoute>
-    ),
+    children: [
+      {
+        element: <ShortStayLayerGuard />,
+        children: [
+          {
+            path: '/',
+            element: <DashboardPage />,
+          },
+          {
+            path: '/properties',
+            element: <PropertiesPage />,
+          },
+          {
+            path: '/properties/create',
+            element: <PropertyCreatePage />,
+          },
+          {
+            path: '/properties/:id',
+            element: <PropertyDetailPage />,
+          },
+          {
+            path: '/properties/:id/edit',
+            element: <PropertyEditPage />,
+          },
+          {
+            path: '/properties/:id/pricing',
+            element: <PricingDashboardPage />,
+          },
+          {
+            path: '/properties/:id/pricing/history',
+            element: <PricingHistoryPage />,
+          },
+          {
+            path: '/bookings',
+            element: <BookingsPage />,
+          },
+          {
+            path: '/bookings/create',
+            element: <BookingCreatePage />,
+          },
+          {
+            path: '/bookings/calendar',
+            element: <CalendarPage />,
+          },
+          {
+            path: '/bookings/:id',
+            element: <BookingDetailPage />,
+          },
+          {
+            path: '/bookings/:id/edit',
+            element: <BookingEditPage />,
+          },
+          {
+            path: '/payments',
+            element: <PaymentsPage />,
+          },
+          {
+            path: '/payments/create',
+            element: <PaymentCreatePage />,
+          },
+          {
+            path: '/payments/revenue',
+            element: <RevenuePage />,
+          },
+          {
+            path: '/payments/:id',
+            element: <PaymentDetailPage />,
+          },
+          {
+            path: '/ota',
+            element: <OtaPage />,
+          },
+          {
+            path: '/ota/create',
+            element: <OtaSetupPage />,
+          },
+        ],
+      },
+      {
+        path: '/profile',
+        element: <LayerAwareProfilePage />,
+      },
+      {
+        element: (
+          <ProtectedRoute role="LongTermLandlord">
+            <LongTermAppShell />
+          </ProtectedRoute>
+        ),
+        children: [
+          {
+            path: '/leases',
+            element: <LeasesPage />,
+          },
+          {
+            path: '/leases/new',
+            element: <LeaseCreatePage />,
+          },
+          {
+            path: '/leases/:id',
+            element: <LeaseDetailPage />,
+          },
+        ],
+      },
+    ],
   },
   {
     path: '*',


### PR DESCRIPTION
## Summary

- Split navigation into short-stay (`AppShell` + `Sidebar`) and long-term (`LongTermAppShell` + `LongTermSidebar`) layers with nested React Router layout routes on preserved `/leases/*` paths.
- Add `useAppLayer` hook with `localStorage` persistence, `LayerSwitcher` for dual-role users, and `ShortStayLayerGuard` to block long-term-only users from short-stay routes.
- Remove Leases from short-stay sidebar; strip per-page `AppShell` from lease pages; role helpers (`isShortStayOnly`, `isLongTermOnly`, `isDualRole`) drive post-login redirect and guards.

## Test plan

- [ ] PropertyOwner-only: login lands on `/`, no Leases nav, no layer switcher; manual `/leases` redirects to `/` with toast
- [ ] LongTermLandlord-only: login lands on `/leases`, long-term sidebar only; manual `/` redirects to `/leases`
- [ ] Dual-role: layer switcher toggles shells and persists preference; deep links auto-sync active layer
- [ ] Lease CRUD at `/leases`, `/leases/new`, `/leases/:id` renders inside `LongTermAppShell`
- [ ] Profile page uses correct shell via `LayerAwareProfilePage`

## Gate status

| Gate | Status | Notes |
|------|--------|-------|
| G1: dotnet test | ⚠️ | 352 passed; 10 integration cleanup failures (Hangfire dispose — pre-existing, backend unchanged) |
| G2: dotnet format | ✅ | verify-no-changes |
| G3: dotnet build /warnaserror | ✅ | 0 warnings |
| G4: EF migrations | N/A | No schema changes |
| G5: npm test | ⚠️ | 77 passed; 12 pricing-dashboard failures pre-existing on main (unrelated to #182); 20/20 new layer tests pass |
| G6: tsc -b --noEmit | ✅ | |
| G7: npm run lint | ⚠️ | New #182 files lint-clean; repo has pre-existing lint debt in pricing/api files |
| G8: npm run build | ✅ | |
| G9: Property compliance | N/A | |
| G10: No secrets | ✅ | |
| G11: Guest compliance | N/A | |
| G12: Backend unchanged | ✅ | |

Closes casazen/backend#182
