### PR TITLE
feat(admin): admin shell, user management UI, CIN compliance and jobs pages (#11)

### DIFF
--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin panel — auth-gate and shell', () => {
+  test('AC12 /admin redirects to / when user lacks Admin role', async ({ page }) => {
+    // Navigate directly without any authenticated session — should redirect to login
+    await page.goto('/admin');
+    // Either ends up on /login (unauthenticated) or on / (authenticated but no Admin role)
+    const url = page.url();
+    expect(url).not.toContain('/admin');
+  });
+
+  test('AC14 /admin/users redirects to / when user lacks Admin role', async ({ page }) => {
+    await page.goto('/admin/users');
+    const url = page.url();
+    expect(url).not.toContain('/admin/users');
+  });
+
+  test('AC15 /admin/cin redirects when user lacks Admin role', async ({ page }) => {
+    await page.goto('/admin/cin');
+    const url = page.url();
+    expect(url).not.toContain('/admin/cin');
+  });
+});

--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -1,0 +1,13 @@
+import { ApiClient } from '@/api/client';
+import type { AdminStats, CinComplianceItem, JobStatus } from '@/types';
+
+export const AdminApi = {
+  getStats: (): Promise<AdminStats> =>
+    ApiClient.get<AdminStats>('/admin/stats'),
+
+  getCinCompliance: (): Promise<CinComplianceItem[]> =>
+    ApiClient.get<CinComplianceItem[]>('/admin/cin-compliance'),
+
+  getJobs: (): Promise<JobStatus[]> =>
+    ApiClient.get<JobStatus[]>('/admin/jobs'),
+};

--- a/src/api/users.api.ts
+++ b/src/api/users.api.ts
@@ -1,0 +1,45 @@
+import { ApiClient } from '@/api/client';
+import type { UserDetail, UserSummary, UpdateProfileRequest, ChangeRoleRequest, PagedResult } from '@/types';
+
+interface GetUsersParams {
+  page?: number;
+  pageSize?: number;
+  role?: string;
+  isActive?: boolean;
+  search?: string;
+}
+
+// Backend returns our PagedResultDto<T> directly (not wrapped in the standard PaginatedResponse shape)
+interface BackendPagedResult<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export const UsersApi = {
+  getUsers: (params: GetUsersParams): Promise<PagedResult<UserSummary>> =>
+    ApiClient.get<BackendPagedResult<UserSummary>>('/users', params as Record<string, unknown>).then(
+      (res) => ({
+        items: res.items ?? [],
+        totalCount: res.totalCount ?? 0,
+        page: res.page ?? 1,
+        pageSize: res.pageSize ?? 20,
+      })
+    ),
+
+  getUserById: (id: string): Promise<UserDetail> =>
+    ApiClient.get<UserDetail>(`/users/${id}`),
+
+  getMe: (): Promise<UserDetail> =>
+    ApiClient.get<UserDetail>('/users/me'),
+
+  updateMe: (body: UpdateProfileRequest): Promise<UserDetail> =>
+    ApiClient.put<UserDetail>('/users/me', body),
+
+  changeRole: (id: string, role: string): Promise<{ id: string; role: string }> =>
+    ApiClient.put<{ id: string; role: string }>(`/users/${id}/role`, { role } as ChangeRoleRequest),
+
+  deactivateUser: (id: string): Promise<void> =>
+    ApiClient.delete<void>(`/users/${id}`),
+};

--- a/src/components/layout/admin-app-shell.tsx
+++ b/src/components/layout/admin-app-shell.tsx
@@ -1,0 +1,21 @@
+import { Outlet } from 'react-router-dom';
+import { AdminSidebar } from './admin-sidebar';
+import { Header } from './header';
+
+interface AdminAppShellProps {
+  children?: React.ReactNode;
+}
+
+export function AdminAppShell({ children }: AdminAppShellProps) {
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <AdminSidebar />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <Header />
+        <main className="flex-1 overflow-y-auto p-4 md:p-6">
+          {children ?? <Outlet />}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -1,0 +1,57 @@
+import { NavLink } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+import { BarChart3, Building2, FileCheck, Home, Settings } from 'lucide-react';
+
+const navItems = [
+  { to: '/admin', icon: BarChart3, label: 'Dashboard', end: true },
+  { to: '/admin/users', icon: Building2, label: 'Users' },
+  { to: '/admin/cin', icon: FileCheck, label: 'CIN Compliance' },
+  { to: '/admin/jobs', icon: Settings, label: 'Background Jobs' },
+];
+
+export function AdminSidebar() {
+  return (
+    <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
+      <div className="flex h-16 items-center border-b px-6">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-destructive text-destructive-foreground shadow-sm">
+            <Home className="h-4 w-4" />
+          </div>
+          <div className="flex flex-col leading-none">
+            <span className="text-base font-bold tracking-tight">CASAZEN</span>
+            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">
+              Admin Panel
+            </span>
+          </div>
+        </div>
+      </div>
+      <nav className="flex-1 space-y-0.5 p-3">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.end}
+            className={({ isActive }) =>
+              cn(
+                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                isActive
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+              )
+            }
+          >
+            <>
+              <item.icon className="h-4 w-4 shrink-0" />
+              {item.label}
+            </>
+          </NavLink>
+        ))}
+      </nav>
+      <div className="border-t p-3">
+        <p className="text-[10px] text-muted-foreground text-center tracking-wide">
+          v1.0.0 · Admin
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/src/features/admin/admin-cin-page.tsx
+++ b/src/features/admin/admin-cin-page.tsx
@@ -1,0 +1,22 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent } from '@/components/ui/card';
+import { CinComplianceTable } from './components/cin-compliance-table';
+import { useCinCompliance } from '@/queries/use-admin';
+
+export function AdminCinPage() {
+  const { data, isLoading } = useCinCompliance();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Conformità CIN"
+        description="Verifica dei codici identificativi nazionali (D.L. 145/2023)"
+      />
+      <Card>
+        <CardContent className="pt-6">
+          <CinComplianceTable items={data ?? []} isLoading={isLoading} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/admin/admin-dashboard-page.tsx
+++ b/src/features/admin/admin-dashboard-page.tsx
@@ -1,0 +1,116 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { AdminKpiCard } from './components/admin-kpi-card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useAdminStats } from '@/queries/use-admin';
+import { Building2, Calendar, DollarSign, FileCheck, Wifi } from 'lucide-react';
+
+export function AdminDashboardPage() {
+  const { data: stats, isLoading } = useAdminStats();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Dashboard Amministratore"
+        description="Panoramica del sistema CasaZen"
+      />
+
+      {isLoading ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-32" />
+          ))}
+        </div>
+      ) : stats ? (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <AdminKpiCard
+              title="Proprietà totali"
+              value={stats.totalProperties}
+              icon={Building2}
+            />
+            <AdminKpiCard
+              title="Proprietà attive"
+              value={stats.activeProperties}
+              icon={Building2}
+            />
+            <AdminKpiCard
+              title="Prenotazioni totali"
+              value={stats.totalBookings}
+              icon={Calendar}
+            />
+            <AdminKpiCard
+              title="Prenotazioni del mese"
+              value={stats.bookingsThisMonth}
+              icon={Calendar}
+            />
+            <AdminKpiCard
+              title="Check-in imminenti"
+              value={stats.upcomingCheckIns}
+              icon={Calendar}
+            />
+            <AdminKpiCard
+              title="Ricavi totali"
+              value={`€ ${stats.totalRevenue.toLocaleString('it-IT', { minimumFractionDigits: 2 })}`}
+              icon={DollarSign}
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <FileCheck className="h-4 w-4" />
+                  Conformità CIN
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Totale</span>
+                  <span className="font-medium">{stats.cinCompliance.total}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-green-600">Validi</span>
+                  <span className="font-medium">{stats.cinCompliance.valid}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-yellow-600">Mancanti</span>
+                  <span className="font-medium">{stats.cinCompliance.missing}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-red-600">Non validi</span>
+                  <span className="font-medium">{stats.cinCompliance.invalid}</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Wifi className="h-4 w-4" />
+                  Salute OTA Sync
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-green-600">Sincronizzati</span>
+                  <span className="font-medium">{stats.otaSyncHealth.synced}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-red-600">Falliti</span>
+                  <span className="font-medium">{stats.otaSyncHealth.failed}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Mai sincronizzati</span>
+                  <span className="font-medium">{stats.otaSyncHealth.neverSynced}</span>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </>
+      ) : (
+        <p className="text-muted-foreground">Impossibile caricare le statistiche.</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/admin/admin-jobs-page.tsx
+++ b/src/features/admin/admin-jobs-page.tsx
@@ -1,0 +1,22 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent } from '@/components/ui/card';
+import { AdminJobsTable } from './components/admin-jobs-table';
+import { useAdminJobs } from '@/queries/use-admin';
+
+export function AdminJobsPage() {
+  const { data, isLoading } = useAdminJobs();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Background Jobs"
+        description="Stato dei job Hangfire (aggiornato ogni 30 secondi)"
+      />
+      <Card>
+        <CardContent className="pt-6">
+          <AdminJobsTable jobs={data ?? []} isLoading={isLoading} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/admin/admin-users-page.tsx
+++ b/src/features/admin/admin-users-page.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { UserManagementTable } from './components/user-management-table';
+import { useUsers } from '@/queries/use-users';
+
+const PAGE_SIZE = 20;
+
+export function AdminUsersPage() {
+  const [search, setSearch] = useState('');
+  const [role, setRole] = useState('');
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useUsers({
+    search: search || undefined,
+    role: role || undefined,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const totalPages = data ? Math.ceil(data.totalCount / PAGE_SIZE) : 1;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Gestione Utenti"
+        description="Visualizza e gestisci tutti gli utenti del sistema"
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Filtri</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3">
+          <Input
+            placeholder="Cerca per nome o email..."
+            value={search}
+            onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+            className="max-w-xs"
+          />
+          <select
+            className="rounded-md border px-3 py-2 text-sm"
+            value={role}
+            onChange={(e) => { setRole(e.target.value); setPage(1); }}
+          >
+            <option value="">Tutti i ruoli</option>
+            <option value="Admin">Admin</option>
+            <option value="PropertyOwner">PropertyOwner</option>
+            <option value="PropertyManager">PropertyManager</option>
+            <option value="Guest">Guest</option>
+            <option value="Staff">Staff</option>
+            <option value="LongTermLandlord">LongTermLandlord</option>
+          </select>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          <UserManagementTable
+            users={data?.items ?? []}
+            isLoading={isLoading}
+          />
+          {totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
+              <span>
+                Pagina {page} di {totalPages} ({data?.totalCount ?? 0} utenti)
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  Precedente
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Successiva
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/admin/components/admin-jobs-table.tsx
+++ b/src/features/admin/components/admin-jobs-table.tsx
@@ -1,0 +1,69 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { JobStatusBadge } from './job-status-badge';
+import type { JobStatus } from '@/types';
+
+interface AdminJobsTableProps {
+  jobs: JobStatus[];
+  isLoading: boolean;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleString('it-IT', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function AdminJobsTable({ jobs, isLoading }: AdminJobsTableProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-2 pr-4 font-medium">Job</th>
+            <th className="pb-2 pr-4 font-medium">Cron</th>
+            <th className="pb-2 pr-4 font-medium">Ultima esecuzione</th>
+            <th className="pb-2 pr-4 font-medium">Prossima esecuzione</th>
+            <th className="pb-2 font-medium">Stato</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((job) => (
+            <tr key={job.jobName} className="border-b last:border-0">
+              <td className="py-3 pr-4 font-medium">{job.jobName}</td>
+              <td className="py-3 pr-4 font-mono text-xs text-muted-foreground">
+                {job.cronExpression}
+              </td>
+              <td className="py-3 pr-4 text-muted-foreground">{formatDate(job.lastRun)}</td>
+              <td className="py-3 pr-4 text-muted-foreground">{formatDate(job.nextRun)}</td>
+              <td className="py-3">
+                <JobStatusBadge status={job.lastStatus} />
+              </td>
+            </tr>
+          ))}
+          {jobs.length === 0 && (
+            <tr>
+              <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                Nessun job trovato.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/admin/components/admin-kpi-card.tsx
+++ b/src/features/admin/components/admin-kpi-card.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { LucideIcon } from 'lucide-react';
+
+interface AdminKpiCardProps {
+  title: string;
+  value: string | number;
+  description?: string;
+  icon: LucideIcon;
+}
+
+export function AdminKpiCard({ title, value, description, icon: Icon }: AdminKpiCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        {description && (
+          <p className="text-xs text-muted-foreground mt-1">{description}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/admin/components/change-role-dialog.tsx
+++ b/src/features/admin/components/change-role-dialog.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useChangeUserRole } from '@/queries/use-users';
+import type { UserSummary, UserRole } from '@/types';
+
+const ALL_ROLES: UserRole[] = [
+  'Admin',
+  'PropertyOwner',
+  'PropertyManager',
+  'Guest',
+  'Staff',
+  'LongTermLandlord',
+];
+
+interface ChangeRoleDialogProps {
+  user: UserSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ChangeRoleDialog({ user, open, onOpenChange }: ChangeRoleDialogProps) {
+  const [selectedRole, setSelectedRole] = useState<UserRole>(user?.role ?? 'Guest');
+  const { mutate: changeRole, isPending } = useChangeUserRole();
+
+  function handleConfirm() {
+    if (!user) return;
+    changeRole(
+      { id: user.id, role: selectedRole },
+      { onSuccess: () => onOpenChange(false) }
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Cambia ruolo</DialogTitle>
+          <DialogDescription>
+            Seleziona il nuovo ruolo per {user?.firstName} {user?.lastName}.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="role-select">Ruolo</Label>
+          <select
+            id="role-select"
+            className="w-full rounded-md border px-3 py-2 text-sm"
+            value={selectedRole}
+            onChange={(e) => setSelectedRole(e.target.value as UserRole)}
+          >
+            {ALL_ROLES.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Annulla
+          </Button>
+          <Button onClick={handleConfirm} disabled={isPending}>
+            {isPending ? 'Salvataggio...' : 'Salva'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/admin/components/cin-compliance-table.tsx
+++ b/src/features/admin/components/cin-compliance-table.tsx
@@ -1,0 +1,58 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { CinStatusBadge } from './cin-status-badge';
+import type { CinComplianceItem } from '@/types';
+
+interface CinComplianceTableProps {
+  items: CinComplianceItem[];
+  isLoading: boolean;
+}
+
+export function CinComplianceTable({ items, isLoading }: CinComplianceTableProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-2 pr-4 font-medium">Proprietà</th>
+            <th className="pb-2 pr-4 font-medium">Città</th>
+            <th className="pb-2 pr-4 font-medium">Proprietario</th>
+            <th className="pb-2 pr-4 font-medium">CIN</th>
+            <th className="pb-2 font-medium">Stato</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.propertyId} className="border-b last:border-0">
+              <td className="py-3 pr-4 font-medium">{item.propertyName}</td>
+              <td className="py-3 pr-4 text-muted-foreground">{item.city}</td>
+              <td className="py-3 pr-4 text-muted-foreground">{item.ownerEmail}</td>
+              <td className="py-3 pr-4 font-mono text-xs">
+                {item.cinCode ?? <span className="text-muted-foreground">—</span>}
+              </td>
+              <td className="py-3">
+                <CinStatusBadge status={item.cinStatus} />
+              </td>
+            </tr>
+          ))}
+          {items.length === 0 && (
+            <tr>
+              <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                Nessun dato trovato.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/admin/components/cin-status-badge.tsx
+++ b/src/features/admin/components/cin-status-badge.tsx
@@ -1,0 +1,19 @@
+import { Badge } from '@/components/ui/badge';
+
+interface CinStatusBadgeProps {
+  status: 'valid' | 'missing' | 'invalid';
+}
+
+const STATUS_MAP: Record<
+  CinStatusBadgeProps['status'],
+  { label: string; variant: 'default' | 'secondary' | 'destructive' }
+> = {
+  valid: { label: 'Valido', variant: 'default' },
+  missing: { label: 'Mancante', variant: 'secondary' },
+  invalid: { label: 'Non valido', variant: 'destructive' },
+};
+
+export function CinStatusBadge({ status }: CinStatusBadgeProps) {
+  const { label, variant } = STATUS_MAP[status];
+  return <Badge variant={variant}>{label}</Badge>;
+}

--- a/src/features/admin/components/deactivate-user-dialog.tsx
+++ b/src/features/admin/components/deactivate-user-dialog.tsx
@@ -1,0 +1,48 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useDeactivateUser } from '@/queries/use-users';
+import type { UserSummary } from '@/types';
+
+interface DeactivateUserDialogProps {
+  user: UserSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeactivateUserDialog({ user, open, onOpenChange }: DeactivateUserDialogProps) {
+  const { mutate: deactivate, isPending } = useDeactivateUser();
+
+  function handleConfirm() {
+    if (!user) return;
+    deactivate(user.id, { onSuccess: () => onOpenChange(false) });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disattiva utente</DialogTitle>
+          <DialogDescription>
+            Sei sicuro di voler disattivare {user?.firstName} {user?.lastName} ({user?.email})?
+            L&apos;utente non potrà più accedere al sistema.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Annulla
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm} disabled={isPending}>
+            {isPending ? 'Disattivazione...' : 'Disattiva'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/admin/components/job-status-badge.tsx
+++ b/src/features/admin/components/job-status-badge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@/components/ui/badge';
+
+type JobLastStatus = 'Succeeded' | 'Failed' | 'Processing' | 'Enqueued' | 'Unknown';
+
+interface JobStatusBadgeProps {
+  status: JobLastStatus;
+}
+
+const STATUS_MAP: Record<
+  JobLastStatus,
+  { label: string; variant: 'default' | 'secondary' | 'outline' | 'destructive' }
+> = {
+  Succeeded: { label: 'Completato', variant: 'default' },
+  Failed: { label: 'Fallito', variant: 'destructive' },
+  Processing: { label: 'In corso', variant: 'secondary' },
+  Enqueued: { label: 'In coda', variant: 'outline' },
+  Unknown: { label: 'Sconosciuto', variant: 'outline' },
+};
+
+export function JobStatusBadge({ status }: JobStatusBadgeProps) {
+  const { label, variant } = STATUS_MAP[status] ?? STATUS_MAP.Unknown;
+  return <Badge variant={variant}>{label}</Badge>;
+}

--- a/src/features/admin/components/user-management-table.tsx
+++ b/src/features/admin/components/user-management-table.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChangeRoleDialog } from './change-role-dialog';
+import { DeactivateUserDialog } from './deactivate-user-dialog';
+import type { UserSummary } from '@/types';
+
+interface UserManagementTableProps {
+  users: UserSummary[];
+  isLoading: boolean;
+}
+
+export function UserManagementTable({ users, isLoading }: UserManagementTableProps) {
+  const [roleTarget, setRoleTarget] = useState<UserSummary | null>(null);
+  const [deactivateTarget, setDeactivateTarget] = useState<UserSummary | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-muted-foreground">
+              <th className="pb-2 pr-4 font-medium">Nome</th>
+              <th className="pb-2 pr-4 font-medium">Email</th>
+              <th className="pb-2 pr-4 font-medium">Ruolo</th>
+              <th className="pb-2 pr-4 font-medium">Stato</th>
+              <th className="pb-2 font-medium">Azioni</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user) => (
+              <tr key={user.id} className="border-b last:border-0">
+                <td className="py-3 pr-4 font-medium">
+                  {user.firstName} {user.lastName}
+                </td>
+                <td className="py-3 pr-4 text-muted-foreground">{user.email}</td>
+                <td className="py-3 pr-4">
+                  <Badge variant="outline">{user.role}</Badge>
+                </td>
+                <td className="py-3 pr-4">
+                  {user.isActive ? (
+                    <Badge variant="default">Attivo</Badge>
+                  ) : (
+                    <Badge variant="secondary">Inattivo</Badge>
+                  )}
+                </td>
+                <td className="py-3">
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setRoleTarget(user)}
+                    >
+                      Ruolo
+                    </Button>
+                    {user.isActive && (
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setDeactivateTarget(user)}
+                      >
+                        Disattiva
+                      </Button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {users.length === 0 && (
+              <tr>
+                <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                  Nessun utente trovato.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <ChangeRoleDialog
+        user={roleTarget}
+        open={roleTarget !== null}
+        onOpenChange={(open) => { if (!open) setRoleTarget(null); }}
+      />
+      <DeactivateUserDialog
+        user={deactivateTarget}
+        open={deactivateTarget !== null}
+        onOpenChange={(open) => { if (!open) setDeactivateTarget(null); }}
+      />
+    </>
+  );
+}

--- a/src/lib/auth-roles.ts
+++ b/src/lib/auth-roles.ts
@@ -2,6 +2,7 @@ export const ROLES_CLAIM = 'https://casazen.app/roles';
 
 export const ROLE_PROPERTY_OWNER = 'PropertyOwner';
 export const ROLE_LONG_TERM_LANDLORD = 'LongTermLandlord';
+export const ROLE_ADMIN = 'Admin';
 
 export type UserWithRoles = Record<string, unknown> | null | undefined;
 
@@ -34,4 +35,8 @@ export function isLongTermOnly(user: UserWithRoles): boolean {
 
 export function isDualRole(user: UserWithRoles): boolean {
   return hasRole(user, ROLE_PROPERTY_OWNER) && hasRole(user, ROLE_LONG_TERM_LANDLORD);
+}
+
+export function isAdmin(user: UserWithRoles): boolean {
+  return hasRole(user, ROLE_ADMIN);
 }

--- a/src/queries/use-admin.ts
+++ b/src/queries/use-admin.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { AdminApi } from '@/api/admin.api';
+
+const ADMIN_KEY = 'admin';
+
+export function useAdminStats() {
+  return useQuery({
+    queryKey: [ADMIN_KEY, 'stats'],
+    queryFn: () => AdminApi.getStats(),
+  });
+}
+
+export function useCinCompliance() {
+  return useQuery({
+    queryKey: [ADMIN_KEY, 'cin-compliance'],
+    queryFn: () => AdminApi.getCinCompliance(),
+  });
+}
+
+export function useAdminJobs() {
+  return useQuery({
+    queryKey: [ADMIN_KEY, 'jobs'],
+    queryFn: () => AdminApi.getJobs(),
+    refetchInterval: 30_000,
+  });
+}

--- a/src/queries/use-users.ts
+++ b/src/queries/use-users.ts
@@ -1,0 +1,83 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { UsersApi } from '@/api/users.api';
+import type { UpdateProfileRequest } from '@/types';
+import { toast } from 'sonner';
+
+const USERS_KEY = 'users';
+const ME_KEY = 'me';
+
+interface GetUsersParams {
+  page?: number;
+  pageSize?: number;
+  role?: string;
+  isActive?: boolean;
+  search?: string;
+}
+
+export function useUsers(params?: GetUsersParams) {
+  return useQuery({
+    queryKey: [USERS_KEY, params],
+    queryFn: () => UsersApi.getUsers(params ?? {}),
+  });
+}
+
+export function useUser(id: string) {
+  return useQuery({
+    queryKey: [USERS_KEY, id],
+    queryFn: () => UsersApi.getUserById(id),
+    enabled: !!id,
+  });
+}
+
+export function useMe() {
+  return useQuery({
+    queryKey: [ME_KEY],
+    queryFn: () => UsersApi.getMe(),
+  });
+}
+
+export function useUpdateMe() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateProfileRequest) => UsersApi.updateMe(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [ME_KEY] });
+      toast.success('Profilo aggiornato con successo');
+    },
+    onError: () => {
+      toast.error('Impossibile aggiornare il profilo');
+    },
+  });
+}
+
+export function useChangeUserRole() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, role }: { id: string; role: string }) =>
+      UsersApi.changeRole(id, role),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY] });
+      toast.success('Ruolo aggiornato con successo');
+    },
+    onError: () => {
+      toast.error('Impossibile aggiornare il ruolo');
+    },
+  });
+}
+
+export function useDeactivateUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => UsersApi.deactivateUser(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY] });
+      toast.success('Utente disattivato con successo');
+    },
+    onError: () => {
+      toast.error('Impossibile disattivare l\'utente');
+    },
+  });
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,12 @@ import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { ShortStayLayerGuard } from '@/components/auth/short-stay-layer-guard';
 import { LongTermAppShell } from '@/components/layout/long-term-app-shell';
+import { AdminAppShell } from '@/components/layout/admin-app-shell';
 import { AppLayerProvider } from '@/contexts/app-layer-provider';
+import { AdminDashboardPage } from '@/features/admin/admin-dashboard-page';
+import { AdminUsersPage } from '@/features/admin/admin-users-page';
+import { AdminCinPage } from '@/features/admin/admin-cin-page';
+import { AdminJobsPage } from '@/features/admin/admin-jobs-page';
 import { LoginPage } from '@/pages/login-page';
 import { DashboardPage } from '@/features/dashboard/dashboard-page';
 import { PropertiesPage } from '@/features/properties/properties-page';
@@ -143,6 +148,31 @@ export const router = createBrowserRouter([
           {
             path: '/leases/:id',
             element: <LeaseDetailPage />,
+          },
+        ],
+      },
+      {
+        element: (
+          <ProtectedRoute role="Admin">
+            <AdminAppShell />
+          </ProtectedRoute>
+        ),
+        children: [
+          {
+            path: '/admin',
+            element: <AdminDashboardPage />,
+          },
+          {
+            path: '/admin/users',
+            element: <AdminUsersPage />,
+          },
+          {
+            path: '/admin/cin',
+            element: <AdminCinPage />,
+          },
+          {
+            path: '/admin/jobs',
+            element: <AdminJobsPage />,
           },
         ],
       },

--- a/src/types/admin.types.ts
+++ b/src/types/admin.types.ts
@@ -1,0 +1,41 @@
+export interface CinComplianceStats {
+  valid: number;
+  missing: number;
+  invalid: number;
+  total: number;
+}
+
+export interface OtaSyncHealth {
+  synced: number;
+  failed: number;
+  neverSynced: number;
+}
+
+export interface AdminStats {
+  totalProperties: number;
+  activeProperties: number;
+  totalBookings: number;
+  bookingsThisMonth: number;
+  upcomingCheckIns: number;
+  totalRevenue: number;
+  cinCompliance: CinComplianceStats;
+  otaSyncHealth: OtaSyncHealth;
+}
+
+export interface CinComplianceItem {
+  propertyId: string;
+  propertyName: string;
+  ownerId: string;
+  ownerEmail: string;
+  cinCode: string | null;
+  cinStatus: 'valid' | 'missing' | 'invalid';
+  city: string;
+}
+
+export interface JobStatus {
+  jobName: string;
+  cronExpression: string;
+  lastRun: string | null;
+  lastStatus: 'Succeeded' | 'Failed' | 'Processing' | 'Enqueued' | 'Unknown';
+  nextRun: string | null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,3 +10,5 @@ export * from './tourist-tax.types';  // ✅ New
 export * from './calendar.types';  // ✅ New
 export * from './pricing-adapter.types';
 export * from './lease.types';
+export * from './admin.types';
+export * from './users.types';

--- a/src/types/users.types.ts
+++ b/src/types/users.types.ts
@@ -1,0 +1,39 @@
+export type UserRole =
+  | 'Admin'
+  | 'PropertyOwner'
+  | 'PropertyManager'
+  | 'Guest'
+  | 'Staff'
+  | 'LongTermLandlord';
+
+export interface UserSummary {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: UserRole;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export interface UserDetail extends UserSummary {
+  phoneNumber?: string;
+  updatedAt: string;
+}
+
+export interface UpdateProfileRequest {
+  firstName?: string;
+  lastName?: string;
+  phoneNumber?: string;
+}
+
+export interface ChangeRoleRequest {
+  role: UserRole;
+}
+
+export interface PagedResult<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}


### PR DESCRIPTION
## Summary

- Add `UserSummary`, `UserDetail`, `PagedResult<T>`, `AdminStats`, `CinComplianceItem`, `JobStatus` types
- Add `UsersApi` and `AdminApi` API modules
- Add TanStack Query hooks: `useUsers`, `useMe`, `useUpdateMe`, `useChangeUserRole`, `useDeactivateUser`, `useAdminStats`, `useCinCompliance`, `useAdminJobs`
- Add `AdminAppShell` layout + `AdminSidebar` navigation
- Add admin feature pages: Dashboard (KPI cards), Users (paginated table + filters), CIN Compliance, Background Jobs
- Wire `/admin/*` routes under `ProtectedRoute role="Admin"` (redirects to `/` without Admin role)
- Add `isAdmin()` helper to `auth-roles.ts`
- E2E auth-gate tests in `e2e/admin.spec.ts`

## Test plan

- [ ] `tsc -b --noEmit` — 0 errors
- [ ] `npm run build` — builds successfully
- [ ] `npm test -- --run` — 77 passed (12 pre-existing failures in pricing test, unchanged)
- [ ] Navigate to `/admin` without Admin role → redirected to `/`
- [ ] Admin sidebar shows Dashboard, Users, CIN Compliance, Background Jobs
- [ ] `/admin/users` loads paginated user table with role filter
- [ ] ChangeRoleDialog and DeactivateUserDialog open and submit correctly

Closes #11