### PR TITLE
test(admin): fix E2E redirect timing in admin spec

### DIFF
--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,23 +1,19 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Admin panel — auth-gate and shell', () => {
-  test('AC12 /admin redirects to / when user lacks Admin role', async ({ page }) => {
-    // Navigate directly without any authenticated session — should redirect to login
+  test('AC12 /admin redirects away when user lacks Admin role', async ({ page }) => {
     await page.goto('/admin');
-    // Either ends up on /login (unauthenticated) or on / (authenticated but no Admin role)
-    const url = page.url();
-    expect(url).not.toContain('/admin');
+    // Wait for React + Auth0 to resolve and apply the ProtectedRoute redirect
+    await expect(page).not.toHaveURL(/\/admin($|\/)/, { timeout: 8000 });
   });
 
-  test('AC14 /admin/users redirects to / when user lacks Admin role', async ({ page }) => {
+  test('AC14 /admin/users redirects away when user lacks Admin role', async ({ page }) => {
     await page.goto('/admin/users');
-    const url = page.url();
-    expect(url).not.toContain('/admin/users');
+    await expect(page).not.toHaveURL(/\/admin\/users/, { timeout: 8000 });
   });
 
-  test('AC15 /admin/cin redirects when user lacks Admin role', async ({ page }) => {
+  test('AC15 /admin/cin redirects away when user lacks Admin role', async ({ page }) => {
     await page.goto('/admin/cin');
-    const url = page.url();
-    expect(url).not.toContain('/admin/cin');
+    await expect(page).not.toHaveURL(/\/admin\/cin/, { timeout: 8000 });
   });
 });


### PR DESCRIPTION
## Summary

- `page.goto()` resolves when the DOM is ready, but not after React + Auth0 have processed the `ProtectedRoute` redirect. The three admin redirect tests were checking `page.url()` immediately after navigation and failing because the SPA redirect hadn't run yet.
- Replaced manual URL string check with `expect(page).not.toHaveURL(/pattern/)`, which polls until the URL changes or the timeout elapses (8 s).

## Test plan

- `npx playwright test e2e/admin.spec.ts` → 4 passed (1 setup + 3 admin redirect guards)

Closes: stage-05 E2E gate for Issue #11