### PR TITLE
release: v1.1.0 — Admin Panel UI (#11)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   e2e:

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin panel — auth-gate and shell', () => {
+  test('AC12 /admin redirects to / when user lacks Admin role', async ({ page }) => {
+    // Navigate directly without any authenticated session — should redirect to login
+    await page.goto('/admin');
+    // Either ends up on /login (unauthenticated) or on / (authenticated but no Admin role)
+    const url = page.url();
+    expect(url).not.toContain('/admin');
+  });
+
+  test('AC14 /admin/users redirects to / when user lacks Admin role', async ({ page }) => {
+    await page.goto('/admin/users');
+    const url = page.url();
+    expect(url).not.toContain('/admin/users');
+  });
+
+  test('AC15 /admin/cin redirects when user lacks Admin role', async ({ page }) => {
+    await page.goto('/admin/cin');
+    const url = page.url();
+    expect(url).not.toContain('/admin/cin');
+  });
+});

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,23 +1,19 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Admin panel — auth-gate and shell', () => {
-  test('AC12 /admin redirects to / when user lacks Admin role', async ({ page }) => {
-    // Navigate directly without any authenticated session — should redirect to login
+  test('AC12 /admin redirects away when user lacks Admin role', async ({ page }) => {
     await page.goto('/admin');
-    // Either ends up on /login (unauthenticated) or on / (authenticated but no Admin role)
-    const url = page.url();
-    expect(url).not.toContain('/admin');
+    // Wait for React + Auth0 to resolve and apply the ProtectedRoute redirect
+    await expect(page).not.toHaveURL(/\/admin($|\/)/, { timeout: 8000 });
   });
 
-  test('AC14 /admin/users redirects to / when user lacks Admin role', async ({ page }) => {
+  test('AC14 /admin/users redirects away when user lacks Admin role', async ({ page }) => {
     await page.goto('/admin/users');
-    const url = page.url();
-    expect(url).not.toContain('/admin/users');
+    await expect(page).not.toHaveURL(/\/admin\/users/, { timeout: 8000 });
   });
 
-  test('AC15 /admin/cin redirects when user lacks Admin role', async ({ page }) => {
+  test('AC15 /admin/cin redirects away when user lacks Admin role', async ({ page }) => {
     await page.goto('/admin/cin');
-    const url = page.url();
-    expect(url).not.toContain('/admin/cin');
+    await expect(page).not.toHaveURL(/\/admin\/cin/, { timeout: 8000 });
   });
 });

--- a/e2e/fixtures/leases.fixtures.ts
+++ b/e2e/fixtures/leases.fixtures.ts
@@ -1,0 +1,1 @@
+export const emptyLeasesList: [] = [];

--- a/e2e/helpers/demo-profile.ts
+++ b/e2e/helpers/demo-profile.ts
@@ -1,0 +1,14 @@
+import type { Page } from '@playwright/test';
+
+export type DemoProfile = 'short-stay' | 'long-term' | 'dual';
+
+export function demoUrl(path: string, profile: DemoProfile): string {
+  const separator = path.includes('?') ? '&' : '?';
+  return `${path}${separator}demoProfile=${profile}`;
+}
+
+export async function setDemoProfile(page: Page, profile: DemoProfile): Promise<void> {
+  await page.addInitScript((value) => {
+    (window as Window & { __E2E_DEMO_PROFILE?: string }).__E2E_DEMO_PROFILE = value;
+  }, profile);
+}

--- a/e2e/helpers/lease-api-mock.ts
+++ b/e2e/helpers/lease-api-mock.ts
@@ -1,0 +1,16 @@
+import type { Page } from '@playwright/test';
+import { emptyLeasesList } from '../fixtures/leases.fixtures';
+
+export async function mockLeasesApiEmpty(page: Page): Promise<void> {
+  await page.route(/\/api\/leases(\?.*)?$/, (route) => {
+    if (route.request().method() !== 'GET') {
+      route.fallback();
+      return;
+    }
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(emptyLeasesList),
+    });
+  });
+}

--- a/e2e/long-term-layer.spec.ts
+++ b/e2e/long-term-layer.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { demoUrl } from './helpers/demo-profile';
+import { mockLeasesApiEmpty } from './helpers/lease-api-mock';
+
+test.describe('Long-term UI layer (#182 acceptance criteria)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  });
+
+  test('AC1 PropertyOwner-only sees short-stay shell without long-term nav', async ({ page }) => {
+    await page.goto(demoUrl('/', 'short-stay'));
+
+    await expect(page.getByText(/property manager/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Bookings' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Leases' })).toHaveCount(0);
+    await expect(page.getByText(/long-term rental/i)).toHaveCount(0);
+  });
+
+  test('AC2 LongTermLandlord-only sees long-term shell and lease home', async ({ page }) => {
+    await page.goto(demoUrl('/', 'long-term'), { waitUntil: 'networkidle' });
+
+    await expect(page).toHaveURL(/\/leases(?:\?.*)?$/, { timeout: 15_000 });
+    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Leases' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Bookings' })).toHaveCount(0);
+  });
+
+  test('AC3 dual-role user can switch layers with persistent switcher', async ({ page }) => {
+    await mockLeasesApiEmpty(page);
+    await page.goto(demoUrl('/', 'dual'), { waitUntil: 'networkidle' });
+
+    const switcher = page.getByRole('tablist', { name: 'Application layer' });
+    await expect(switcher).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Long-term' }).click();
+    await expect(page).toHaveURL(/\/leases/, { timeout: 15_000 });
+    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Short-stay' }).click();
+    await expect(page).toHaveURL(/\/(?:\?.*)?$/, { timeout: 15_000 });
+    await expect(page.getByText(/property manager/i)).toBeVisible();
+  });
+
+  test('AC4 long-term layer renders leases list route', async ({ page }) => {
+    await mockLeasesApiEmpty(page);
+    await page.goto(demoUrl('/leases', 'long-term'), { waitUntil: 'networkidle' });
+
+    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+    await expect(page.getByRole('heading', { name: /long-term leases/i })).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('AC5 PropertyOwner-only is redirected away from /leases', async ({ page }) => {
+    await page.goto(demoUrl('/leases', 'short-stay'), { waitUntil: 'networkidle' });
+
+    await expect(page).not.toHaveURL(/\/leases/, { timeout: 15_000 });
+    await expect(page.getByText(/property manager/i)).toBeVisible();
+  });
+
+  test('AC6 dual-role deep link to /leases stays in long-term shell', async ({ page }) => {
+    await mockLeasesApiEmpty(page);
+    await page.goto(demoUrl('/leases', 'dual'), { waitUntil: 'networkidle' });
+
+    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Leases' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Long-term' })).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/e2e/pricing-ai-flow.spec.ts
+++ b/e2e/pricing-ai-flow.spec.ts
@@ -5,6 +5,7 @@ import {
   mockConfigDisabled,
   mockHistoryAfterSync,
 } from './helpers/api-mock';
+import { demoUrl } from './helpers/demo-profile';
 
 const PRICING_URL = `/properties/${PROPERTY_ID}/pricing`;
 const HISTORY_URL = `/properties/${PROPERTY_ID}/pricing/history`;
@@ -22,7 +23,7 @@ test('enable AI pricing, trigger manual sync, and verify new history entry appea
     }
   });
 
-  await page.goto(PRICING_URL);
+  await page.goto(demoUrl(PRICING_URL, 'short-stay'));
 
   // The AI pricing config card should be visible
   await expect(page.getByRole('heading', { name: 'AI Dynamic Pricing', level: 3 })).toBeVisible();
@@ -47,7 +48,7 @@ test('enable AI pricing, trigger manual sync, and verify new history entry appea
   await expect.poll(() => syncCalled).toBe(true);
 
   // Navigate to the history page to confirm the new entry is listed
-  await page.goto(HISTORY_URL);
+  await page.goto(demoUrl(HISTORY_URL, 'short-stay'));
 
   const newEntryReason = historyAfterSync.items[0].changeReason; // 'Manual sync triggered'
   await expect(page.getByText(newEntryReason)).toBeVisible();
@@ -82,7 +83,7 @@ test('disable AI pricing and verify the UI reflects the disabled state', async (
     }
   });
 
-  await page.goto(PRICING_URL);
+  await page.goto(demoUrl(PRICING_URL, 'short-stay'));
 
   // Pricing should start as enabled
   const toggle = page.getByRole('switch', { name: /enable ai pricing/i });
@@ -112,7 +113,7 @@ test('disable AI pricing and verify the UI reflects the disabled state', async (
 test('audit trail page paginates correctly across multiple pages', async ({ page }) => {
   await mockPricingApiDefaults(page);
 
-  await page.goto(HISTORY_URL);
+  await page.goto(demoUrl(HISTORY_URL, 'short-stay'));
 
   // Page header
   await expect(page.getByRole('heading', { name: 'Pricing Audit Trail' })).toBeVisible();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
+    viewport: { width: 1280, height: 720 },
   },
 
   projects: [
@@ -31,7 +32,8 @@ export default defineConfig({
   webServer: {
     command: 'npm run dev:demo',
     url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
+    // Always start dev:demo so VITE_DEMO_MODE is set (avoid reusing a non-demo dev server on :5173)
+    reuseExistingServer: false,
     env: {
       VITE_DEMO_MODE: 'true',
     },

--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -1,0 +1,13 @@
+import { ApiClient } from '@/api/client';
+import type { AdminStats, CinComplianceItem, JobStatus } from '@/types';
+
+export const AdminApi = {
+  getStats: (): Promise<AdminStats> =>
+    ApiClient.get<AdminStats>('/admin/stats'),
+
+  getCinCompliance: (): Promise<CinComplianceItem[]> =>
+    ApiClient.get<CinComplianceItem[]>('/admin/cin-compliance'),
+
+  getJobs: (): Promise<JobStatus[]> =>
+    ApiClient.get<JobStatus[]>('/admin/jobs'),
+};

--- a/src/api/users.api.ts
+++ b/src/api/users.api.ts
@@ -1,0 +1,45 @@
+import { ApiClient } from '@/api/client';
+import type { UserDetail, UserSummary, UpdateProfileRequest, ChangeRoleRequest, PagedResult } from '@/types';
+
+interface GetUsersParams {
+  page?: number;
+  pageSize?: number;
+  role?: string;
+  isActive?: boolean;
+  search?: string;
+}
+
+// Backend returns our PagedResultDto<T> directly (not wrapped in the standard PaginatedResponse shape)
+interface BackendPagedResult<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export const UsersApi = {
+  getUsers: (params: GetUsersParams): Promise<PagedResult<UserSummary>> =>
+    ApiClient.get<BackendPagedResult<UserSummary>>('/users', params as Record<string, unknown>).then(
+      (res) => ({
+        items: res.items ?? [],
+        totalCount: res.totalCount ?? 0,
+        page: res.page ?? 1,
+        pageSize: res.pageSize ?? 20,
+      })
+    ),
+
+  getUserById: (id: string): Promise<UserDetail> =>
+    ApiClient.get<UserDetail>(`/users/${id}`),
+
+  getMe: (): Promise<UserDetail> =>
+    ApiClient.get<UserDetail>('/users/me'),
+
+  updateMe: (body: UpdateProfileRequest): Promise<UserDetail> =>
+    ApiClient.put<UserDetail>('/users/me', body),
+
+  changeRole: (id: string, role: string): Promise<{ id: string; role: string }> =>
+    ApiClient.put<{ id: string; role: string }>(`/users/${id}/role`, { role } as ChangeRoleRequest),
+
+  deactivateUser: (id: string): Promise<void> =>
+    ApiClient.delete<void>(`/users/${id}`),
+};

--- a/src/components/auth/__tests__/short-stay-layer-guard.test.tsx
+++ b/src/components/auth/__tests__/short-stay-layer-guard.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ShortStayLayerGuard } from '../short-stay-layer-guard';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-app-layer-context', () => ({
+  useAppLayerContext: vi.fn(),
+}));
+
+import { useAuth } from '@/hooks/use-auth';
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+
+function renderGuard(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route element={<ShortStayLayerGuard />}>
+          <Route path="/" element={<div>Short-stay content</div>} />
+          <Route path="/bookings" element={<div>Bookings</div>} />
+        </Route>
+        <Route path="/leases" element={<div>Leases</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ShortStayLayerGuard', () => {
+  it('redirects long-term-only users to /leases', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { roles: ['LongTermLandlord'] },
+    } as ReturnType<typeof useAuth>);
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'long-term',
+      effectiveLayer: 'long-term',
+      canSwitchLayer: false,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/leases',
+    });
+
+    renderGuard('/');
+    expect(screen.getByText('Leases')).toBeInTheDocument();
+  });
+
+  it('redirects dual-role users in long-term layer to /leases', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { roles: ['PropertyOwner', 'LongTermLandlord'] },
+    } as ReturnType<typeof useAuth>);
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'long-term',
+      effectiveLayer: 'long-term',
+      canSwitchLayer: true,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/leases',
+    });
+
+    renderGuard('/bookings');
+    expect(screen.getByText('Leases')).toBeInTheDocument();
+  });
+
+  it('allows dual-role users in short-stay layer', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { roles: ['PropertyOwner', 'LongTermLandlord'] },
+    } as ReturnType<typeof useAuth>);
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: true,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/',
+    });
+
+    renderGuard('/');
+    expect(screen.getByText('Short-stay content')).toBeInTheDocument();
+  });
+
+  it('allows property-owner-only users', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { roles: ['PropertyOwner'] },
+    } as ReturnType<typeof useAuth>);
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: false,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/',
+    });
+
+    renderGuard('/');
+    expect(screen.getByText('Short-stay content')).toBeInTheDocument();
+  });
+});

--- a/src/components/auth/short-stay-layer-guard.tsx
+++ b/src/components/auth/short-stay-layer-guard.tsx
@@ -1,0 +1,19 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '@/hooks/use-auth';
+import { isDualRole, isLongTermOnly } from '@/lib/auth-roles';
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+
+export function ShortStayLayerGuard() {
+  const { user } = useAuth();
+  const { activeLayer } = useAppLayerContext();
+
+  if (isLongTermOnly(user)) {
+    return <Navigate to="/leases" replace />;
+  }
+
+  if (isDualRole(user) && activeLayer === 'long-term') {
+    return <Navigate to="/leases" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/components/layout/__tests__/layer-switcher.test.tsx
+++ b/src/components/layout/__tests__/layer-switcher.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LayerSwitcher } from '../layer-switcher';
+
+vi.mock('@/hooks/use-app-layer-context', () => ({
+  useAppLayerContext: vi.fn(),
+}));
+
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+
+describe('LayerSwitcher', () => {
+  it('renders nothing when layer switching is disabled', () => {
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: false,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/',
+    });
+
+    const { container } = render(<LayerSwitcher />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders segmented control for dual-role users', () => {
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: true,
+      setLayer: vi.fn(),
+      getDefaultHomePath: () => '/',
+    });
+
+    render(<LayerSwitcher />);
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Short-stay' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Long-term' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('calls setLayer when a segment is clicked', () => {
+    const setLayer = vi.fn();
+    vi.mocked(useAppLayerContext).mockReturnValue({
+      activeLayer: 'short-stay',
+      effectiveLayer: 'short-stay',
+      canSwitchLayer: true,
+      setLayer,
+      getDefaultHomePath: () => '/',
+    });
+
+    render(<LayerSwitcher />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Long-term' }));
+    expect(setLayer).toHaveBeenCalledWith('long-term');
+  });
+});

--- a/src/components/layout/admin-app-shell.tsx
+++ b/src/components/layout/admin-app-shell.tsx
@@ -1,0 +1,21 @@
+import { Outlet } from 'react-router-dom';
+import { AdminSidebar } from './admin-sidebar';
+import { Header } from './header';
+
+interface AdminAppShellProps {
+  children?: React.ReactNode;
+}
+
+export function AdminAppShell({ children }: AdminAppShellProps) {
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <AdminSidebar />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <Header />
+        <main className="flex-1 overflow-y-auto p-4 md:p-6">
+          {children ?? <Outlet />}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -1,0 +1,57 @@
+import { NavLink } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+import { BarChart3, Building2, FileCheck, Home, Settings } from 'lucide-react';
+
+const navItems = [
+  { to: '/admin', icon: BarChart3, label: 'Dashboard', end: true },
+  { to: '/admin/users', icon: Building2, label: 'Users' },
+  { to: '/admin/cin', icon: FileCheck, label: 'CIN Compliance' },
+  { to: '/admin/jobs', icon: Settings, label: 'Background Jobs' },
+];
+
+export function AdminSidebar() {
+  return (
+    <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
+      <div className="flex h-16 items-center border-b px-6">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-destructive text-destructive-foreground shadow-sm">
+            <Home className="h-4 w-4" />
+          </div>
+          <div className="flex flex-col leading-none">
+            <span className="text-base font-bold tracking-tight">CASAZEN</span>
+            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">
+              Admin Panel
+            </span>
+          </div>
+        </div>
+      </div>
+      <nav className="flex-1 space-y-0.5 p-3">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.end}
+            className={({ isActive }) =>
+              cn(
+                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                isActive
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+              )
+            }
+          >
+            <>
+              <item.icon className="h-4 w-4 shrink-0" />
+              {item.label}
+            </>
+          </NavLink>
+        ))}
+      </nav>
+      <div className="border-t p-3">
+        <p className="text-[10px] text-muted-foreground text-center tracking-wide">
+          v1.0.0 · Admin
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,7 +3,11 @@ import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useUiStore } from '@/store/ui-store';
 
-export function Header() {
+interface HeaderProps {
+  slotStart?: React.ReactNode;
+}
+
+export function Header({ slotStart }: HeaderProps) {
   const toggleSidebar = useUiStore((state) => state.toggleSidebar);
 
   return (
@@ -16,6 +20,7 @@ export function Header() {
       >
         <Menu className="h-5 w-5" />
       </Button>
+      {slotStart}
       <div className="flex-1" />
       <UserMenu />
     </header>

--- a/src/components/layout/layer-switcher.tsx
+++ b/src/components/layout/layer-switcher.tsx
@@ -1,0 +1,74 @@
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+import type { AppLayer } from '@/hooks/use-app-layer';
+import { cn } from '@/lib/utils';
+import { useCallback, useRef } from 'react';
+
+const LAYERS: { value: AppLayer; label: string }[] = [
+  { value: 'short-stay', label: 'Short-stay' },
+  { value: 'long-term', label: 'Long-term' },
+];
+
+export function LayerSwitcher() {
+  const { activeLayer, setLayer, canSwitchLayer } = useAppLayerContext();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const currentIndex = LAYERS.findIndex((layer) => layer.value === activeLayer);
+      if (currentIndex === -1) return;
+
+      let nextIndex = currentIndex;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        nextIndex = (currentIndex + 1) % LAYERS.length;
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        nextIndex = (currentIndex - 1 + LAYERS.length) % LAYERS.length;
+      } else {
+        return;
+      }
+
+      event.preventDefault();
+      const nextLayer = LAYERS[nextIndex].value;
+      setLayer(nextLayer);
+      tabRefs.current[nextIndex]?.focus();
+    },
+    [activeLayer, setLayer]
+  );
+
+  if (!canSwitchLayer) {
+    return null;
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Application layer"
+      className="ml-2 flex rounded-lg border bg-muted p-0.5"
+      onKeyDown={handleKeyDown}
+    >
+      {LAYERS.map((layer, index) => {
+        const isSelected = activeLayer === layer.value;
+        return (
+          <button
+            key={layer.value}
+            ref={(element) => {
+              tabRefs.current[index] = element;
+            }}
+            type="button"
+            role="tab"
+            aria-selected={isSelected}
+            tabIndex={isSelected ? 0 : -1}
+            className={cn(
+              'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+              isSelected
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+            onClick={() => setLayer(layer.value)}
+          >
+            {layer.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/layout/long-term-app-shell.tsx
+++ b/src/components/layout/long-term-app-shell.tsx
@@ -1,24 +1,25 @@
-import { Sidebar } from './sidebar';
+import { Outlet } from 'react-router-dom';
+import { LongTermSidebar } from './long-term-sidebar';
 import { Header } from './header';
 import { LayerSwitcher } from './layer-switcher';
 import { DemoBanner } from '@/components/shared/demo-banner';
 import { useAppLayerContext } from '@/hooks/use-app-layer-context';
 
-interface AppShellProps {
-  children: React.ReactNode;
+interface LongTermAppShellProps {
+  children?: React.ReactNode;
 }
 
-export function AppShell({ children }: AppShellProps) {
+export function LongTermAppShell({ children }: LongTermAppShellProps) {
   const { canSwitchLayer } = useAppLayerContext();
 
   return (
     <div className="flex h-screen overflow-hidden">
-      <Sidebar />
+      <LongTermSidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <DemoBanner />
         <Header slotStart={canSwitchLayer ? <LayerSwitcher /> : undefined} />
         <main className="flex-1 overflow-y-auto p-4 md:p-6">
-          {children}
+          {children ?? <Outlet />}
         </main>
       </div>
     </div>

--- a/src/components/layout/long-term-sidebar.tsx
+++ b/src/components/layout/long-term-sidebar.tsx
@@ -1,26 +1,13 @@
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import {
-  LayoutDashboard,
-  Home,
-  Calendar,
-  CreditCard,
-  Repeat,
-  Search,
-  User,
-} from 'lucide-react';
+import { FileText, Home, User } from 'lucide-react';
 
 const navItems = [
-  { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
-  { to: '/properties', icon: Home, label: 'Properties' },
-  { to: '/bookings', icon: Calendar, label: 'Bookings' },
-  { to: '/payments', icon: CreditCard, label: 'Payments' },
-  { to: '/ota', icon: Repeat, label: 'OTA Sync' },
-  { to: '/search', icon: Search, label: 'Search' },
+  { to: '/leases', icon: FileText, label: 'Leases' },
   { to: '/profile', icon: User, label: 'Profile' },
 ];
 
-export function Sidebar() {
+export function LongTermSidebar() {
   return (
     <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
       <div className="flex h-16 items-center border-b px-6">
@@ -30,7 +17,9 @@ export function Sidebar() {
           </div>
           <div className="flex flex-col leading-none">
             <span className="text-base font-bold tracking-tight">CASAZEN</span>
-            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">Property Manager</span>
+            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">
+              Long-Term Rental
+            </span>
           </div>
         </div>
       </div>
@@ -39,7 +28,7 @@ export function Sidebar() {
           <NavLink
             key={item.to}
             to={item.to}
-            end={item.to === '/'}
+            end={item.to === '/leases'}
             className={({ isActive }) =>
               cn(
                 'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',

--- a/src/config/demo.config.ts
+++ b/src/config/demo.config.ts
@@ -1,16 +1,84 @@
 /**
  * Demo mode configuration
- * When VITE_DEMO_MODE is true, the app runs without authentication
+ * When VITE_DEMO_MODE is true, the app runs without authentication.
+ *
+ * VITE_DEMO_PROFILE selects the persona for E2E and local testing:
+ * - short-stay: PropertyOwner only
+ * - long-term: LongTermLandlord only (default)
+ * - dual: both roles (layer switcher)
  */
-
 export const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true';
 
-export const demoUser = {
-  name: 'Demo User',
-  email: 'demo@casazen.com',
-  picture: 'https://ui-avatars.com/api/?name=Demo+User&background=0D8ABC&color=fff',
-  roles: ['LongTermLandlord'],
-  'https://casazen.app/roles': ['LongTermLandlord'],
+export type DemoProfile = 'short-stay' | 'long-term' | 'dual';
+
+const ROLES_CLAIM = 'https://casazen.app/roles';
+
+const demoProfiles: Record<DemoProfile, { roles: string[] }> = {
+  'short-stay': {
+    roles: ['PropertyOwner'],
+  },
+  'long-term': {
+    roles: ['LongTermLandlord'],
+  },
+  dual: {
+    roles: ['PropertyOwner', 'LongTermLandlord'],
+  },
 };
 
+function resolveDemoProfile(): DemoProfile {
+  const raw = import.meta.env.VITE_DEMO_PROFILE as string | undefined;
+  if (raw === 'short-stay' || raw === 'long-term' || raw === 'dual') {
+    return raw;
+  }
+  return 'long-term';
+}
+
+function buildDemoUser(profile: DemoProfile) {
+  const roles = demoProfiles[profile].roles;
+  return {
+    name: 'Demo User',
+    email: 'demo@casazen.com',
+    picture: 'https://ui-avatars.com/api/?name=Demo+User&background=0D8ABC&color=fff',
+    roles,
+    [ROLES_CLAIM]: roles,
+  };
+}
+
+const DEMO_PROFILE_STORAGE_KEY = 'casazen:demo-profile';
+
+function resolveRuntimeDemoProfile(): DemoProfile | null {
+  if (typeof window === 'undefined') return null;
+
+  const params = new URLSearchParams(window.location.search);
+  const fromQuery = params.get('demoProfile');
+  if (fromQuery === 'short-stay' || fromQuery === 'long-term' || fromQuery === 'dual') {
+    sessionStorage.setItem(DEMO_PROFILE_STORAGE_KEY, fromQuery);
+    return fromQuery;
+  }
+
+  const stored = sessionStorage.getItem(DEMO_PROFILE_STORAGE_KEY);
+  if (stored === 'short-stay' || stored === 'long-term' || stored === 'dual') {
+    return stored;
+  }
+
+  const runtime = (window as Window & { __E2E_DEMO_PROFILE?: DemoProfile }).__E2E_DEMO_PROFILE;
+  if (runtime && runtime in demoProfiles) {
+    return runtime;
+  }
+
+  return null;
+}
+
+/** Demo persona: `?demoProfile=` query (E2E), `window.__E2E_DEMO_PROFILE`, or `VITE_DEMO_PROFILE`. */
+export function getDemoUser() {
+  const runtime = resolveRuntimeDemoProfile();
+  return buildDemoUser(runtime ?? resolveDemoProfile());
+}
+
+export const demoUser = buildDemoUser(resolveDemoProfile());
+
 console.log('🎭 Demo mode:', isDemoMode ? 'ENABLED' : 'DISABLED');
+if (isDemoMode) {
+  const profile = resolveDemoProfile();
+  console.log('🎭 Demo profile:', profile, demoProfiles[profile].roles);
+}

--- a/src/contexts/app-layer-context.ts
+++ b/src/contexts/app-layer-context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { UseAppLayerReturn } from '@/hooks/use-app-layer';
+
+export const AppLayerContext = createContext<UseAppLayerReturn | null>(null);

--- a/src/contexts/app-layer-provider.tsx
+++ b/src/contexts/app-layer-provider.tsx
@@ -1,0 +1,9 @@
+import { useAppLayer } from '@/hooks/use-app-layer';
+import { AppLayerContext } from '@/contexts/app-layer-context';
+
+export function AppLayerProvider({ children }: { children: React.ReactNode }) {
+  const layerState = useAppLayer();
+  return (
+    <AppLayerContext.Provider value={layerState}>{children}</AppLayerContext.Provider>
+  );
+}

--- a/src/features/admin/admin-cin-page.tsx
+++ b/src/features/admin/admin-cin-page.tsx
@@ -1,0 +1,22 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent } from '@/components/ui/card';
+import { CinComplianceTable } from './components/cin-compliance-table';
+import { useCinCompliance } from '@/queries/use-admin';
+
+export function AdminCinPage() {
+  const { data, isLoading } = useCinCompliance();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Conformità CIN"
+        description="Verifica dei codici identificativi nazionali (D.L. 145/2023)"
+      />
+      <Card>
+        <CardContent className="pt-6">
+          <CinComplianceTable items={data ?? []} isLoading={isLoading} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/admin/admin-dashboard-page.tsx
+++ b/src/features/admin/admin-dashboard-page.tsx
@@ -1,0 +1,116 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { AdminKpiCard } from './components/admin-kpi-card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useAdminStats } from '@/queries/use-admin';
+import { Building2, Calendar, DollarSign, FileCheck, Wifi } from 'lucide-react';
+
+export function AdminDashboardPage() {
+  const { data: stats, isLoading } = useAdminStats();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Dashboard Amministratore"
+        description="Panoramica del sistema CasaZen"
+      />
+
+      {isLoading ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-32" />
+          ))}
+        </div>
+      ) : stats ? (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <AdminKpiCard
+              title="Proprietà totali"
+              value={stats.totalProperties}
+              icon={Building2}
+            />
+            <AdminKpiCard
+              title="Proprietà attive"
+              value={stats.activeProperties}
+              icon={Building2}
+            />
+            <AdminKpiCard
+              title="Prenotazioni totali"
+              value={stats.totalBookings}
+              icon={Calendar}
+            />
+            <AdminKpiCard
+              title="Prenotazioni del mese"
+              value={stats.bookingsThisMonth}
+              icon={Calendar}
+            />
+            <AdminKpiCard
+              title="Check-in imminenti"
+              value={stats.upcomingCheckIns}
+              icon={Calendar}
+            />
+            <AdminKpiCard
+              title="Ricavi totali"
+              value={`€ ${stats.totalRevenue.toLocaleString('it-IT', { minimumFractionDigits: 2 })}`}
+              icon={DollarSign}
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <FileCheck className="h-4 w-4" />
+                  Conformità CIN
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Totale</span>
+                  <span className="font-medium">{stats.cinCompliance.total}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-green-600">Validi</span>
+                  <span className="font-medium">{stats.cinCompliance.valid}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-yellow-600">Mancanti</span>
+                  <span className="font-medium">{stats.cinCompliance.missing}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-red-600">Non validi</span>
+                  <span className="font-medium">{stats.cinCompliance.invalid}</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Wifi className="h-4 w-4" />
+                  Salute OTA Sync
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-green-600">Sincronizzati</span>
+                  <span className="font-medium">{stats.otaSyncHealth.synced}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-red-600">Falliti</span>
+                  <span className="font-medium">{stats.otaSyncHealth.failed}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Mai sincronizzati</span>
+                  <span className="font-medium">{stats.otaSyncHealth.neverSynced}</span>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </>
+      ) : (
+        <p className="text-muted-foreground">Impossibile caricare le statistiche.</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/admin/admin-jobs-page.tsx
+++ b/src/features/admin/admin-jobs-page.tsx
@@ -1,0 +1,22 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent } from '@/components/ui/card';
+import { AdminJobsTable } from './components/admin-jobs-table';
+import { useAdminJobs } from '@/queries/use-admin';
+
+export function AdminJobsPage() {
+  const { data, isLoading } = useAdminJobs();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Background Jobs"
+        description="Stato dei job Hangfire (aggiornato ogni 30 secondi)"
+      />
+      <Card>
+        <CardContent className="pt-6">
+          <AdminJobsTable jobs={data ?? []} isLoading={isLoading} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/admin/admin-users-page.tsx
+++ b/src/features/admin/admin-users-page.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { UserManagementTable } from './components/user-management-table';
+import { useUsers } from '@/queries/use-users';
+
+const PAGE_SIZE = 20;
+
+export function AdminUsersPage() {
+  const [search, setSearch] = useState('');
+  const [role, setRole] = useState('');
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useUsers({
+    search: search || undefined,
+    role: role || undefined,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const totalPages = data ? Math.ceil(data.totalCount / PAGE_SIZE) : 1;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Gestione Utenti"
+        description="Visualizza e gestisci tutti gli utenti del sistema"
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Filtri</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3">
+          <Input
+            placeholder="Cerca per nome o email..."
+            value={search}
+            onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+            className="max-w-xs"
+          />
+          <select
+            className="rounded-md border px-3 py-2 text-sm"
+            value={role}
+            onChange={(e) => { setRole(e.target.value); setPage(1); }}
+          >
+            <option value="">Tutti i ruoli</option>
+            <option value="Admin">Admin</option>
+            <option value="PropertyOwner">PropertyOwner</option>
+            <option value="PropertyManager">PropertyManager</option>
+            <option value="Guest">Guest</option>
+            <option value="Staff">Staff</option>
+            <option value="LongTermLandlord">LongTermLandlord</option>
+          </select>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          <UserManagementTable
+            users={data?.items ?? []}
+            isLoading={isLoading}
+          />
+          {totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
+              <span>
+                Pagina {page} di {totalPages} ({data?.totalCount ?? 0} utenti)
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  Precedente
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Successiva
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/admin/components/admin-jobs-table.tsx
+++ b/src/features/admin/components/admin-jobs-table.tsx
@@ -1,0 +1,69 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { JobStatusBadge } from './job-status-badge';
+import type { JobStatus } from '@/types';
+
+interface AdminJobsTableProps {
+  jobs: JobStatus[];
+  isLoading: boolean;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleString('it-IT', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function AdminJobsTable({ jobs, isLoading }: AdminJobsTableProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-2 pr-4 font-medium">Job</th>
+            <th className="pb-2 pr-4 font-medium">Cron</th>
+            <th className="pb-2 pr-4 font-medium">Ultima esecuzione</th>
+            <th className="pb-2 pr-4 font-medium">Prossima esecuzione</th>
+            <th className="pb-2 font-medium">Stato</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((job) => (
+            <tr key={job.jobName} className="border-b last:border-0">
+              <td className="py-3 pr-4 font-medium">{job.jobName}</td>
+              <td className="py-3 pr-4 font-mono text-xs text-muted-foreground">
+                {job.cronExpression}
+              </td>
+              <td className="py-3 pr-4 text-muted-foreground">{formatDate(job.lastRun)}</td>
+              <td className="py-3 pr-4 text-muted-foreground">{formatDate(job.nextRun)}</td>
+              <td className="py-3">
+                <JobStatusBadge status={job.lastStatus} />
+              </td>
+            </tr>
+          ))}
+          {jobs.length === 0 && (
+            <tr>
+              <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                Nessun job trovato.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/admin/components/admin-kpi-card.tsx
+++ b/src/features/admin/components/admin-kpi-card.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { LucideIcon } from 'lucide-react';
+
+interface AdminKpiCardProps {
+  title: string;
+  value: string | number;
+  description?: string;
+  icon: LucideIcon;
+}
+
+export function AdminKpiCard({ title, value, description, icon: Icon }: AdminKpiCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        {description && (
+          <p className="text-xs text-muted-foreground mt-1">{description}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/admin/components/change-role-dialog.tsx
+++ b/src/features/admin/components/change-role-dialog.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useChangeUserRole } from '@/queries/use-users';
+import type { UserSummary, UserRole } from '@/types';
+
+const ALL_ROLES: UserRole[] = [
+  'Admin',
+  'PropertyOwner',
+  'PropertyManager',
+  'Guest',
+  'Staff',
+  'LongTermLandlord',
+];
+
+interface ChangeRoleDialogProps {
+  user: UserSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ChangeRoleDialog({ user, open, onOpenChange }: ChangeRoleDialogProps) {
+  const [selectedRole, setSelectedRole] = useState<UserRole>(user?.role ?? 'Guest');
+  const { mutate: changeRole, isPending } = useChangeUserRole();
+
+  function handleConfirm() {
+    if (!user) return;
+    changeRole(
+      { id: user.id, role: selectedRole },
+      { onSuccess: () => onOpenChange(false) }
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Cambia ruolo</DialogTitle>
+          <DialogDescription>
+            Seleziona il nuovo ruolo per {user?.firstName} {user?.lastName}.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="role-select">Ruolo</Label>
+          <select
+            id="role-select"
+            className="w-full rounded-md border px-3 py-2 text-sm"
+            value={selectedRole}
+            onChange={(e) => setSelectedRole(e.target.value as UserRole)}
+          >
+            {ALL_ROLES.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Annulla
+          </Button>
+          <Button onClick={handleConfirm} disabled={isPending}>
+            {isPending ? 'Salvataggio...' : 'Salva'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/admin/components/cin-compliance-table.tsx
+++ b/src/features/admin/components/cin-compliance-table.tsx
@@ -1,0 +1,58 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { CinStatusBadge } from './cin-status-badge';
+import type { CinComplianceItem } from '@/types';
+
+interface CinComplianceTableProps {
+  items: CinComplianceItem[];
+  isLoading: boolean;
+}
+
+export function CinComplianceTable({ items, isLoading }: CinComplianceTableProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-2 pr-4 font-medium">Proprietà</th>
+            <th className="pb-2 pr-4 font-medium">Città</th>
+            <th className="pb-2 pr-4 font-medium">Proprietario</th>
+            <th className="pb-2 pr-4 font-medium">CIN</th>
+            <th className="pb-2 font-medium">Stato</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.propertyId} className="border-b last:border-0">
+              <td className="py-3 pr-4 font-medium">{item.propertyName}</td>
+              <td className="py-3 pr-4 text-muted-foreground">{item.city}</td>
+              <td className="py-3 pr-4 text-muted-foreground">{item.ownerEmail}</td>
+              <td className="py-3 pr-4 font-mono text-xs">
+                {item.cinCode ?? <span className="text-muted-foreground">—</span>}
+              </td>
+              <td className="py-3">
+                <CinStatusBadge status={item.cinStatus} />
+              </td>
+            </tr>
+          ))}
+          {items.length === 0 && (
+            <tr>
+              <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                Nessun dato trovato.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/admin/components/cin-status-badge.tsx
+++ b/src/features/admin/components/cin-status-badge.tsx
@@ -1,0 +1,19 @@
+import { Badge } from '@/components/ui/badge';
+
+interface CinStatusBadgeProps {
+  status: 'valid' | 'missing' | 'invalid';
+}
+
+const STATUS_MAP: Record<
+  CinStatusBadgeProps['status'],
+  { label: string; variant: 'default' | 'secondary' | 'destructive' }
+> = {
+  valid: { label: 'Valido', variant: 'default' },
+  missing: { label: 'Mancante', variant: 'secondary' },
+  invalid: { label: 'Non valido', variant: 'destructive' },
+};
+
+export function CinStatusBadge({ status }: CinStatusBadgeProps) {
+  const { label, variant } = STATUS_MAP[status];
+  return <Badge variant={variant}>{label}</Badge>;
+}

--- a/src/features/admin/components/deactivate-user-dialog.tsx
+++ b/src/features/admin/components/deactivate-user-dialog.tsx
@@ -1,0 +1,48 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useDeactivateUser } from '@/queries/use-users';
+import type { UserSummary } from '@/types';
+
+interface DeactivateUserDialogProps {
+  user: UserSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeactivateUserDialog({ user, open, onOpenChange }: DeactivateUserDialogProps) {
+  const { mutate: deactivate, isPending } = useDeactivateUser();
+
+  function handleConfirm() {
+    if (!user) return;
+    deactivate(user.id, { onSuccess: () => onOpenChange(false) });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disattiva utente</DialogTitle>
+          <DialogDescription>
+            Sei sicuro di voler disattivare {user?.firstName} {user?.lastName} ({user?.email})?
+            L&apos;utente non potrà più accedere al sistema.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Annulla
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm} disabled={isPending}>
+            {isPending ? 'Disattivazione...' : 'Disattiva'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/admin/components/job-status-badge.tsx
+++ b/src/features/admin/components/job-status-badge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@/components/ui/badge';
+
+type JobLastStatus = 'Succeeded' | 'Failed' | 'Processing' | 'Enqueued' | 'Unknown';
+
+interface JobStatusBadgeProps {
+  status: JobLastStatus;
+}
+
+const STATUS_MAP: Record<
+  JobLastStatus,
+  { label: string; variant: 'default' | 'secondary' | 'outline' | 'destructive' }
+> = {
+  Succeeded: { label: 'Completato', variant: 'default' },
+  Failed: { label: 'Fallito', variant: 'destructive' },
+  Processing: { label: 'In corso', variant: 'secondary' },
+  Enqueued: { label: 'In coda', variant: 'outline' },
+  Unknown: { label: 'Sconosciuto', variant: 'outline' },
+};
+
+export function JobStatusBadge({ status }: JobStatusBadgeProps) {
+  const { label, variant } = STATUS_MAP[status] ?? STATUS_MAP.Unknown;
+  return <Badge variant={variant}>{label}</Badge>;
+}

--- a/src/features/admin/components/user-management-table.tsx
+++ b/src/features/admin/components/user-management-table.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChangeRoleDialog } from './change-role-dialog';
+import { DeactivateUserDialog } from './deactivate-user-dialog';
+import type { UserSummary } from '@/types';
+
+interface UserManagementTableProps {
+  users: UserSummary[];
+  isLoading: boolean;
+}
+
+export function UserManagementTable({ users, isLoading }: UserManagementTableProps) {
+  const [roleTarget, setRoleTarget] = useState<UserSummary | null>(null);
+  const [deactivateTarget, setDeactivateTarget] = useState<UserSummary | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-muted-foreground">
+              <th className="pb-2 pr-4 font-medium">Nome</th>
+              <th className="pb-2 pr-4 font-medium">Email</th>
+              <th className="pb-2 pr-4 font-medium">Ruolo</th>
+              <th className="pb-2 pr-4 font-medium">Stato</th>
+              <th className="pb-2 font-medium">Azioni</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user) => (
+              <tr key={user.id} className="border-b last:border-0">
+                <td className="py-3 pr-4 font-medium">
+                  {user.firstName} {user.lastName}
+                </td>
+                <td className="py-3 pr-4 text-muted-foreground">{user.email}</td>
+                <td className="py-3 pr-4">
+                  <Badge variant="outline">{user.role}</Badge>
+                </td>
+                <td className="py-3 pr-4">
+                  {user.isActive ? (
+                    <Badge variant="default">Attivo</Badge>
+                  ) : (
+                    <Badge variant="secondary">Inattivo</Badge>
+                  )}
+                </td>
+                <td className="py-3">
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setRoleTarget(user)}
+                    >
+                      Ruolo
+                    </Button>
+                    {user.isActive && (
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setDeactivateTarget(user)}
+                      >
+                        Disattiva
+                      </Button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {users.length === 0 && (
+              <tr>
+                <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                  Nessun utente trovato.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <ChangeRoleDialog
+        user={roleTarget}
+        open={roleTarget !== null}
+        onOpenChange={(open) => { if (!open) setRoleTarget(null); }}
+      />
+      <DeactivateUserDialog
+        user={deactivateTarget}
+        open={deactivateTarget !== null}
+        onOpenChange={(open) => { if (!open) setDeactivateTarget(null); }}
+      />
+    </>
+  );
+}

--- a/src/features/leases/lease-create-page.tsx
+++ b/src/features/leases/lease-create-page.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from 'react-router-dom';
-import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { LeaseCreateForm } from './components/lease-create-form';
 import { useCreateLease } from '@/queries/use-leases';
@@ -15,8 +14,7 @@ export function LeaseCreatePage() {
   };
 
   return (
-    <AppShell>
-      <div className="mx-auto max-w-4xl space-y-6">
+    <div className="mx-auto max-w-4xl space-y-6">
         <PageHeader
           title="Create lease"
           description="Define contract parties and terms — a draft will be saved for review"
@@ -25,7 +23,6 @@ export function LeaseCreatePage() {
           onSubmit={handleSubmit}
           isLoading={createLease.isPending}
         />
-      </div>
-    </AppShell>
+    </div>
   );
 }

--- a/src/features/leases/lease-detail-page.tsx
+++ b/src/features/leases/lease-detail-page.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, Loader2, PenLine } from 'lucide-react';
-import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { Button } from '@/components/ui/button';
@@ -35,17 +34,15 @@ export function LeaseDetailPage() {
 
   if (!lease) {
     return (
-      <AppShell>
-        <div className="py-12 text-center">
-          <h2 className="mb-2 text-2xl font-bold">Lease not found</h2>
-          <p className="text-muted-foreground">
-            The lease you are looking for does not exist or you do not have access.
-          </p>
-          <Button className="mt-4" variant="outline" onClick={() => navigate('/leases')}>
-            Back to leases
-          </Button>
-        </div>
-      </AppShell>
+      <div className="py-12 text-center">
+        <h2 className="mb-2 text-2xl font-bold">Lease not found</h2>
+        <p className="text-muted-foreground">
+          The lease you are looking for does not exist or you do not have access.
+        </p>
+        <Button className="mt-4" variant="outline" onClick={() => navigate('/leases')}>
+          Back to leases
+        </Button>
+      </div>
     );
   }
 
@@ -73,8 +70,7 @@ export function LeaseDetailPage() {
   const registrationData = registration ?? lease.registration;
 
   return (
-    <AppShell>
-      <div className="space-y-6">
+    <div className="space-y-6">
         <div className="flex items-center gap-3">
           <Button variant="ghost" size="icon" onClick={() => navigate('/leases')}>
             <ArrowLeft className="h-4 w-4" />
@@ -203,7 +199,6 @@ export function LeaseDetailPage() {
             )}
           </div>
         </div>
-      </div>
-    </AppShell>
+    </div>
   );
 }

--- a/src/features/leases/leases-page.tsx
+++ b/src/features/leases/leases-page.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from 'react-router-dom';
 import { FileText, Plus } from 'lucide-react';
-import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { EmptyState } from '@/components/shared/empty-state';
 import { LoadingScreen } from '@/components/shared/loading-screen';
@@ -27,8 +26,7 @@ export function LeasesPage() {
   const items = leases ?? [];
 
   return (
-    <AppShell>
-      <div className="space-y-6">
+    <div className="space-y-6">
         <PageHeader
           title="Long-term leases"
           description="Manage contract drafts, signing, and RLI registration"
@@ -95,7 +93,6 @@ export function LeasesPage() {
             ))}
           </div>
         )}
-      </div>
-    </AppShell>
+    </div>
   );
 }

--- a/src/features/profile/layer-aware-profile-page.tsx
+++ b/src/features/profile/layer-aware-profile-page.tsx
@@ -1,0 +1,43 @@
+import { AppShell } from '@/components/layout/app-shell';
+import { LongTermAppShell } from '@/components/layout/long-term-app-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+import { ProfileInfo } from './components/profile-info';
+import { useAuth } from '@/hooks/use-auth';
+
+function ProfileContent() {
+  const { isLoading, user } = useAuth();
+
+  if (isLoading || !user) {
+    return <LoadingScreen />;
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <PageHeader
+        title="My Profile"
+        description="View and manage your account information"
+      />
+      <ProfileInfo user={user} />
+    </div>
+  );
+}
+
+export function LayerAwareProfilePage() {
+  const { effectiveLayer } = useAppLayerContext();
+
+  if (effectiveLayer === 'long-term') {
+    return (
+      <LongTermAppShell>
+        <ProfileContent />
+      </LongTermAppShell>
+    );
+  }
+
+  return (
+    <AppShell>
+      <ProfileContent />
+    </AppShell>
+  );
+}

--- a/src/hooks/__tests__/use-app-layer.test.ts
+++ b/src/hooks/__tests__/use-app-layer.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ACTIVE_LAYER_STORAGE_KEY,
+  getDefaultHomePath,
+  resolveInitialLayer,
+} from '../use-app-layer';
+import { ROLE_LONG_TERM_LANDLORD, ROLE_PROPERTY_OWNER } from '@/lib/auth-roles';
+
+describe('use-app-layer helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns short-stay home for short-stay layer', () => {
+    expect(getDefaultHomePath('short-stay')).toBe('/');
+  });
+
+  it('returns leases home for long-term layer', () => {
+    expect(getDefaultHomePath('long-term')).toBe('/leases');
+  });
+
+  it('resolves short-stay-only users to short-stay layer', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER] };
+    expect(resolveInitialLayer(user)).toBe('short-stay');
+  });
+
+  it('resolves long-term-only users to long-term layer', () => {
+    const user = { roles: [ROLE_LONG_TERM_LANDLORD] };
+    expect(resolveInitialLayer(user)).toBe('long-term');
+  });
+
+  it('ignores localStorage for single-role users', () => {
+    localStorage.setItem(ACTIVE_LAYER_STORAGE_KEY, 'long-term');
+    const user = { roles: [ROLE_PROPERTY_OWNER] };
+    expect(resolveInitialLayer(user)).toBe('short-stay');
+  });
+
+  it('reads localStorage for dual-role users', () => {
+    localStorage.setItem(ACTIVE_LAYER_STORAGE_KEY, 'long-term');
+    const user = { roles: [ROLE_PROPERTY_OWNER, ROLE_LONG_TERM_LANDLORD] };
+    expect(resolveInitialLayer(user)).toBe('long-term');
+  });
+
+  it('defaults dual-role users to short-stay when no preference stored', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER, ROLE_LONG_TERM_LANDLORD] };
+    expect(resolveInitialLayer(user)).toBe('short-stay');
+  });
+});

--- a/src/hooks/use-app-layer-context.ts
+++ b/src/hooks/use-app-layer-context.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { AppLayerContext } from '@/contexts/app-layer-context';
+import type { UseAppLayerReturn } from '@/hooks/use-app-layer';
+
+export function useAppLayerContext(): UseAppLayerReturn {
+  const context = useContext(AppLayerContext);
+  if (!context) {
+    throw new Error('useAppLayerContext must be used within AppLayerProvider');
+  }
+  return context;
+}

--- a/src/hooks/use-app-layer.ts
+++ b/src/hooks/use-app-layer.ts
@@ -1,0 +1,136 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  isDualRole,
+  isLongTermOnly,
+  isShortStayOnly,
+  type UserWithRoles,
+} from '@/lib/auth-roles';
+
+export type AppLayer = 'short-stay' | 'long-term';
+
+export const ACTIVE_LAYER_STORAGE_KEY = 'casazen:active-layer';
+
+const SHORT_STAY_PATH_PREFIXES = [
+  '/',
+  '/properties',
+  '/bookings',
+  '/payments',
+  '/ota',
+  '/search',
+];
+
+export function getDefaultHomePath(layer: AppLayer = 'short-stay'): string {
+  return layer === 'long-term' ? '/leases' : '/';
+}
+
+export function resolveInitialLayer(user: UserWithRoles): AppLayer {
+  if (isShortStayOnly(user)) return 'short-stay';
+  if (isLongTermOnly(user)) return 'long-term';
+
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(ACTIVE_LAYER_STORAGE_KEY);
+    if (stored === 'long-term' || stored === 'short-stay') {
+      return stored;
+    }
+  }
+
+  return 'short-stay';
+}
+
+function readStoredLayer(): AppLayer {
+  if (typeof window === 'undefined') return 'short-stay';
+  const stored = localStorage.getItem(ACTIVE_LAYER_STORAGE_KEY);
+  return stored === 'long-term' ? 'long-term' : 'short-stay';
+}
+
+function persistLayer(layer: AppLayer): void {
+  localStorage.setItem(ACTIVE_LAYER_STORAGE_KEY, layer);
+}
+
+function isShortStayDeepLink(pathname: string): boolean {
+  if (pathname === '/') return true;
+  return SHORT_STAY_PATH_PREFIXES.some(
+    (prefix) => prefix !== '/' && (pathname === prefix || pathname.startsWith(`${prefix}/`))
+  );
+}
+
+function getPathLayer(pathname: string, canSwitchLayer: boolean): AppLayer | null {
+  if (!canSwitchLayer) return null;
+  if (pathname.startsWith('/leases')) return 'long-term';
+  if (isShortStayDeepLink(pathname)) return 'short-stay';
+  return null;
+}
+
+export interface UseAppLayerReturn {
+  activeLayer: AppLayer;
+  setLayer: (layer: AppLayer) => void;
+  effectiveLayer: AppLayer;
+  canSwitchLayer: boolean;
+  getDefaultHomePath: (layer?: AppLayer) => string;
+}
+
+export function useAppLayer(): UseAppLayerReturn {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const canSwitchLayer = isDualRole(user);
+
+  const forcedLayer = useMemo((): AppLayer | null => {
+    if (isShortStayOnly(user)) return 'short-stay';
+    if (isLongTermOnly(user)) return 'long-term';
+    return null;
+  }, [user]);
+
+  const pathLayer = useMemo(
+    () => getPathLayer(location.pathname, canSwitchLayer),
+    [canSwitchLayer, location.pathname]
+  );
+
+  const [storedLayer, setStoredLayer] = useState<AppLayer>(readStoredLayer);
+  const [prevPathLayer, setPrevPathLayer] = useState<AppLayer | null>(pathLayer);
+  const [prevForcedLayer, setPrevForcedLayer] = useState<AppLayer | null>(forcedLayer);
+
+  if (pathLayer !== prevPathLayer) {
+    setPrevPathLayer(pathLayer);
+    if (pathLayer) {
+      setStoredLayer(pathLayer);
+      persistLayer(pathLayer);
+    }
+  }
+
+  if (forcedLayer !== prevForcedLayer) {
+    setPrevForcedLayer(forcedLayer);
+    if (forcedLayer) {
+      setStoredLayer(forcedLayer);
+    }
+  }
+
+  const activeLayer = forcedLayer ?? pathLayer ?? storedLayer;
+  const effectiveLayer = forcedLayer ?? activeLayer;
+
+  const setLayer = useCallback(
+    (layer: AppLayer) => {
+      if (!canSwitchLayer) return;
+      setStoredLayer(layer);
+      persistLayer(layer);
+      navigate(getDefaultHomePath(layer), { replace: true });
+    },
+    [canSwitchLayer, navigate]
+  );
+
+  const getHomePath = useCallback(
+    (layer?: AppLayer) => getDefaultHomePath(layer ?? effectiveLayer),
+    [effectiveLayer]
+  );
+
+  return {
+    activeLayer,
+    setLayer,
+    effectiveLayer,
+    canSwitchLayer,
+    getDefaultHomePath: getHomePath,
+  };
+}

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,7 +1,7 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { useEffect } from 'react';
 import { setAccessTokenGetter } from '@/lib/axios';
-import { isDemoMode, demoUser } from '@/config/demo.config';
+import { isDemoMode, getDemoUser } from '@/config/demo.config';
 
 export function useAuth() {
   const {
@@ -44,7 +44,7 @@ export function useAuth() {
     return {
       isLoading: false,
       isAuthenticated: true,
-      user: demoUser,
+      user: getDemoUser(),
       login: () => console.log('Demo mode: login simulation'),
       logout,
       getAccessToken: async () => 'demo-token',

--- a/src/lib/__tests__/auth-roles.test.ts
+++ b/src/lib/__tests__/auth-roles.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { getUserRoles, hasRole, ROLES_CLAIM } from '../auth-roles';
+import {
+  getUserRoles,
+  hasRole,
+  isDualRole,
+  isLongTermOnly,
+  isShortStayOnly,
+  ROLES_CLAIM,
+  ROLE_LONG_TERM_LANDLORD,
+  ROLE_PROPERTY_OWNER,
+} from '../auth-roles';
 
 describe('auth-roles', () => {
   it('reads roles from Auth0 custom claim namespace', () => {
@@ -17,5 +26,26 @@ describe('auth-roles', () => {
   it('returns empty roles for missing user', () => {
     expect(getUserRoles(undefined)).toEqual([]);
     expect(hasRole(null, 'LongTermLandlord')).toBe(false);
+  });
+
+  it('identifies short-stay-only users', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER] };
+    expect(isShortStayOnly(user)).toBe(true);
+    expect(isLongTermOnly(user)).toBe(false);
+    expect(isDualRole(user)).toBe(false);
+  });
+
+  it('identifies long-term-only users', () => {
+    const user = { roles: [ROLE_LONG_TERM_LANDLORD] };
+    expect(isLongTermOnly(user)).toBe(true);
+    expect(isShortStayOnly(user)).toBe(false);
+    expect(isDualRole(user)).toBe(false);
+  });
+
+  it('identifies dual-role users', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER, ROLE_LONG_TERM_LANDLORD] };
+    expect(isDualRole(user)).toBe(true);
+    expect(isShortStayOnly(user)).toBe(false);
+    expect(isLongTermOnly(user)).toBe(false);
   });
 });

--- a/src/lib/auth-roles.ts
+++ b/src/lib/auth-roles.ts
@@ -1,6 +1,9 @@
 export const ROLES_CLAIM = 'https://casazen.app/roles';
 
-type UserWithRoles = Record<string, unknown> | null | undefined;
+export const ROLE_PROPERTY_OWNER = 'PropertyOwner';
+export const ROLE_LONG_TERM_LANDLORD = 'LongTermLandlord';
+
+export type UserWithRoles = Record<string, unknown> | null | undefined;
 
 export function getUserRoles(user: UserWithRoles): string[] {
   if (!user) return [];
@@ -19,4 +22,16 @@ export function getUserRoles(user: UserWithRoles): string[] {
 
 export function hasRole(user: UserWithRoles, role: string): boolean {
   return getUserRoles(user).includes(role);
+}
+
+export function isShortStayOnly(user: UserWithRoles): boolean {
+  return hasRole(user, ROLE_PROPERTY_OWNER) && !hasRole(user, ROLE_LONG_TERM_LANDLORD);
+}
+
+export function isLongTermOnly(user: UserWithRoles): boolean {
+  return hasRole(user, ROLE_LONG_TERM_LANDLORD) && !hasRole(user, ROLE_PROPERTY_OWNER);
+}
+
+export function isDualRole(user: UserWithRoles): boolean {
+  return hasRole(user, ROLE_PROPERTY_OWNER) && hasRole(user, ROLE_LONG_TERM_LANDLORD);
 }

--- a/src/lib/auth-roles.ts
+++ b/src/lib/auth-roles.ts
@@ -2,6 +2,7 @@ export const ROLES_CLAIM = 'https://casazen.app/roles';
 
 export const ROLE_PROPERTY_OWNER = 'PropertyOwner';
 export const ROLE_LONG_TERM_LANDLORD = 'LongTermLandlord';
+export const ROLE_ADMIN = 'Admin';
 
 export type UserWithRoles = Record<string, unknown> | null | undefined;
 
@@ -34,4 +35,8 @@ export function isLongTermOnly(user: UserWithRoles): boolean {
 
 export function isDualRole(user: UserWithRoles): boolean {
   return hasRole(user, ROLE_PROPERTY_OWNER) && hasRole(user, ROLE_LONG_TERM_LANDLORD);
+}
+
+export function isAdmin(user: UserWithRoles): boolean {
+  return hasRole(user, ROLE_ADMIN);
 }

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -3,17 +3,19 @@ import { useAuth } from '@/hooks/use-auth';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { getDefaultHomePath, resolveInitialLayer } from '@/hooks/use-app-layer';
 import { Home, LogIn } from 'lucide-react';
 
 export function LoginPage() {
-  const { isAuthenticated, login } = useAuth();
+  const { isAuthenticated, user, login } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (isAuthenticated) {
-      navigate('/');
+    if (isAuthenticated && user) {
+      const layer = resolveInitialLayer(user);
+      navigate(getDefaultHomePath(layer), { replace: true });
     }
-  }, [isAuthenticated, navigate]);
+  }, [isAuthenticated, user, navigate]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">

--- a/src/queries/use-admin.ts
+++ b/src/queries/use-admin.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { AdminApi } from '@/api/admin.api';
+
+const ADMIN_KEY = 'admin';
+
+export function useAdminStats() {
+  return useQuery({
+    queryKey: [ADMIN_KEY, 'stats'],
+    queryFn: () => AdminApi.getStats(),
+  });
+}
+
+export function useCinCompliance() {
+  return useQuery({
+    queryKey: [ADMIN_KEY, 'cin-compliance'],
+    queryFn: () => AdminApi.getCinCompliance(),
+  });
+}
+
+export function useAdminJobs() {
+  return useQuery({
+    queryKey: [ADMIN_KEY, 'jobs'],
+    queryFn: () => AdminApi.getJobs(),
+    refetchInterval: 30_000,
+  });
+}

--- a/src/queries/use-users.ts
+++ b/src/queries/use-users.ts
@@ -1,0 +1,83 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { UsersApi } from '@/api/users.api';
+import type { UpdateProfileRequest } from '@/types';
+import { toast } from 'sonner';
+
+const USERS_KEY = 'users';
+const ME_KEY = 'me';
+
+interface GetUsersParams {
+  page?: number;
+  pageSize?: number;
+  role?: string;
+  isActive?: boolean;
+  search?: string;
+}
+
+export function useUsers(params?: GetUsersParams) {
+  return useQuery({
+    queryKey: [USERS_KEY, params],
+    queryFn: () => UsersApi.getUsers(params ?? {}),
+  });
+}
+
+export function useUser(id: string) {
+  return useQuery({
+    queryKey: [USERS_KEY, id],
+    queryFn: () => UsersApi.getUserById(id),
+    enabled: !!id,
+  });
+}
+
+export function useMe() {
+  return useQuery({
+    queryKey: [ME_KEY],
+    queryFn: () => UsersApi.getMe(),
+  });
+}
+
+export function useUpdateMe() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateProfileRequest) => UsersApi.updateMe(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [ME_KEY] });
+      toast.success('Profilo aggiornato con successo');
+    },
+    onError: () => {
+      toast.error('Impossibile aggiornare il profilo');
+    },
+  });
+}
+
+export function useChangeUserRole() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, role }: { id: string; role: string }) =>
+      UsersApi.changeRole(id, role),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY] });
+      toast.success('Ruolo aggiornato con successo');
+    },
+    onError: () => {
+      toast.error('Impossibile aggiornare il ruolo');
+    },
+  });
+}
+
+export function useDeactivateUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => UsersApi.deactivateUser(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY] });
+      toast.success('Utente disattivato con successo');
+    },
+    onError: () => {
+      toast.error('Impossibile disattivare l\'utente');
+    },
+  });
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,8 @@
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 import { ProtectedRoute } from '@/components/auth/protected-route';
+import { ShortStayLayerGuard } from '@/components/auth/short-stay-layer-guard';
+import { LongTermAppShell } from '@/components/layout/long-term-app-shell';
+import { AppLayerProvider } from '@/contexts/app-layer-provider';
 import { LoginPage } from '@/pages/login-page';
 import { DashboardPage } from '@/features/dashboard/dashboard-page';
 import { PropertiesPage } from '@/features/properties/properties-page';
@@ -18,7 +21,7 @@ import { RevenuePage } from '@/features/payments/revenue-page';
 import { OtaPage } from '@/features/ota/ota-page';
 import { OtaSetupPage } from '@/features/ota/ota-setup-page';
 import { SearchPage } from '@/features/search/search-page';
-import { ProfilePage } from '@/features/profile/profile-page';
+import { LayerAwareProfilePage } from '@/features/profile/layer-aware-profile-page';
 import { PricingDashboardPage } from '@/features/pricing';
 import { PricingHistoryPage } from '@/features/pricing';
 import { LeasesPage, LeaseCreatePage, LeaseDetailPage } from '@/features/leases';
@@ -29,184 +32,121 @@ export const router = createBrowserRouter([
     element: <LoginPage />,
   },
   {
-    path: '/',
-    element: (
-      <ProtectedRoute>
-        <DashboardPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties',
-    element: (
-      <ProtectedRoute>
-        <PropertiesPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/create',
-    element: (
-      <ProtectedRoute>
-        <PropertyCreatePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/:id',
-    element: (
-      <ProtectedRoute>
-        <PropertyDetailPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/:id/edit',
-    element: (
-      <ProtectedRoute>
-        <PropertyEditPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/:id/pricing',
-    element: (
-      <ProtectedRoute>
-        <PricingDashboardPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings',
-    element: (
-      <ProtectedRoute>
-        <BookingsPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings/create',
-    element: (
-      <ProtectedRoute>
-        <BookingCreatePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings/calendar',
-    element: (
-      <ProtectedRoute>
-        <CalendarPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings/:id',
-    element: (
-      <ProtectedRoute>
-        <BookingDetailPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/bookings/:id/edit',
-    element: (
-      <ProtectedRoute>
-        <BookingEditPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/payments',
-    element: (
-      <ProtectedRoute>
-        <PaymentsPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/payments/create',
-    element: (
-      <ProtectedRoute>
-        <PaymentCreatePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/payments/revenue',
-    element: (
-      <ProtectedRoute>
-        <RevenuePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/payments/:id',
-    element: (
-      <ProtectedRoute>
-        <PaymentDetailPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/ota',
-    element: (
-      <ProtectedRoute>
-        <OtaPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/ota/create',
-    element: (
-      <ProtectedRoute>
-        <OtaSetupPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
     path: '/search',
     element: <SearchPage />,
   },
   {
-    path: '/profile',
     element: (
       <ProtectedRoute>
-        <ProfilePage />
+        <AppLayerProvider>
+          <Outlet />
+        </AppLayerProvider>
       </ProtectedRoute>
     ),
-  },
-  {
-    path: '/leases',
-    element: (
-      <ProtectedRoute role="LongTermLandlord">
-        <LeasesPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/leases/new',
-    element: (
-      <ProtectedRoute role="LongTermLandlord">
-        <LeaseCreatePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/leases/:id',
-    element: (
-      <ProtectedRoute role="LongTermLandlord">
-        <LeaseDetailPage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/properties/:id/pricing/history',
-    element: (
-      <ProtectedRoute>
-        <PricingHistoryPage />
-      </ProtectedRoute>
-    ),
+    children: [
+      {
+        element: <ShortStayLayerGuard />,
+        children: [
+          {
+            path: '/',
+            element: <DashboardPage />,
+          },
+          {
+            path: '/properties',
+            element: <PropertiesPage />,
+          },
+          {
+            path: '/properties/create',
+            element: <PropertyCreatePage />,
+          },
+          {
+            path: '/properties/:id',
+            element: <PropertyDetailPage />,
+          },
+          {
+            path: '/properties/:id/edit',
+            element: <PropertyEditPage />,
+          },
+          {
+            path: '/properties/:id/pricing',
+            element: <PricingDashboardPage />,
+          },
+          {
+            path: '/properties/:id/pricing/history',
+            element: <PricingHistoryPage />,
+          },
+          {
+            path: '/bookings',
+            element: <BookingsPage />,
+          },
+          {
+            path: '/bookings/create',
+            element: <BookingCreatePage />,
+          },
+          {
+            path: '/bookings/calendar',
+            element: <CalendarPage />,
+          },
+          {
+            path: '/bookings/:id',
+            element: <BookingDetailPage />,
+          },
+          {
+            path: '/bookings/:id/edit',
+            element: <BookingEditPage />,
+          },
+          {
+            path: '/payments',
+            element: <PaymentsPage />,
+          },
+          {
+            path: '/payments/create',
+            element: <PaymentCreatePage />,
+          },
+          {
+            path: '/payments/revenue',
+            element: <RevenuePage />,
+          },
+          {
+            path: '/payments/:id',
+            element: <PaymentDetailPage />,
+          },
+          {
+            path: '/ota',
+            element: <OtaPage />,
+          },
+          {
+            path: '/ota/create',
+            element: <OtaSetupPage />,
+          },
+        ],
+      },
+      {
+        path: '/profile',
+        element: <LayerAwareProfilePage />,
+      },
+      {
+        element: (
+          <ProtectedRoute role="LongTermLandlord">
+            <LongTermAppShell />
+          </ProtectedRoute>
+        ),
+        children: [
+          {
+            path: '/leases',
+            element: <LeasesPage />,
+          },
+          {
+            path: '/leases/new',
+            element: <LeaseCreatePage />,
+          },
+          {
+            path: '/leases/:id',
+            element: <LeaseDetailPage />,
+          },
+        ],
+      },
+    ],
   },
   {
     path: '*',

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,12 @@ import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { ShortStayLayerGuard } from '@/components/auth/short-stay-layer-guard';
 import { LongTermAppShell } from '@/components/layout/long-term-app-shell';
+import { AdminAppShell } from '@/components/layout/admin-app-shell';
 import { AppLayerProvider } from '@/contexts/app-layer-provider';
+import { AdminDashboardPage } from '@/features/admin/admin-dashboard-page';
+import { AdminUsersPage } from '@/features/admin/admin-users-page';
+import { AdminCinPage } from '@/features/admin/admin-cin-page';
+import { AdminJobsPage } from '@/features/admin/admin-jobs-page';
 import { LoginPage } from '@/pages/login-page';
 import { DashboardPage } from '@/features/dashboard/dashboard-page';
 import { PropertiesPage } from '@/features/properties/properties-page';
@@ -143,6 +148,31 @@ export const router = createBrowserRouter([
           {
             path: '/leases/:id',
             element: <LeaseDetailPage />,
+          },
+        ],
+      },
+      {
+        element: (
+          <ProtectedRoute role="Admin">
+            <AdminAppShell />
+          </ProtectedRoute>
+        ),
+        children: [
+          {
+            path: '/admin',
+            element: <AdminDashboardPage />,
+          },
+          {
+            path: '/admin/users',
+            element: <AdminUsersPage />,
+          },
+          {
+            path: '/admin/cin',
+            element: <AdminCinPage />,
+          },
+          {
+            path: '/admin/jobs',
+            element: <AdminJobsPage />,
           },
         ],
       },

--- a/src/types/admin.types.ts
+++ b/src/types/admin.types.ts
@@ -1,0 +1,41 @@
+export interface CinComplianceStats {
+  valid: number;
+  missing: number;
+  invalid: number;
+  total: number;
+}
+
+export interface OtaSyncHealth {
+  synced: number;
+  failed: number;
+  neverSynced: number;
+}
+
+export interface AdminStats {
+  totalProperties: number;
+  activeProperties: number;
+  totalBookings: number;
+  bookingsThisMonth: number;
+  upcomingCheckIns: number;
+  totalRevenue: number;
+  cinCompliance: CinComplianceStats;
+  otaSyncHealth: OtaSyncHealth;
+}
+
+export interface CinComplianceItem {
+  propertyId: string;
+  propertyName: string;
+  ownerId: string;
+  ownerEmail: string;
+  cinCode: string | null;
+  cinStatus: 'valid' | 'missing' | 'invalid';
+  city: string;
+}
+
+export interface JobStatus {
+  jobName: string;
+  cronExpression: string;
+  lastRun: string | null;
+  lastStatus: 'Succeeded' | 'Failed' | 'Processing' | 'Enqueued' | 'Unknown';
+  nextRun: string | null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,3 +10,5 @@ export * from './tourist-tax.types';  // ✅ New
 export * from './calendar.types';  // ✅ New
 export * from './pricing-adapter.types';
 export * from './lease.types';
+export * from './admin.types';
+export * from './users.types';

--- a/src/types/users.types.ts
+++ b/src/types/users.types.ts
@@ -1,0 +1,39 @@
+export type UserRole =
+  | 'Admin'
+  | 'PropertyOwner'
+  | 'PropertyManager'
+  | 'Guest'
+  | 'Staff'
+  | 'LongTermLandlord';
+
+export interface UserSummary {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: UserRole;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export interface UserDetail extends UserSummary {
+  phoneNumber?: string;
+  updatedAt: string;
+}
+
+export interface UpdateProfileRequest {
+  firstName?: string;
+  lastName?: string;
+  phoneNumber?: string;
+}
+
+export interface ChangeRoleRequest {
+  role: UserRole;
+}
+
+export interface PagedResult<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary

This release promotes the Admin Panel frontend (Issue #11) to production.

- **Admin shell**: dedicated `/admin` layout with sidebar navigation for system management pages
- **User management UI**: list, search, assign roles and activate/deactivate users via the admin API
- **CIN compliance page**: property compliance status dashboard — highlights properties missing Italian CIN codes (D.L. 145/2023)
- **Hangfire jobs page**: view background job status from the admin panel without accessing the Hangfire dashboard directly
- **E2E test stability**: fixed admin E2E timing assertion (PR #89)
- **Reconciliation**: merged `main` back into `develop` to align history before release (PR #91)

## Included PRs

- BE #183 — `feat(admin): user management CRUD and admin panel endpoints (#11)`
- FE #88 — `feat(admin): admin shell, user management UI, CIN compliance and jobs pages (#11)`
- FE #89 — `test(admin): fix E2E timing`
- FE #91 — `chore(release): merge main into develop — reconcile admin routes for v1.1.0`

## Release bundle

See `Sessions/bundle-11.md` in the backend repo — all features verified on test environment.

## Test plan

- `https://casazen.vercel.app` loads without error
- Login with `Admin` role → `/admin` route is accessible
- Login with `PropertyOwner` role → `/admin` route redirects to dashboard

Closes #11