### PR TITLE
feat(nav): context workspace switcher (#189)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist-ssr
 
 opencode.json
 public/test-auth.html
+e2e/.auth/

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -1,0 +1,13 @@
+# Copy to ../.env.e2e (gitignored) for local E2E runs.
+#
+# Test user (Auth0 database connection — automatable in Playwright):
+#   User ID: auth0|6a209c92984357dfe61c45ac
+#
+# Required roles in Auth0: LongTermLandlord (+ PropertyOwner for layer-switcher tests)
+
+E2E_AUTH0_EMAIL=your-e2e-user@example.com
+E2E_AUTH0_PASSWORD=your-e2e-password
+E2E_AUTH0_USER_ID=auth0|6a209c92984357dfe61c45ac
+
+# Optional overrides
+# E2E_BASE_URL=http://localhost:5173

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,19 @@
+import { test as setup, expect } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { loginViaAuth0, waitForAppReady } from './helpers/auth';
+import { e2eEnv, requireE2eCredentials } from './helpers/env';
+
+setup('authenticate long-term test user', async ({ page }) => {
+  mkdirSync(dirname(e2eEnv.authStoragePath), { recursive: true });
+
+  const { email } = requireE2eCredentials();
+
+  await loginViaAuth0(page);
+  await waitForAppReady(page);
+
+  await page.goto('/profile');
+  await expect(page.getByRole('heading', { name: email })).toBeVisible({ timeout: 15_000 });
+
+  await page.context().storageState({ path: e2eEnv.authStoragePath });
+});

--- a/e2e/context-workspace-switch.spec.ts
+++ b/e2e/context-workspace-switch.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { demoUrl } from './helpers/demo-profile';
+import { mockLeasesApiEmpty } from './helpers/lease-api-mock';
+
+test.describe('Context workspace switcher (#189)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  });
+
+  test('redirects legacy /leases to canonical long-rent route', async ({ page }) => {
+    await mockLeasesApiEmpty(page);
+    await page.goto(demoUrl('/leases', 'long-term'), { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/app\/long-rent\/leases/);
+  });
+
+  test('short-rent profile uses canonical context path', async ({ page }) => {
+    await page.goto(demoUrl('/app/short-rent/profile', 'short-stay'));
+    await expect(page).toHaveURL(/\/app\/short-rent\/profile/);
+  });
+
+  test('long-rent user cannot access short-rent routes', async ({ page }) => {
+    await mockLeasesApiEmpty(page);
+    await page.goto(demoUrl('/app/short-rent/bookings', 'long-term'), { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/app\/long-rent\/leases/);
+  });
+
+  test('dual-role user can switch between contexts', async ({ page }) => {
+    await mockLeasesApiEmpty(page);
+    await page.goto(demoUrl('/app/short-rent', 'dual'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('tab', { name: 'Affitti brevi' })).toBeVisible();
+    await page.getByRole('tab', { name: 'Affitti lungo termine' }).click();
+    await expect(page).toHaveURL(/\/app\/long-rent\/leases/);
+    await page.getByRole('tab', { name: 'Affitti brevi' }).click();
+    await expect(page).toHaveURL(/\/app\/short-rent/);
+  });
+
+  test('admin-only user lands in admin context', async ({ page }) => {
+    await page.goto(demoUrl('/app/choose-context', 'admin'));
+    await expect(page).toHaveURL(/\/app\/admin/);
+    await expect(page.getByRole('link', { name: 'Utenti' })).toBeVisible();
+  });
+});

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,174 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { requireE2eCredentials, e2eEnv } from './env';
+
+export async function loginViaAuth0(page: Page): Promise<void> {
+  const { email, password } = requireE2eCredentials();
+
+  await page.goto('/login');
+  await page.getByRole('button', { name: /sign in with auth0/i }).click();
+
+  await page.waitForURL(/auth0\.com/, { timeout: 30_000 });
+
+  const usernameField = page
+    .locator('input[name="username"], input[name="email"], input[type="email"]')
+    .first();
+  await usernameField.waitFor({ state: 'visible', timeout: 15_000 });
+  await usernameField.fill(email);
+
+  const passwordField = page.locator('input[name="password"], input[type="password"]').first();
+  const passwordVisible = await passwordField.isVisible().catch(() => false);
+
+  if (!passwordVisible) {
+    await page
+      .locator(
+        'button[type="submit"], button[name="action"], button[data-action-button-primary="true"]'
+      )
+      .first()
+      .click();
+    await passwordField.waitFor({ state: 'visible', timeout: 15_000 });
+  }
+
+  await passwordField.fill(password);
+
+  await page
+    .locator(
+      'button[type="submit"], button[name="action"], button[data-action-button-primary="true"]'
+    )
+    .first()
+    .click();
+
+  await page.waitForURL((url) => !url.hostname.includes('auth0.com'), { timeout: 60_000 });
+}
+
+export async function readAuth0Sub(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const decodeSub = (token: string): string | null => {
+      try {
+        const segment = token.split('.')[1];
+        if (!segment) return null;
+        const normalized = segment.replace(/-/g, '+').replace(/_/g, '/');
+        const padded = normalized.padEnd(
+          normalized.length + ((4 - (normalized.length % 4)) % 4),
+          '='
+        );
+        const payload = JSON.parse(atob(padded)) as { sub?: string };
+        return payload.sub ?? null;
+      } catch {
+        return null;
+      }
+    };
+
+    for (const key of Object.keys(localStorage)) {
+      if (!key.includes('auth0spajs')) continue;
+      try {
+        const raw = localStorage.getItem(key);
+        if (!raw) continue;
+        const parsed = JSON.parse(raw) as {
+          body?: {
+            id_token?: string;
+            decodedToken?: { user?: { sub?: string } };
+          };
+        };
+
+        const fromDecoded = parsed.body?.decodedToken?.user?.sub;
+        if (fromDecoded) return fromDecoded;
+
+        const idToken = parsed.body?.id_token;
+        if (typeof idToken === 'string') {
+          const sub = decodeSub(idToken);
+          if (sub) return sub;
+        }
+      } catch {
+        // try next cache entry
+      }
+    }
+
+    return null;
+  });
+}
+
+export async function readAuth0Roles(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const decodeRoles = (token: string): string[] => {
+      try {
+        const segment = token.split('.')[1];
+        if (!segment) return [];
+        const normalized = segment.replace(/-/g, '+').replace(/_/g, '/');
+        const padded = normalized.padEnd(
+          normalized.length + ((4 - (normalized.length % 4)) % 4),
+          '='
+        );
+        const payload = JSON.parse(atob(padded)) as Record<string, unknown>;
+        const roles = payload['https://casazen.app/roles'];
+        return Array.isArray(roles)
+          ? roles.filter((role): role is string => typeof role === 'string')
+          : [];
+      } catch {
+        return [];
+      }
+    };
+
+    for (const key of Object.keys(localStorage)) {
+      if (!key.includes('auth0spajs')) continue;
+      try {
+        const raw = localStorage.getItem(key);
+        if (!raw) continue;
+        const parsed = JSON.parse(raw) as {
+          body?: { access_token?: string; id_token?: string };
+        };
+
+        const accessToken = parsed.body?.access_token;
+        if (typeof accessToken === 'string') {
+          const roles = decodeRoles(accessToken);
+          if (roles.length > 0) return roles;
+        }
+
+        const idToken = parsed.body?.id_token;
+        if (typeof idToken === 'string') {
+          const roles = decodeRoles(idToken);
+          if (roles.length > 0) return roles;
+        }
+      } catch {
+        // try next cache entry
+      }
+    }
+
+    return [];
+  });
+}
+
+export async function assertAuthenticatedUser(page: Page): Promise<void> {
+  const sub = await readAuth0Sub(page);
+  expect(sub, 'Auth0 sub missing after login').toBeTruthy();
+
+  if (e2eEnv.auth0UserId) {
+    expect(sub, `Expected Auth0 sub ${e2eEnv.auth0UserId}`).toBe(e2eEnv.auth0UserId);
+  }
+
+  const roles = await readAuth0Roles(page);
+  expect(
+    roles,
+    'LongTermLandlord role missing in JWT — assign it in Auth0 for this user and update the Login Action to set roles on access + ID tokens'
+  ).toContain('LongTermLandlord');
+}
+
+export async function waitForAppReady(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const text = document.body.innerText;
+      if (text.includes('Authenticating...')) return false;
+      if (text.includes('Sign in with Auth0')) return false;
+
+      return (
+        text.includes('Long-term leases') ||
+        text.includes('Long-Term Rental') ||
+        text.includes('Property Manager') ||
+        text.includes('Dashboard') ||
+        text.includes('No leases yet')
+      );
+    },
+    undefined,
+    { timeout: 90_000 }
+  );
+}

--- a/e2e/helpers/demo-profile.ts
+++ b/e2e/helpers/demo-profile.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-export type DemoProfile = 'short-stay' | 'long-term' | 'dual';
+export type DemoProfile = 'short-stay' | 'long-term' | 'dual' | 'admin' | 'triple';
 
 export function demoUrl(path: string, profile: DemoProfile): string {
   const separator = path.includes('?') ? '&' : '?';

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -1,0 +1,45 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function loadEnvFile(relativePath: string): void {
+  const absolutePath = resolve(process.cwd(), relativePath);
+  if (!existsSync(absolutePath)) return;
+
+  const content = readFileSync(absolutePath, 'utf8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim().replace(/^["']|["']$/g, '');
+    if (key && process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadEnvFile('.env');
+loadEnvFile('.env.e2e');
+
+export const e2eEnv = {
+  baseUrl: process.env.E2E_BASE_URL ?? 'http://localhost:5173',
+  auth0Email: process.env.E2E_AUTH0_EMAIL ?? '',
+  auth0Password: process.env.E2E_AUTH0_PASSWORD ?? '',
+  /** Optional: assert JWT `sub` after login (e.g. auth0|6a209c92984357dfe61c45ac) */
+  auth0UserId: process.env.E2E_AUTH0_USER_ID ?? '',
+  authStoragePath: 'e2e/.auth/long-term-user.json',
+} as const;
+
+export function requireE2eCredentials(): { email: string; password: string } {
+  const { auth0Email, auth0Password } = e2eEnv;
+  if (!auth0Email || !auth0Password) {
+    throw new Error(
+      'E2E_AUTH0_EMAIL and E2E_AUTH0_PASSWORD are required. Copy e2e/.env.example to .env.e2e and set a dedicated Auth0 database user with LongTermLandlord role.',
+    );
+  }
+
+  return { email: auth0Email, password: auth0Password };
+}

--- a/e2e/long-term-flow.spec.ts
+++ b/e2e/long-term-flow.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+import { waitForAppReady } from './helpers/auth';
+
+test.describe.skip('Long-term layer (real Auth0 + API)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+  });
+
+  test('AC0 user has LongTermLandlord role and can open /leases', async ({ page }) => {
+    await page.goto('/leases');
+
+    const onLeases = /\/leases/.test(page.url());
+    const hasLongTermShell = await page.getByText(/long-term rental/i).isVisible().catch(() => false);
+
+    expect(
+      onLeases && hasLongTermShell,
+      'User lacks LongTermLandlord role — assign it in Auth0 for auth0|6a209c92984357dfe61c45ac and ensure Login Action sets https://casazen.app/roles on tokens'
+    ).toBeTruthy();
+  });
+
+  test('AC1 shows long-term shell on /leases with sidebar and heading', async ({ page }) => {
+    await page.goto('/leases');
+    await expect(page).toHaveURL(/\/leases/, { timeout: 30_000 });
+    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Leases' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /long-term leases/i })).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
+  test('AC2 layer switcher moves between short-stay and long-term when available', async ({
+    page,
+  }) => {
+    await page.goto('/leases');
+    await expect(page.getByText(/long-term rental/i)).toBeVisible({ timeout: 30_000 });
+
+    const switcher = page.getByRole('tablist', { name: 'Application layer' });
+    const hasSwitcher = await switcher.isVisible().catch(() => false);
+
+    if (!hasSwitcher) {
+      test.skip(true, 'User is long-term-only; layer switcher not expected.');
+    }
+
+    await page.getByRole('tab', { name: 'Short-stay' }).click();
+    await expect(page).toHaveURL(/\/(?:\?.*)?$/, { timeout: 15_000 });
+    await expect(page.getByText(/property manager/i)).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Long-term' }).click();
+    await expect(page).toHaveURL(/\/leases/, { timeout: 15_000 });
+    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+  });
+
+  test('AC3 navigates create-lease form and validates required fields', async ({ page }) => {
+    await page.goto('/leases/new');
+    await expect(page.getByRole('heading', { name: /create lease/i })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page.getByRole('button', { name: /create lease draft/i }).click();
+
+    await expect(page.getByText(/property is required/i)).toBeVisible();
+    await expect(page.getByText(/start date is required/i)).toBeVisible();
+    await expect(page.getByText(/end date is required/i)).toBeVisible();
+  });
+
+  test('AC4 creates a lease draft when a property with APE is available', async ({ page }) => {
+    await page.goto('/leases/new');
+    await expect(page.getByRole('heading', { name: /create lease/i })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const propertySelect = page.locator('#propertyId');
+    const optionCount = await propertySelect.locator('option').count();
+    if (optionCount <= 1) {
+      test.skip(true, 'No properties available for the authenticated user.');
+    }
+
+    await propertySelect.selectOption({ index: 1 });
+    await page.waitForTimeout(1500);
+
+    const apeAlert = page.getByRole('alert');
+    if (await apeAlert.isVisible().catch(() => false)) {
+      test.skip(true, 'Selected property is missing an APE document required for lease creation.');
+    }
+
+    const startDate = '2026-07-01';
+    const endDate = '2027-06-30';
+
+    await page.locator('#startDate').fill(startDate);
+    await page.locator('#endDate').fill(endDate);
+    await page.locator('#monthlyRent').fill('1200');
+
+    await page.locator('[id="landlord.firstName"]').fill('Mario');
+    await page.locator('[id="landlord.lastName"]').fill('Rossi');
+    await page.locator('[id="landlord.fiscalCode"]').fill('RSSMRA80A01H501U');
+    await page.locator('[id="landlord.citizenship"]').fill('IT');
+    await page.locator('[id="landlord.contactEmail"]').fill('landlord@example.com');
+
+    await page.locator('[id="tenant.firstName"]').fill('Luigi');
+    await page.locator('[id="tenant.lastName"]').fill('Verdi');
+    await page.locator('[id="tenant.fiscalCode"]').fill('VRDLGU85C15F205X');
+    await page.locator('[id="tenant.citizenship"]').fill('IT');
+    await page.locator('[id="tenant.contactEmail"]').fill('tenant@example.com');
+
+    await page.getByRole('button', { name: /create lease draft/i }).click();
+
+    await expect(page).toHaveURL(/\/leases\/[0-9a-f-]+/i, { timeout: 30_000 });
+    await expect(page.getByText(/draft/i).first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('AC5 profile page is reachable from long-term shell', async ({ page }) => {
+    await page.goto('/leases');
+    await expect(page.getByText(/long-term rental/i)).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole('link', { name: 'Profile' }).click();
+    await expect(page).toHaveURL(/\/profile/, { timeout: 15_000 });
+    await expect(page.getByRole('heading', { name: /profile information/i })).toBeVisible();
+  });
+
+  test('AC6 short-stay routes stay hidden in long-term-only navigation', async ({ page }) => {
+    await page.goto('/leases');
+    await expect(page.getByText(/long-term rental/i)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole('link', { name: 'Bookings' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'OTA Sync' })).toHaveCount(0);
+  });
+});

--- a/e2e/long-term-layer.spec.ts
+++ b/e2e/long-term-layer.spec.ts
@@ -13,58 +13,57 @@ test.describe('Long-term UI layer (#182 acceptance criteria)', () => {
   test('AC1 PropertyOwner-only sees short-stay shell without long-term nav', async ({ page }) => {
     await page.goto(demoUrl('/', 'short-stay'));
 
-    await expect(page.getByText(/property manager/i)).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Bookings' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Leases' })).toHaveCount(0);
-    await expect(page.getByText(/long-term rental/i)).toHaveCount(0);
+    await expect(page).toHaveURL(/\/app\/short-rent/, { timeout: 15_000 });
+    await expect(page.getByRole('link', { name: 'Prenotazioni' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Contratti' })).toHaveCount(0);
   });
 
   test('AC2 LongTermLandlord-only sees long-term shell and lease home', async ({ page }) => {
-    await page.goto(demoUrl('/', 'long-term'), { waitUntil: 'networkidle' });
+    await page.goto(demoUrl('/', 'long-term'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page).toHaveURL(/\/leases(?:\?.*)?$/, { timeout: 15_000 });
+    await expect(page).toHaveURL(/\/app\/long-rent\/leases(?:\?.*)?$/, { timeout: 15_000 });
     await expect(page.getByText(/long-term rental/i)).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Leases' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Bookings' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Contratti' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Prenotazioni' })).toHaveCount(0);
   });
 
   test('AC3 dual-role user can switch layers with persistent switcher', async ({ page }) => {
     await mockLeasesApiEmpty(page);
-    await page.goto(demoUrl('/', 'dual'), { waitUntil: 'networkidle' });
+    await page.goto(demoUrl('/', 'dual'), { waitUntil: 'domcontentloaded' });
 
-    const switcher = page.getByRole('tablist', { name: 'Application layer' });
+    const switcher = page.getByRole('tablist', { name: 'Workspace context' });
     await expect(switcher).toBeVisible();
 
-    await page.getByRole('tab', { name: 'Long-term' }).click();
-    await expect(page).toHaveURL(/\/leases/, { timeout: 15_000 });
+    await page.getByRole('tab', { name: 'Affitti lungo termine' }).click();
+    await expect(page).toHaveURL(/\/app\/long-rent\/leases/, { timeout: 15_000 });
     await expect(page.getByText(/long-term rental/i)).toBeVisible();
 
-    await page.getByRole('tab', { name: 'Short-stay' }).click();
-    await expect(page).toHaveURL(/\/(?:\?.*)?$/, { timeout: 15_000 });
+    await page.getByRole('tab', { name: 'Affitti brevi' }).click();
+    await expect(page).toHaveURL(/\/app\/short-rent(?:\?.*)?$/, { timeout: 15_000 });
     await expect(page.getByText(/property manager/i)).toBeVisible();
   });
 
   test('AC4 long-term layer renders leases list route', async ({ page }) => {
     await mockLeasesApiEmpty(page);
-    await page.goto(demoUrl('/leases', 'long-term'), { waitUntil: 'networkidle' });
+    await page.goto(demoUrl('/leases', 'long-term'), { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByText(/long-term rental/i)).toBeVisible();
     await expect(page.getByRole('heading', { name: /long-term leases/i })).toBeVisible({ timeout: 15_000 });
   });
 
   test('AC5 PropertyOwner-only is redirected away from /leases', async ({ page }) => {
-    await page.goto(demoUrl('/leases', 'short-stay'), { waitUntil: 'networkidle' });
+    await page.goto(demoUrl('/leases', 'short-stay'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page).not.toHaveURL(/\/leases/, { timeout: 15_000 });
+    await expect(page).toHaveURL(/\/app\/short-rent/, { timeout: 15_000 });
     await expect(page.getByText(/property manager/i)).toBeVisible();
   });
 
   test('AC6 dual-role deep link to /leases stays in long-term shell', async ({ page }) => {
     await mockLeasesApiEmpty(page);
-    await page.goto(demoUrl('/leases', 'dual'), { waitUntil: 'networkidle' });
+    await page.goto(demoUrl('/leases', 'dual'), { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByText(/long-term rental/i)).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Leases' })).toBeVisible();
-    await expect(page.getByRole('tab', { name: 'Long-term' })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('link', { name: 'Contratti' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Affitti lungo termine' })).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/src/api/contexts.ts
+++ b/src/api/contexts.ts
@@ -1,0 +1,23 @@
+import axios from '@/lib/axios';
+import type { AppContextKey } from '@/config/route-manifest';
+
+export interface ContextBootstrapDto {
+  contextKey: AppContextKey;
+  displayName: string;
+  roleKey: string;
+  permissions: string[];
+  defaultRoute: string;
+}
+
+export interface UserContextsResponse {
+  userId: string;
+  contexts: ContextBootstrapDto[];
+  lastUsedContextKey?: AppContextKey | null;
+}
+
+export const contextsApi = {
+  async getContexts(): Promise<UserContextsResponse> {
+    const response = await axios.get<UserContextsResponse>('/me/contexts');
+    return response.data;
+  },
+};

--- a/src/components/auth/context-route-guard.tsx
+++ b/src/components/auth/context-route-guard.tsx
@@ -1,0 +1,34 @@
+import { Navigate } from 'react-router-dom';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import type { AppContextKey } from '@/config/route-manifest';
+import { useWorkspace } from '@/hooks/use-workspace';
+
+interface ContextRouteGuardProps {
+  contextKey: AppContextKey;
+  requiredPermissions?: string[];
+  children: React.ReactNode;
+}
+
+export function ContextRouteGuard({ contextKey, requiredPermissions = [], children }: ContextRouteGuardProps) {
+  const { contexts, isReady, getDefaultRoute } = useWorkspace();
+  const current = contexts.find((ctx) => ctx.contextKey === contextKey);
+
+  if (!isReady) {
+    return <LoadingScreen message="Loading workspace..." />;
+  }
+
+  if (contexts.length === 0) {
+    return <Navigate to="/app/no-access" replace />;
+  }
+
+  if (!current) {
+    return <Navigate to={contexts[0].defaultRoute} replace />;
+  }
+
+  const hasAllPermissions = requiredPermissions.every((permission) => current.permissions.includes(permission));
+  if (!hasAllPermissions) {
+    return <Navigate to={getDefaultRoute(current.contextKey)} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/auth/user-menu.tsx
+++ b/src/components/auth/user-menu.tsx
@@ -10,9 +10,11 @@ import {
 import { User, LogOut } from 'lucide-react';
 import { getInitials } from '@/lib/utils';
 import { useNavigate } from 'react-router-dom';
+import { useWorkspace } from '@/hooks/use-workspace';
 
 export function UserMenu() {
   const { user, logout } = useAuth();
+  const { activeContext } = useWorkspace();
   const navigate = useNavigate();
 
   if (!user) return null;
@@ -33,7 +35,7 @@ export function UserMenu() {
           </div>
         </div>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={() => navigate('/profile')}>
+        <DropdownMenuItem onClick={() => navigate(`/app/${activeContext ?? 'short-rent'}/profile`)}>
           <User className="mr-2 h-4 w-4" />
           Profile
         </DropdownMenuItem>

--- a/src/components/layout/__tests__/workspace-switcher.test.tsx
+++ b/src/components/layout/__tests__/workspace-switcher.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { WorkspaceSwitcher } from '../workspace-switcher';
+
+vi.mock('@/hooks/use-workspace', () => ({
+  useWorkspace: vi.fn(),
+}));
+
+import { useWorkspace } from '@/hooks/use-workspace';
+
+describe('WorkspaceSwitcher', () => {
+  it('renders nothing for single context', () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      contexts: [
+        { contextKey: 'short-rent', displayName: 'Affitti brevi', roleKey: 'property_owner', permissions: [], defaultRoute: '/app/short-rent' },
+      ],
+      activeContext: 'short-rent',
+      isReady: true,
+      setActiveContext: vi.fn(),
+      hasPermission: vi.fn(),
+      getDefaultRoute: vi.fn(),
+    });
+
+    const { container } = render(<WorkspaceSwitcher />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('switches context when tab is clicked', () => {
+    const setActiveContext = vi.fn();
+    vi.mocked(useWorkspace).mockReturnValue({
+      contexts: [
+        { contextKey: 'short-rent', displayName: 'Affitti brevi', roleKey: 'property_owner', permissions: [], defaultRoute: '/app/short-rent' },
+        { contextKey: 'long-rent', displayName: 'Affitti lungo termine', roleKey: 'long_term_landlord', permissions: [], defaultRoute: '/app/long-rent/leases' },
+      ],
+      activeContext: 'short-rent',
+      isReady: true,
+      setActiveContext,
+      hasPermission: vi.fn(),
+      getDefaultRoute: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Affitti lungo termine' }));
+    expect(setActiveContext).toHaveBeenCalledWith('long-rent');
+  });
+});

--- a/src/components/layout/admin-app-shell.tsx
+++ b/src/components/layout/admin-app-shell.tsx
@@ -1,17 +1,21 @@
 import { Outlet } from 'react-router-dom';
 import { AdminSidebar } from './admin-sidebar';
 import { Header } from './header';
+import { WorkspaceSwitcher } from './workspace-switcher';
+import { useWorkspace } from '@/hooks/use-workspace';
 
 interface AdminAppShellProps {
   children?: React.ReactNode;
 }
 
 export function AdminAppShell({ children }: AdminAppShellProps) {
+  const { contexts } = useWorkspace();
+
   return (
     <div className="flex h-screen overflow-hidden">
       <AdminSidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <Header />
+        <Header slotStart={contexts.length > 1 ? <WorkspaceSwitcher /> : undefined} />
         <main className="flex-1 overflow-y-auto p-4 md:p-6">
           {children ?? <Outlet />}
         </main>

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -1,15 +1,23 @@
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import { BarChart3, Building2, FileCheck, Home, Settings } from 'lucide-react';
+import { FileCheck, Home, LayoutDashboard, Settings, Users, type LucideIcon } from 'lucide-react';
+import { getNavEntries } from '@/config/route-manifest';
 
-const navItems = [
-  { to: '/admin', icon: BarChart3, label: 'Dashboard', end: true },
-  { to: '/admin/users', icon: Building2, label: 'Users' },
-  { to: '/admin/cin', icon: FileCheck, label: 'CIN Compliance' },
-  { to: '/admin/jobs', icon: Settings, label: 'Background Jobs' },
-];
+const ICONS: Record<string, LucideIcon> = {
+  LayoutDashboard,
+  Users,
+  FileCheck,
+  Settings,
+};
 
 export function AdminSidebar() {
+  const navItems = getNavEntries('admin').map((entry) => ({
+    to: entry.path,
+    icon: ICONS[entry.icon ?? 'LayoutDashboard'] ?? LayoutDashboard,
+    label: entry.navLabel ?? '',
+    end: entry.path === '/app/admin',
+  }));
+
   return (
     <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
       <div className="flex h-16 items-center border-b px-6">

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,22 +1,22 @@
 import { Sidebar } from './sidebar';
 import { Header } from './header';
-import { LayerSwitcher } from './layer-switcher';
+import { WorkspaceSwitcher } from './workspace-switcher';
 import { DemoBanner } from '@/components/shared/demo-banner';
-import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+import { useWorkspace } from '@/hooks/use-workspace';
 
 interface AppShellProps {
   children: React.ReactNode;
 }
 
 export function AppShell({ children }: AppShellProps) {
-  const { canSwitchLayer } = useAppLayerContext();
+  const { contexts } = useWorkspace();
 
   return (
     <div className="flex h-screen overflow-hidden">
       <Sidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <DemoBanner />
-        <Header slotStart={canSwitchLayer ? <LayerSwitcher /> : undefined} />
+        <Header slotStart={contexts.length > 1 ? <WorkspaceSwitcher /> : undefined} />
         <main className="flex-1 overflow-y-auto p-4 md:p-6">
           {children}
         </main>

--- a/src/components/layout/context-layout.tsx
+++ b/src/components/layout/context-layout.tsx
@@ -1,0 +1,35 @@
+import { Navigate, Outlet, useLocation, useParams } from 'react-router-dom';
+import { AdminAppShell } from './admin-app-shell';
+import { LongTermAppShell } from './long-term-app-shell';
+import type { AppContextKey } from '@/config/route-manifest';
+
+const KNOWN_CONTEXTS: AppContextKey[] = ['short-rent', 'long-rent', 'admin'];
+
+export function ContextLayout() {
+  const { context } = useParams();
+  const location = useLocation();
+  const contextFromPath = location.pathname.split('/')[2] as AppContextKey | undefined;
+  const contextKey = (context ?? contextFromPath) as AppContextKey | undefined;
+
+  if (!contextKey || !KNOWN_CONTEXTS.includes(contextKey)) {
+    return <Navigate to="/app/choose-context" replace />;
+  }
+
+  if (contextKey === 'long-rent') {
+    return (
+      <LongTermAppShell>
+        <Outlet />
+      </LongTermAppShell>
+    );
+  }
+
+  if (contextKey === 'admin') {
+    return (
+      <AdminAppShell>
+        <Outlet />
+      </AdminAppShell>
+    );
+  }
+
+  return <Outlet />;
+}

--- a/src/components/layout/long-term-app-shell.tsx
+++ b/src/components/layout/long-term-app-shell.tsx
@@ -1,23 +1,23 @@
 import { Outlet } from 'react-router-dom';
 import { LongTermSidebar } from './long-term-sidebar';
 import { Header } from './header';
-import { LayerSwitcher } from './layer-switcher';
+import { WorkspaceSwitcher } from './workspace-switcher';
 import { DemoBanner } from '@/components/shared/demo-banner';
-import { useAppLayerContext } from '@/hooks/use-app-layer-context';
+import { useWorkspace } from '@/hooks/use-workspace';
 
 interface LongTermAppShellProps {
   children?: React.ReactNode;
 }
 
 export function LongTermAppShell({ children }: LongTermAppShellProps) {
-  const { canSwitchLayer } = useAppLayerContext();
+  const { contexts } = useWorkspace();
 
   return (
     <div className="flex h-screen overflow-hidden">
       <LongTermSidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <DemoBanner />
-        <Header slotStart={canSwitchLayer ? <LayerSwitcher /> : undefined} />
+        <Header slotStart={contexts.length > 1 ? <WorkspaceSwitcher /> : undefined} />
         <main className="flex-1 overflow-y-auto p-4 md:p-6">
           {children ?? <Outlet />}
         </main>

--- a/src/components/layout/long-term-sidebar.tsx
+++ b/src/components/layout/long-term-sidebar.tsx
@@ -1,13 +1,21 @@
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import { FileText, Home, User } from 'lucide-react';
+import { FileText, Home, User, type LucideIcon } from 'lucide-react';
+import { getNavEntries } from '@/config/route-manifest';
 
-const navItems = [
-  { to: '/leases', icon: FileText, label: 'Leases' },
-  { to: '/profile', icon: User, label: 'Profile' },
-];
+const ICONS: Record<string, LucideIcon> = {
+  FileText,
+  User,
+};
 
 export function LongTermSidebar() {
+  const navItems = getNavEntries('long-rent').map((entry) => ({
+    to: entry.path,
+    icon: ICONS[entry.icon ?? 'FileText'] ?? FileText,
+    label: entry.navLabel ?? '',
+    end: entry.path === '/app/long-rent/leases',
+  }));
+
   return (
     <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
       <div className="flex h-16 items-center border-b px-6">
@@ -28,7 +36,7 @@ export function LongTermSidebar() {
           <NavLink
             key={item.to}
             to={item.to}
-            end={item.to === '/leases'}
+            end={item.end}
             className={({ isActive }) =>
               cn(
                 'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,26 +1,37 @@
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import {
+  Calendar,
+  CalendarDays,
+  ChartColumn,
+  CreditCard,
+  Home,
+  LayoutDashboard,
+  Repeat,
+  type LucideIcon,
+  User,
+} from 'lucide-react';
+import { getNavEntries } from '@/config/route-manifest';
+
+const ICONS: Record<string, LucideIcon> = {
   LayoutDashboard,
   Home,
   Calendar,
+  CalendarDays,
   CreditCard,
+  ChartColumn,
   Repeat,
-  Search,
   User,
-} from 'lucide-react';
-
-const navItems = [
-  { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
-  { to: '/properties', icon: Home, label: 'Properties' },
-  { to: '/bookings', icon: Calendar, label: 'Bookings' },
-  { to: '/payments', icon: CreditCard, label: 'Payments' },
-  { to: '/ota', icon: Repeat, label: 'OTA Sync' },
-  { to: '/search', icon: Search, label: 'Search' },
-  { to: '/profile', icon: User, label: 'Profile' },
-];
+};
 
 export function Sidebar() {
+  const navItems = getNavEntries('short-rent').map((entry) => ({
+    to: entry.path,
+    label: entry.navLabel ?? '',
+    icon: ICONS[entry.icon ?? 'LayoutDashboard'] ?? LayoutDashboard,
+    end: entry.path === '/app/short-rent',
+  }));
+
   return (
     <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
       <div className="flex h-16 items-center border-b px-6">
@@ -39,7 +50,7 @@ export function Sidebar() {
           <NavLink
             key={item.to}
             to={item.to}
-            end={item.to === '/'}
+            end={item.end}
             className={({ isActive }) =>
               cn(
                 'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',

--- a/src/components/layout/workspace-switcher.tsx
+++ b/src/components/layout/workspace-switcher.tsx
@@ -1,0 +1,66 @@
+import { useCallback, useRef } from 'react';
+import { cn } from '@/lib/utils';
+import { useWorkspace } from '@/hooks/use-workspace';
+
+export function WorkspaceSwitcher() {
+  const { contexts, activeContext, setActiveContext } = useWorkspace();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const currentIndex = contexts.findIndex((ctx) => ctx.contextKey === activeContext);
+      if (currentIndex === -1) return;
+
+      let nextIndex = currentIndex;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        nextIndex = (currentIndex + 1) % contexts.length;
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        nextIndex = (currentIndex - 1 + contexts.length) % contexts.length;
+      } else {
+        return;
+      }
+
+      event.preventDefault();
+      const nextContext = contexts[nextIndex];
+      setActiveContext(nextContext.contextKey);
+      tabRefs.current[nextIndex]?.focus();
+    },
+    [activeContext, contexts, setActiveContext],
+  );
+
+  if (contexts.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Workspace context"
+      className="ml-2 flex rounded-lg border bg-muted p-0.5"
+      onKeyDown={handleKeyDown}
+    >
+      {contexts.map((context, index) => {
+        const isSelected = activeContext === context.contextKey;
+        return (
+          <button
+            key={context.contextKey}
+            ref={(element) => {
+              tabRefs.current[index] = element;
+            }}
+            type="button"
+            role="tab"
+            aria-selected={isSelected}
+            tabIndex={isSelected ? 0 : -1}
+            className={cn(
+              'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+              isSelected ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+            )}
+            onClick={() => setActiveContext(context.contextKey)}
+          >
+            {context.displayName}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/config/demo.config.ts
+++ b/src/config/demo.config.ts
@@ -10,30 +10,37 @@
 export const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true';
 
 export type DemoProfile = 'short-stay' | 'long-term' | 'dual';
+export type ExtendedDemoProfile = DemoProfile | 'admin' | 'triple';
 
 const ROLES_CLAIM = 'https://casazen.app/roles';
 
-const demoProfiles: Record<DemoProfile, { roles: string[] }> = {
+const demoProfiles: Record<ExtendedDemoProfile, { roles: string[] }> = {
   'short-stay': {
     roles: ['PropertyOwner'],
   },
   'long-term': {
     roles: ['LongTermLandlord'],
   },
+  admin: {
+    roles: ['Admin'],
+  },
   dual: {
     roles: ['PropertyOwner', 'LongTermLandlord'],
   },
+  triple: {
+    roles: ['PropertyOwner', 'LongTermLandlord', 'Admin'],
+  },
 };
 
-function resolveDemoProfile(): DemoProfile {
+function resolveDemoProfile(): ExtendedDemoProfile {
   const raw = import.meta.env.VITE_DEMO_PROFILE as string | undefined;
-  if (raw === 'short-stay' || raw === 'long-term' || raw === 'dual') {
-    return raw;
+  if (raw && raw in demoProfiles) {
+    return raw as ExtendedDemoProfile;
   }
   return 'long-term';
 }
 
-function buildDemoUser(profile: DemoProfile) {
+function buildDemoUser(profile: ExtendedDemoProfile) {
   const roles = demoProfiles[profile].roles;
   return {
     name: 'Demo User',
@@ -46,22 +53,22 @@ function buildDemoUser(profile: DemoProfile) {
 
 const DEMO_PROFILE_STORAGE_KEY = 'casazen:demo-profile';
 
-function resolveRuntimeDemoProfile(): DemoProfile | null {
+function resolveRuntimeDemoProfile(): ExtendedDemoProfile | null {
   if (typeof window === 'undefined') return null;
 
   const params = new URLSearchParams(window.location.search);
   const fromQuery = params.get('demoProfile');
-  if (fromQuery === 'short-stay' || fromQuery === 'long-term' || fromQuery === 'dual') {
+  if (fromQuery && fromQuery in demoProfiles) {
     sessionStorage.setItem(DEMO_PROFILE_STORAGE_KEY, fromQuery);
-    return fromQuery;
+    return fromQuery as ExtendedDemoProfile;
   }
 
   const stored = sessionStorage.getItem(DEMO_PROFILE_STORAGE_KEY);
-  if (stored === 'short-stay' || stored === 'long-term' || stored === 'dual') {
-    return stored;
+  if (stored && stored in demoProfiles) {
+    return stored as ExtendedDemoProfile;
   }
 
-  const runtime = (window as Window & { __E2E_DEMO_PROFILE?: DemoProfile }).__E2E_DEMO_PROFILE;
+  const runtime = (window as Window & { __E2E_DEMO_PROFILE?: ExtendedDemoProfile }).__E2E_DEMO_PROFILE;
   if (runtime && runtime in demoProfiles) {
     return runtime;
   }

--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -1,0 +1,247 @@
+export type AppContextKey = 'short-rent' | 'long-rent' | 'admin';
+
+export interface RouteManifestEntry {
+  path: string;
+  context: AppContextKey;
+  requiredPermissions: string[];
+  navLabel?: string;
+  icon?: string;
+  isDefault?: boolean;
+  component: () => Promise<{ default: React.ComponentType }>;
+  legacyPaths?: string[];
+}
+
+export const ROUTE_MANIFEST: RouteManifestEntry[] = [
+  {
+    path: '/app/short-rent',
+    context: 'short-rent',
+    requiredPermissions: [],
+    navLabel: 'Dashboard',
+    icon: 'LayoutDashboard',
+    isDefault: true,
+    component: async () => ({ default: (await import('@/features/dashboard/dashboard-page')).DashboardPage }),
+    legacyPaths: ['/', '/app/short-rent/'],
+  },
+  {
+    path: '/app/short-rent/properties',
+    context: 'short-rent',
+    requiredPermissions: ['property.read'],
+    navLabel: 'Proprietà',
+    icon: 'Home',
+    component: async () => ({ default: (await import('@/features/properties/properties-page')).PropertiesPage }),
+    legacyPaths: ['/properties'],
+  },
+  {
+    path: '/app/short-rent/properties/create',
+    context: 'short-rent',
+    requiredPermissions: ['property.write'],
+    component: async () => ({ default: (await import('@/features/properties/property-create-page')).PropertyCreatePage }),
+    legacyPaths: ['/properties/create'],
+  },
+  {
+    path: '/app/short-rent/properties/:id',
+    context: 'short-rent',
+    requiredPermissions: ['property.read'],
+    component: async () => ({ default: (await import('@/features/properties/property-detail-page')).PropertyDetailPage }),
+    legacyPaths: ['/properties/:id'],
+  },
+  {
+    path: '/app/short-rent/properties/:id/edit',
+    context: 'short-rent',
+    requiredPermissions: ['property.write'],
+    component: async () => ({ default: (await import('@/features/properties/property-edit-page')).PropertyEditPage }),
+    legacyPaths: ['/properties/:id/edit'],
+  },
+  {
+    path: '/app/short-rent/properties/:id/pricing',
+    context: 'short-rent',
+    requiredPermissions: ['property.read'],
+    component: async () => ({ default: (await import('@/features/pricing')).PricingDashboardPage }),
+    legacyPaths: ['/properties/:id/pricing'],
+  },
+  {
+    path: '/app/short-rent/properties/:id/pricing/history',
+    context: 'short-rent',
+    requiredPermissions: ['property.read'],
+    component: async () => ({ default: (await import('@/features/pricing')).PricingHistoryPage }),
+    legacyPaths: ['/properties/:id/pricing/history'],
+  },
+  {
+    path: '/app/short-rent/bookings',
+    context: 'short-rent',
+    requiredPermissions: ['booking.read'],
+    navLabel: 'Prenotazioni',
+    icon: 'Calendar',
+    component: async () => ({ default: (await import('@/features/bookings/bookings-page')).BookingsPage }),
+    legacyPaths: ['/bookings'],
+  },
+  {
+    path: '/app/short-rent/bookings/create',
+    context: 'short-rent',
+    requiredPermissions: ['booking.write'],
+    component: async () => ({ default: (await import('@/features/bookings/booking-create-page')).BookingCreatePage }),
+    legacyPaths: ['/bookings/create'],
+  },
+  {
+    path: '/app/short-rent/bookings/calendar',
+    context: 'short-rent',
+    requiredPermissions: ['booking.read'],
+    navLabel: 'Calendario',
+    icon: 'CalendarDays',
+    component: async () => ({ default: (await import('@/features/bookings/calendar-page')).CalendarPage }),
+    legacyPaths: ['/bookings/calendar'],
+  },
+  {
+    path: '/app/short-rent/bookings/:id',
+    context: 'short-rent',
+    requiredPermissions: ['booking.read'],
+    component: async () => ({ default: (await import('@/features/bookings/booking-detail-page')).BookingDetailPage }),
+    legacyPaths: ['/bookings/:id'],
+  },
+  {
+    path: '/app/short-rent/bookings/:id/edit',
+    context: 'short-rent',
+    requiredPermissions: ['booking.write'],
+    component: async () => ({ default: (await import('@/features/bookings/booking-edit-page')).BookingEditPage }),
+    legacyPaths: ['/bookings/:id/edit'],
+  },
+  {
+    path: '/app/short-rent/payments',
+    context: 'short-rent',
+    requiredPermissions: ['payment.read'],
+    navLabel: 'Pagamenti',
+    icon: 'CreditCard',
+    component: async () => ({ default: (await import('@/features/payments/payments-page')).PaymentsPage }),
+    legacyPaths: ['/payments'],
+  },
+  {
+    path: '/app/short-rent/payments/create',
+    context: 'short-rent',
+    requiredPermissions: ['payment.write'],
+    component: async () => ({ default: (await import('@/features/payments/payment-create-page')).PaymentCreatePage }),
+    legacyPaths: ['/payments/create'],
+  },
+  {
+    path: '/app/short-rent/payments/revenue',
+    context: 'short-rent',
+    requiredPermissions: ['payment.read'],
+    navLabel: 'Ricavi',
+    icon: 'ChartColumn',
+    component: async () => ({ default: (await import('@/features/payments/revenue-page')).RevenuePage }),
+    legacyPaths: ['/payments/revenue'],
+  },
+  {
+    path: '/app/short-rent/payments/:id',
+    context: 'short-rent',
+    requiredPermissions: ['payment.read'],
+    component: async () => ({ default: (await import('@/features/payments/payment-detail-page')).PaymentDetailPage }),
+    legacyPaths: ['/payments/:id'],
+  },
+  {
+    path: '/app/short-rent/ota',
+    context: 'short-rent',
+    requiredPermissions: ['ota.read'],
+    navLabel: 'OTA',
+    icon: 'Repeat',
+    component: async () => ({ default: (await import('@/features/ota/ota-page')).OtaPage }),
+    legacyPaths: ['/ota'],
+  },
+  {
+    path: '/app/short-rent/ota/create',
+    context: 'short-rent',
+    requiredPermissions: ['ota.write'],
+    component: async () => ({ default: (await import('@/features/ota/ota-setup-page')).OtaSetupPage }),
+    legacyPaths: ['/ota/create'],
+  },
+  {
+    path: '/app/short-rent/profile',
+    context: 'short-rent',
+    requiredPermissions: [],
+    navLabel: 'Profilo',
+    icon: 'User',
+    component: async () => ({ default: (await import('@/features/profile/profile-page')).ProfilePage }),
+    legacyPaths: ['/profile'],
+  },
+  {
+    path: '/app/long-rent/leases',
+    context: 'long-rent',
+    requiredPermissions: ['lease.read'],
+    navLabel: 'Contratti',
+    icon: 'FileText',
+    isDefault: true,
+    component: async () => ({ default: (await import('@/features/leases')).LeasesPage }),
+    legacyPaths: ['/leases'],
+  },
+  {
+    path: '/app/long-rent/leases/new',
+    context: 'long-rent',
+    requiredPermissions: ['lease.create'],
+    component: async () => ({ default: (await import('@/features/leases')).LeaseCreatePage }),
+    legacyPaths: ['/leases/new'],
+  },
+  {
+    path: '/app/long-rent/leases/:id',
+    context: 'long-rent',
+    requiredPermissions: ['lease.read'],
+    component: async () => ({ default: (await import('@/features/leases')).LeaseDetailPage }),
+    legacyPaths: ['/leases/:id'],
+  },
+  {
+    path: '/app/long-rent/profile',
+    context: 'long-rent',
+    requiredPermissions: [],
+    navLabel: 'Profilo',
+    icon: 'User',
+    component: async () => ({ default: (await import('@/features/profile/profile-content-page')).ProfileContentPage }),
+    legacyPaths: ['/profile'],
+  },
+  {
+    path: '/app/admin',
+    context: 'admin',
+    requiredPermissions: ['admin.stats.read'],
+    navLabel: 'Dashboard',
+    icon: 'LayoutDashboard',
+    isDefault: true,
+    component: async () => ({ default: (await import('@/features/admin/admin-dashboard-page')).AdminDashboardPage }),
+    legacyPaths: ['/admin'],
+  },
+  {
+    path: '/app/admin/users',
+    context: 'admin',
+    requiredPermissions: ['admin.users.read'],
+    navLabel: 'Utenti',
+    icon: 'Users',
+    component: async () => ({ default: (await import('@/features/admin/admin-users-page')).AdminUsersPage }),
+    legacyPaths: ['/admin/users'],
+  },
+  {
+    path: '/app/admin/cin',
+    context: 'admin',
+    requiredPermissions: ['admin.cin.read'],
+    navLabel: 'CIN',
+    icon: 'FileCheck',
+    component: async () => ({ default: (await import('@/features/admin/admin-cin-page')).AdminCinPage }),
+    legacyPaths: ['/admin/cin'],
+  },
+  {
+    path: '/app/admin/jobs',
+    context: 'admin',
+    requiredPermissions: ['admin.jobs.read'],
+    navLabel: 'Job',
+    icon: 'Settings',
+    component: async () => ({ default: (await import('@/features/admin/admin-jobs-page')).AdminJobsPage }),
+    legacyPaths: ['/admin/jobs'],
+  },
+];
+
+export function getDefaultRoute(contextKey: AppContextKey): string {
+  return ROUTE_MANIFEST.find((entry) => entry.context === contextKey && entry.isDefault)?.path ?? '/app/choose-context';
+}
+
+export function getNavEntries(contextKey: AppContextKey): RouteManifestEntry[] {
+  return ROUTE_MANIFEST.filter((entry) => entry.context === contextKey && !!entry.navLabel);
+}
+
+export function getManifestEntry(path: string): RouteManifestEntry | undefined {
+  return ROUTE_MANIFEST.find((entry) => entry.path === path);
+}

--- a/src/contexts/workspace-context.ts
+++ b/src/contexts/workspace-context.ts
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+import type { AppContextKey } from '@/config/route-manifest';
+import type { ContextBootstrapDto } from '@/api/contexts';
+
+export const ACTIVE_CONTEXT_STORAGE_KEY = 'casazen:active-context';
+export const LEGACY_ACTIVE_LAYER_STORAGE_KEY = 'casazen:active-layer';
+
+export interface WorkspaceContextValue {
+  contexts: ContextBootstrapDto[];
+  activeContext: AppContextKey | null;
+  isReady: boolean;
+  setActiveContext: (contextKey: AppContextKey, navigateToDefault?: boolean) => void;
+  hasPermission: (contextKey: AppContextKey, permission: string) => boolean;
+  getDefaultRoute: (contextKey: AppContextKey) => string;
+}
+
+export const WorkspaceContext = createContext<WorkspaceContextValue | undefined>(undefined);

--- a/src/contexts/workspace-provider.tsx
+++ b/src/contexts/workspace-provider.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { contextsApi, type ContextBootstrapDto } from '@/api/contexts';
+import { getDefaultRoute, type AppContextKey } from '@/config/route-manifest';
+import { getDemoUser, isDemoMode } from '@/config/demo.config';
+import { useAuth } from '@/hooks/use-auth';
+import { deriveContextsFromRoles, getUserRoles } from '@/lib/auth-roles';
+import {
+  ACTIVE_CONTEXT_STORAGE_KEY,
+  LEGACY_ACTIVE_LAYER_STORAGE_KEY,
+  WorkspaceContext,
+} from './workspace-context';
+
+function readStoredContext(): AppContextKey | null {
+  const stored = localStorage.getItem(ACTIVE_CONTEXT_STORAGE_KEY);
+  if (stored === 'short-rent' || stored === 'long-rent' || stored === 'admin') {
+    return stored;
+  }
+
+  const legacy = localStorage.getItem(LEGACY_ACTIVE_LAYER_STORAGE_KEY);
+  if (legacy === 'short-stay') {
+    return 'short-rent';
+  }
+  if (legacy === 'long-term') {
+    return 'long-rent';
+  }
+  return null;
+}
+
+export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const roleSignature = useMemo(() => {
+    const authUser = isDemoMode ? getDemoUser() : user;
+    return getUserRoles(authUser).slice().sort().join('|');
+  }, [isDemoMode, location.search, user]);
+  const [contexts, setContexts] = useState<ContextBootstrapDto[]>([]);
+  const [activeContext, setActiveContextState] = useState<AppContextKey | null>(readStoredContext);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadContexts = async () => {
+      const authUser = isDemoMode ? getDemoUser() : user;
+
+      if (isDemoMode) {
+        const fallback = deriveContextsFromRoles(authUser);
+        if (!mounted) return;
+        setContexts(fallback);
+        const stored = readStoredContext();
+        const resolved = fallback.some((c) => c.contextKey === stored)
+          ? stored
+          : fallback[0]?.contextKey ?? null;
+        setActiveContextState(resolved);
+        if (resolved) {
+          localStorage.setItem(ACTIVE_CONTEXT_STORAGE_KEY, resolved);
+        }
+        setIsReady(true);
+        return;
+      }
+
+      try {
+        const bootstrap = await contextsApi.getContexts();
+        if (!mounted) return;
+        setContexts(bootstrap.contexts);
+
+        const stored = readStoredContext();
+        const preferred = bootstrap.lastUsedContextKey ?? stored;
+        const resolved = bootstrap.contexts.some((c) => c.contextKey === preferred)
+          ? preferred ?? null
+          : bootstrap.contexts[0]?.contextKey ?? null;
+        setActiveContextState(resolved);
+        if (resolved) {
+          localStorage.setItem(ACTIVE_CONTEXT_STORAGE_KEY, resolved);
+        }
+      } catch {
+        if (!mounted) return;
+        const fallback = deriveContextsFromRoles(authUser);
+        setContexts(fallback);
+        const stored = readStoredContext();
+        const resolved = fallback.some((c) => c.contextKey === stored)
+          ? stored
+          : fallback[0]?.contextKey ?? null;
+        setActiveContextState(resolved);
+        if (resolved) {
+          localStorage.setItem(ACTIVE_CONTEXT_STORAGE_KEY, resolved);
+        }
+      } finally {
+        if (mounted) {
+          setIsReady(true);
+        }
+      }
+    };
+
+    void loadContexts();
+    return () => {
+      mounted = false;
+    };
+  }, [roleSignature]);
+
+  const setActiveContext = useCallback(
+    (contextKey: AppContextKey, navigateToDefault = true) => {
+      if (!contexts.some((c) => c.contextKey === contextKey)) {
+        return;
+      }
+
+      setActiveContextState((previous) => (previous === contextKey ? previous : contextKey));
+      localStorage.setItem(ACTIVE_CONTEXT_STORAGE_KEY, contextKey);
+      if (navigateToDefault) {
+        const target = contexts.find((c) => c.contextKey === contextKey)?.defaultRoute ?? getDefaultRoute(contextKey);
+        navigate(target, { replace: true });
+      }
+    },
+    [contexts, navigate],
+  );
+
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    const match = location.pathname.match(/^\/app\/(short-rent|long-rent|admin)(?:\/|$)/);
+    if (!match) {
+      return;
+    }
+
+    const fromUrl = match[1] as AppContextKey;
+    if (!contexts.some((c) => c.contextKey === fromUrl)) {
+      return;
+    }
+
+    setActiveContextState((previous) => (previous === fromUrl ? previous : fromUrl));
+    localStorage.setItem(ACTIVE_CONTEXT_STORAGE_KEY, fromUrl);
+  }, [contexts, isReady, location.pathname]);
+
+  const hasPermission = useCallback(
+    (contextKey: AppContextKey, permission: string) => {
+      const ctx = contexts.find((c) => c.contextKey === contextKey);
+      if (!ctx) return false;
+      if (!permission) return true;
+      return ctx.permissions.includes(permission);
+    },
+    [contexts],
+  );
+
+  const getDefaultContextRoute = useCallback(
+    (contextKey: AppContextKey) => contexts.find((c) => c.contextKey === contextKey)?.defaultRoute ?? getDefaultRoute(contextKey),
+    [contexts],
+  );
+
+  const value = useMemo(
+    () => ({
+      contexts,
+      activeContext,
+      isReady,
+      setActiveContext,
+      hasPermission,
+      getDefaultRoute: getDefaultContextRoute,
+    }),
+    [activeContext, contexts, getDefaultContextRoute, hasPermission, isReady, setActiveContext],
+  );
+
+  return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
+}

--- a/src/features/bookings/booking-create-page.tsx
+++ b/src/features/bookings/booking-create-page.tsx
@@ -11,7 +11,7 @@ export function BookingCreatePage() {
 
   const handleSubmit = async (data: BookingFormValues) => {
     await createBooking.mutateAsync(data);
-    navigate('/bookings');
+    navigate('/app/short-rent/bookings');
   };
 
   return (

--- a/src/features/bookings/booking-edit-page.tsx
+++ b/src/features/bookings/booking-edit-page.tsx
@@ -15,7 +15,7 @@ export function BookingEditPage() {
   const handleSubmit = async (data: BookingFormValues) => {
     if (id) {
       await updateBooking.mutateAsync({ id, data });
-      navigate('/bookings');
+      navigate('/app/short-rent/bookings');
     }
   };
 

--- a/src/features/bookings/calendar-page.tsx
+++ b/src/features/bookings/calendar-page.tsx
@@ -13,7 +13,7 @@ export function CalendarPage() {
 
   const handleSelectEvent = (event: BookingCalendarEvent) => {
     if (event.resource) {
-      navigate(`/bookings/${event.resource.id}`);
+      navigate(`/app/short-rent/bookings/${event.resource.id}`);
     }
   };
 
@@ -29,7 +29,7 @@ export function CalendarPage() {
           title="Bookings Calendar"
           description="View and manage bookings in calendar format"
           action={
-            <Button variant="outline" onClick={() => navigate('/bookings')}>
+            <Button variant="outline" onClick={() => navigate('/app/short-rent/bookings')}>
               <List className="mr-2 h-4 w-4" />
               List View
             </Button>

--- a/src/features/leases/lease-detail-page.tsx
+++ b/src/features/leases/lease-detail-page.tsx
@@ -39,7 +39,7 @@ export function LeaseDetailPage() {
         <p className="text-muted-foreground">
           The lease you are looking for does not exist or you do not have access.
         </p>
-        <Button className="mt-4" variant="outline" onClick={() => navigate('/leases')}>
+        <Button className="mt-4" variant="outline" onClick={() => navigate('/app/long-rent/leases')}>
           Back to leases
         </Button>
       </div>
@@ -72,7 +72,7 @@ export function LeaseDetailPage() {
   return (
     <div className="space-y-6">
         <div className="flex items-center gap-3">
-          <Button variant="ghost" size="icon" onClick={() => navigate('/leases')}>
+          <Button variant="ghost" size="icon" onClick={() => navigate('/app/long-rent/leases')}>
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <PageHeader

--- a/src/features/leases/leases-page.tsx
+++ b/src/features/leases/leases-page.tsx
@@ -31,7 +31,7 @@ export function LeasesPage() {
           title="Long-term leases"
           description="Manage contract drafts, signing, and RLI registration"
           action={
-            <Button onClick={() => navigate('/leases/new')}>
+            <Button onClick={() => navigate('/app/long-rent/leases/new')}>
               <Plus className="mr-2 h-4 w-4" />
               Create lease
             </Button>
@@ -51,7 +51,7 @@ export function LeasesPage() {
             description="Create your first long-term lease contract draft to start the signing and registration workflow."
             action={{
               label: 'Create lease',
-              onClick: () => navigate('/leases/new'),
+              onClick: () => navigate('/app/long-rent/leases/new'),
             }}
           />
         ) : (
@@ -60,7 +60,7 @@ export function LeasesPage() {
               <Card
                 key={lease.id}
                 className="cursor-pointer transition-colors hover:bg-muted/40"
-                onClick={() => navigate(`/leases/${lease.id}`)}
+                onClick={() => navigate(`/app/long-rent/leases/${lease.id}`)}
               >
                 <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
                   <div className="space-y-1">

--- a/src/features/ota/ota-setup-page.tsx
+++ b/src/features/ota/ota-setup-page.tsx
@@ -38,7 +38,7 @@ export function OtaSetupPage() {
 
   const onSubmit = async (data: OtaIntegrationFormValues) => {
     await createIntegration.mutateAsync(data);
-    navigate('/ota');
+    navigate('/app/short-rent/ota');
   };
 
   return (
@@ -176,7 +176,7 @@ export function OtaSetupPage() {
           )}
 
           <div className="flex justify-end gap-4">
-            <Button type="button" variant="outline" onClick={() => navigate('/ota')}>
+            <Button type="button" variant="outline" onClick={() => navigate('/app/short-rent/ota')}>
               Cancel
             </Button>
             <Button type="submit" disabled={createIntegration.isPending}>

--- a/src/features/payments/payment-create-page.tsx
+++ b/src/features/payments/payment-create-page.tsx
@@ -32,7 +32,7 @@ export function PaymentCreatePage() {
 
   const onSubmit = async (data: PaymentFormValues) => {
     await createPayment.mutateAsync(data);
-    navigate('/payments');
+    navigate('/app/short-rent/payments');
   };
 
   return (
@@ -126,7 +126,7 @@ export function PaymentCreatePage() {
           </Card>
 
           <div className="flex justify-end gap-4">
-            <Button type="button" variant="outline" onClick={() => navigate('/payments')}>
+            <Button type="button" variant="outline" onClick={() => navigate('/app/short-rent/payments')}>
               Cancel
             </Button>
             <Button type="submit" disabled={createPayment.isPending}>

--- a/src/features/payments/revenue-page.tsx
+++ b/src/features/payments/revenue-page.tsx
@@ -30,7 +30,7 @@ export function RevenuePage() {
           title="Revenue Analytics"
           description="Track and analyze your revenue performance"
           action={
-            <Button variant="outline" onClick={() => navigate('/payments')}>
+            <Button variant="outline" onClick={() => navigate('/app/short-rent/payments')}>
               <ArrowLeft className="mr-2 h-4 w-4" />
               Back to Payments
             </Button>

--- a/src/features/pricing/__tests__/pricing-dashboard-page.test.tsx
+++ b/src/features/pricing/__tests__/pricing-dashboard-page.test.tsx
@@ -4,11 +4,11 @@ import { createElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { PricingDashboardPage } from '../pricing-dashboard-page';
-import * as pricingQueries from '@/queries/pricingAdapter';
+import * as pricingQueries from '@/queries/use-pricing-adapter';
 import type { PricingAdapterConfig, PricingPreviewResponse } from '@/types';
 import type { PricingHistoryPagedResponse } from '@/types';
 
-vi.mock('@/queries/pricingAdapter');
+vi.mock('@/queries/use-pricing-adapter');
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock('@/components/layout/app-shell', () => ({
   AppShell: ({ children }: { children: React.ReactNode }) => createElement('div', { 'data-testid': 'app-shell' }, children),
@@ -111,7 +111,7 @@ function setupAllMocks(overrides: Partial<{
   vi.mocked(pricingQueries.usePricingAdapterConfig).mockReturnValue({ data: configData, isLoading: configLoading } as any);
   vi.mocked(pricingQueries.usePricingPreview).mockReturnValue({ data: previewData, isLoading: false } as any);
   vi.mocked(pricingQueries.usePricingHistory).mockReturnValue({ data: historyData, isLoading: false } as any);
-  vi.mocked(pricingQueries.useUpdatePricingAdapterConfig).mockReturnValue({ ...noopMutation(), mutate: updateMutate } as any);
+  vi.mocked(pricingQueries.useSavePricingAdapterConfig).mockReturnValue({ ...noopMutation(), mutate: updateMutate } as any);
   vi.mocked(pricingQueries.useDisablePricingAdapter).mockReturnValue({ ...noopMutation(), mutate: disableMutate } as any);
   vi.mocked(pricingQueries.useTriggerPricingSync).mockReturnValue({ ...noopMutation(), mutate: syncMutate } as any);
 }
@@ -237,7 +237,7 @@ describe('PricingDashboardPage', () => {
     vi.mocked(pricingQueries.usePricingAdapterConfig).mockReturnValue({ data: mockConfig, isLoading: false } as any);
     vi.mocked(pricingQueries.usePricingPreview).mockReturnValue({ data: mockPreview, isLoading: false } as any);
     vi.mocked(pricingQueries.usePricingHistory).mockReturnValue({ data: undefined, isLoading: true } as any);
-    vi.mocked(pricingQueries.useUpdatePricingAdapterConfig).mockReturnValue(noopMutation() as any);
+    vi.mocked(pricingQueries.useSavePricingAdapterConfig).mockReturnValue(noopMutation() as any);
     vi.mocked(pricingQueries.useDisablePricingAdapter).mockReturnValue(noopMutation() as any);
     vi.mocked(pricingQueries.useTriggerPricingSync).mockReturnValue(noopMutation() as any);
 

--- a/src/features/profile/profile-content-page.tsx
+++ b/src/features/profile/profile-content-page.tsx
@@ -1,0 +1,23 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { ProfileInfo } from './components/profile-info';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import { useAuth } from '@/hooks/use-auth';
+
+export function ProfileContentPage() {
+  const { isLoading, user } = useAuth();
+
+  if (isLoading || !user) {
+    return <LoadingScreen />;
+  }
+
+  return (
+    <div className="space-y-6 max-w-3xl mx-auto">
+      <PageHeader
+        title="My Profile"
+        description="View and manage your account information"
+      />
+
+      <ProfileInfo user={user} />
+    </div>
+  );
+}

--- a/src/features/properties/property-create-page.tsx
+++ b/src/features/properties/property-create-page.tsx
@@ -11,7 +11,7 @@ export function PropertyCreatePage() {
 
   const handleSubmit = async (data: PropertyFormValues) => {
     await createProperty.mutateAsync(data);
-    navigate('/properties');
+    navigate('/app/short-rent/properties');
   };
 
   return (

--- a/src/features/properties/property-edit-page.tsx
+++ b/src/features/properties/property-edit-page.tsx
@@ -15,7 +15,7 @@ export function PropertyEditPage() {
   const handleSubmit = async (data: PropertyFormValues) => {
     if (id) {
       await updateProperty.mutateAsync({ id, data });
-      navigate('/properties');
+      navigate('/app/short-rent/properties');
     }
   };
 

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { setAccessTokenGetter } from '@/lib/axios';
 import { isDemoMode, getDemoUser } from '@/config/demo.config';
 
@@ -39,12 +39,14 @@ export function useAuth() {
     });
   };
 
+  const demoUser = useMemo(() => getDemoUser(), [typeof window !== 'undefined' ? window.location.href : '']);
+
   // In demo mode, return mock authentication state
   if (isDemoMode) {
     return {
       isLoading: false,
       isAuthenticated: true,
-      user: getDemoUser(),
+      user: demoUser,
       login: () => console.log('Demo mode: login simulation'),
       logout,
       getAccessToken: async () => 'demo-token',

--- a/src/hooks/use-workspace.ts
+++ b/src/hooks/use-workspace.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { WorkspaceContext } from '@/contexts/workspace-context';
+
+export function useWorkspace() {
+  const context = useContext(WorkspaceContext);
+  if (!context) {
+    throw new Error('useWorkspace must be used within WorkspaceProvider');
+  }
+  return context;
+}

--- a/src/lib/__tests__/auth-roles.test.ts
+++ b/src/lib/__tests__/auth-roles.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import {
   getUserRoles,
   hasRole,
+  deriveContextsFromRoles,
   isDualRole,
   isLongTermOnly,
   isShortStayOnly,
   ROLES_CLAIM,
+  ROLE_ADMIN,
   ROLE_LONG_TERM_LANDLORD,
   ROLE_PROPERTY_OWNER,
 } from '../auth-roles';
@@ -47,5 +49,14 @@ describe('auth-roles', () => {
     expect(isDualRole(user)).toBe(true);
     expect(isShortStayOnly(user)).toBe(false);
     expect(isLongTermOnly(user)).toBe(false);
+  });
+
+  it('derives workspace contexts from JWT roles', () => {
+    const user = { roles: [ROLE_PROPERTY_OWNER, ROLE_ADMIN] };
+    const contexts = deriveContextsFromRoles(user);
+
+    expect(contexts).toHaveLength(2);
+    expect(contexts.some((c) => c.contextKey === 'short-rent')).toBe(true);
+    expect(contexts.some((c) => c.contextKey === 'admin')).toBe(true);
   });
 });

--- a/src/lib/auth-roles.ts
+++ b/src/lib/auth-roles.ts
@@ -40,3 +40,66 @@ export function isDualRole(user: UserWithRoles): boolean {
 export function isAdmin(user: UserWithRoles): boolean {
   return hasRole(user, ROLE_ADMIN);
 }
+
+export interface DerivedContext {
+  contextKey: 'short-rent' | 'long-rent' | 'admin';
+  displayName: string;
+  roleKey: string;
+  permissions: string[];
+  defaultRoute: string;
+}
+
+export function deriveContextsFromRoles(user: UserWithRoles): DerivedContext[] {
+  const roles = getUserRoles(user);
+  const contexts: DerivedContext[] = [];
+
+  if (roles.includes(ROLE_PROPERTY_OWNER)) {
+    contexts.push({
+      contextKey: 'short-rent',
+      displayName: 'Affitti brevi',
+      roleKey: 'property_owner',
+      permissions: [
+        'property.read',
+        'property.write',
+        'booking.read',
+        'booking.write',
+        'payment.read',
+        'payment.write',
+        'ota.read',
+        'ota.write',
+        'guest.read',
+        'guest.write',
+      ],
+      defaultRoute: '/app/short-rent',
+    });
+  }
+
+  if (roles.includes(ROLE_LONG_TERM_LANDLORD)) {
+    contexts.push({
+      contextKey: 'long-rent',
+      displayName: 'Affitti lungo termine',
+      roleKey: 'long_term_landlord',
+      permissions: ['lease.read', 'lease.create', 'lease.sign', 'lease.register'],
+      defaultRoute: '/app/long-rent/leases',
+    });
+  }
+
+  if (roles.includes(ROLE_ADMIN)) {
+    contexts.push({
+      contextKey: 'admin',
+      displayName: 'Amministrazione',
+      roleKey: 'platform_admin',
+      permissions: [
+        'admin.stats.read',
+        'admin.users.read',
+        'admin.users.manage',
+        'admin.cin.read',
+        'admin.jobs.read',
+        'admin.tax.manage',
+      ],
+      defaultRoute: '/app/admin',
+    });
+  }
+
+  return contexts;
+}

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,0 +1,11 @@
+export function decodeJwtPayload(token: string): Record<string, unknown> {
+  const segment = token.split('.')[1];
+  if (!segment) {
+    throw new Error('Invalid JWT: missing payload segment');
+  }
+
+  const normalized = segment.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+  const json = atob(padded);
+  return JSON.parse(json) as Record<string, unknown>;
+}

--- a/src/pages/context-picker-page.tsx
+++ b/src/pages/context-picker-page.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useWorkspace } from '@/hooks/use-workspace';
+import { Navigate } from 'react-router-dom';
+
+export function ContextPickerPage() {
+  const { contexts, isReady, setActiveContext } = useWorkspace();
+
+  if (!isReady) {
+    return null;
+  }
+
+  if (contexts.length === 0) {
+    return <Navigate to="/app/no-access" replace />;
+  }
+
+  if (contexts.length === 1) {
+    return <Navigate to={contexts[0].defaultRoute} replace />;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/20 px-4">
+      <Card className="w-full max-w-xl">
+        <CardHeader>
+          <CardTitle>Seleziona workspace</CardTitle>
+          <CardDescription>Scegli il contesto applicativo da aprire.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {contexts.map((context) => (
+            <Button
+              key={context.contextKey}
+              variant="outline"
+              className="w-full justify-start"
+              onClick={() => setActiveContext(context.contextKey)}
+            >
+              {context.displayName}
+            </Button>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -3,7 +3,6 @@ import { useAuth } from '@/hooks/use-auth';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { getDefaultHomePath, resolveInitialLayer } from '@/hooks/use-app-layer';
 import { Home, LogIn } from 'lucide-react';
 
 export function LoginPage() {
@@ -12,8 +11,7 @@ export function LoginPage() {
 
   useEffect(() => {
     if (isAuthenticated && user) {
-      const layer = resolveInitialLayer(user);
-      navigate(getDefaultHomePath(layer), { replace: true });
+      navigate('/app/choose-context', { replace: true });
     }
   }, [isAuthenticated, user, navigate]);
 

--- a/src/pages/no-access-page.tsx
+++ b/src/pages/no-access-page.tsx
@@ -1,0 +1,23 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+
+export function NoAccessPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/20 px-4">
+      <Card className="w-full max-w-lg text-center">
+        <CardHeader>
+          <CardTitle>Nessun accesso disponibile</CardTitle>
+          <CardDescription>
+            Il tuo account non e associato ad alcun workspace operativo.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={() => navigate('/login', { replace: true })}>Torna al login</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,35 +1,39 @@
-import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
+import { createBrowserRouter, Navigate, Outlet, type RouteObject } from 'react-router-dom';
 import { ProtectedRoute } from '@/components/auth/protected-route';
-import { ShortStayLayerGuard } from '@/components/auth/short-stay-layer-guard';
-import { LongTermAppShell } from '@/components/layout/long-term-app-shell';
-import { AdminAppShell } from '@/components/layout/admin-app-shell';
-import { AppLayerProvider } from '@/contexts/app-layer-provider';
-import { AdminDashboardPage } from '@/features/admin/admin-dashboard-page';
-import { AdminUsersPage } from '@/features/admin/admin-users-page';
-import { AdminCinPage } from '@/features/admin/admin-cin-page';
-import { AdminJobsPage } from '@/features/admin/admin-jobs-page';
 import { LoginPage } from '@/pages/login-page';
-import { DashboardPage } from '@/features/dashboard/dashboard-page';
-import { PropertiesPage } from '@/features/properties/properties-page';
-import { PropertyCreatePage } from '@/features/properties/property-create-page';
-import { PropertyEditPage } from '@/features/properties/property-edit-page';
-import { PropertyDetailPage } from '@/features/properties/property-detail-page';
-import { BookingsPage } from '@/features/bookings/bookings-page';
-import { BookingCreatePage } from '@/features/bookings/booking-create-page';
-import { BookingEditPage } from '@/features/bookings/booking-edit-page';
-import { BookingDetailPage } from '@/features/bookings/booking-detail-page';
-import { CalendarPage } from '@/features/bookings/calendar-page';
-import { PaymentsPage } from '@/features/payments/payments-page';
-import { PaymentCreatePage } from '@/features/payments/payment-create-page';
-import { PaymentDetailPage } from '@/features/payments/payment-detail-page';
-import { RevenuePage } from '@/features/payments/revenue-page';
-import { OtaPage } from '@/features/ota/ota-page';
-import { OtaSetupPage } from '@/features/ota/ota-setup-page';
 import { SearchPage } from '@/features/search/search-page';
-import { LayerAwareProfilePage } from '@/features/profile/layer-aware-profile-page';
-import { PricingDashboardPage } from '@/features/pricing';
-import { PricingHistoryPage } from '@/features/pricing';
-import { LeasesPage, LeaseCreatePage, LeaseDetailPage } from '@/features/leases';
+import { WorkspaceProvider } from '@/contexts/workspace-provider';
+import { ContextLayout } from '@/components/layout/context-layout';
+import { ContextRouteGuard } from '@/components/auth/context-route-guard';
+import { ContextPickerPage } from '@/pages/context-picker-page';
+import { NoAccessPage } from '@/pages/no-access-page';
+import { ROUTE_MANIFEST, type AppContextKey } from '@/config/route-manifest';
+import { LegacyRedirect } from './legacy-redirect';
+import { ManifestRoute } from './manifest-route';
+
+function buildContextChildren(contextKey: AppContextKey): RouteObject[] {
+  const prefix = `/app/${contextKey}`;
+  const entries = ROUTE_MANIFEST.filter((entry) => entry.context === contextKey);
+
+  return entries.map((entry) => {
+    const relativePath = entry.path === prefix ? '' : entry.path.slice(`${prefix}/`.length);
+    return {
+      path: relativePath,
+      element: (
+        <ContextRouteGuard contextKey={contextKey} requiredPermissions={entry.requiredPermissions}>
+          <ManifestRoute entry={entry} />
+        </ContextRouteGuard>
+      ),
+    } satisfies RouteObject;
+  });
+}
+
+const legacyPaths = Array.from(
+  new Set(
+    ROUTE_MANIFEST.flatMap((entry) => entry.legacyPaths ?? [])
+      .filter((path) => path !== '/'),
+  ),
+);
 
 export const router = createBrowserRouter([
   {
@@ -41,145 +45,69 @@ export const router = createBrowserRouter([
     element: <SearchPage />,
   },
   {
+    path: '/app',
     element: (
       <ProtectedRoute>
-        <AppLayerProvider>
+        <WorkspaceProvider>
           <Outlet />
-        </AppLayerProvider>
+        </WorkspaceProvider>
       </ProtectedRoute>
     ),
     children: [
       {
-        element: <ShortStayLayerGuard />,
+        path: 'choose-context',
+        element: <ContextPickerPage />,
+      },
+      {
+        path: 'no-access',
+        element: <NoAccessPage />,
+      },
+      {
+        path: 'short-rent',
+        element: <ContextLayout />,
         children: [
-          {
-            path: '/',
-            element: <DashboardPage />,
-          },
-          {
-            path: '/properties',
-            element: <PropertiesPage />,
-          },
-          {
-            path: '/properties/create',
-            element: <PropertyCreatePage />,
-          },
-          {
-            path: '/properties/:id',
-            element: <PropertyDetailPage />,
-          },
-          {
-            path: '/properties/:id/edit',
-            element: <PropertyEditPage />,
-          },
-          {
-            path: '/properties/:id/pricing',
-            element: <PricingDashboardPage />,
-          },
-          {
-            path: '/properties/:id/pricing/history',
-            element: <PricingHistoryPage />,
-          },
-          {
-            path: '/bookings',
-            element: <BookingsPage />,
-          },
-          {
-            path: '/bookings/create',
-            element: <BookingCreatePage />,
-          },
-          {
-            path: '/bookings/calendar',
-            element: <CalendarPage />,
-          },
-          {
-            path: '/bookings/:id',
-            element: <BookingDetailPage />,
-          },
-          {
-            path: '/bookings/:id/edit',
-            element: <BookingEditPage />,
-          },
-          {
-            path: '/payments',
-            element: <PaymentsPage />,
-          },
-          {
-            path: '/payments/create',
-            element: <PaymentCreatePage />,
-          },
-          {
-            path: '/payments/revenue',
-            element: <RevenuePage />,
-          },
-          {
-            path: '/payments/:id',
-            element: <PaymentDetailPage />,
-          },
-          {
-            path: '/ota',
-            element: <OtaPage />,
-          },
-          {
-            path: '/ota/create',
-            element: <OtaSetupPage />,
-          },
+          ...buildContextChildren('short-rent'),
         ],
       },
       {
-        path: '/profile',
-        element: <LayerAwareProfilePage />,
-      },
-      {
-        element: (
-          <ProtectedRoute role="LongTermLandlord">
-            <LongTermAppShell />
-          </ProtectedRoute>
-        ),
+        path: 'long-rent',
+        element: <ContextLayout />,
         children: [
-          {
-            path: '/leases',
-            element: <LeasesPage />,
-          },
-          {
-            path: '/leases/new',
-            element: <LeaseCreatePage />,
-          },
-          {
-            path: '/leases/:id',
-            element: <LeaseDetailPage />,
-          },
+          ...buildContextChildren('long-rent'),
         ],
       },
       {
-        element: (
-          <ProtectedRoute role="Admin">
-            <AdminAppShell />
-          </ProtectedRoute>
-        ),
+        path: 'admin',
+        element: <ContextLayout />,
         children: [
-          {
-            path: '/admin',
-            element: <AdminDashboardPage />,
-          },
-          {
-            path: '/admin/users',
-            element: <AdminUsersPage />,
-          },
-          {
-            path: '/admin/cin',
-            element: <AdminCinPage />,
-          },
-          {
-            path: '/admin/jobs',
-            element: <AdminJobsPage />,
-          },
+          ...buildContextChildren('admin'),
         ],
       },
     ],
   },
   {
+    element: (
+      <ProtectedRoute>
+        <WorkspaceProvider>
+          <LegacyRedirect />
+        </WorkspaceProvider>
+      </ProtectedRoute>
+    ),
+    children: [],
+    path: '/',
+  },
+  ...legacyPaths.map((path) => ({
+    path,
+    element: (
+      <ProtectedRoute>
+        <WorkspaceProvider>
+          <LegacyRedirect />
+        </WorkspaceProvider>
+      </ProtectedRoute>
+    ),
+  })),
+  {
     path: '*',
-    element: <Navigate to="/" replace />,
+    element: <Navigate to="/app/choose-context" replace />,
   },
 ]);

--- a/src/routes/legacy-redirect.tsx
+++ b/src/routes/legacy-redirect.tsx
@@ -1,0 +1,42 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { matchPath } from 'react-router-dom';
+import { ROUTE_MANIFEST } from '@/config/route-manifest';
+import { useWorkspace } from '@/hooks/use-workspace';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+
+export function LegacyRedirect() {
+  const location = useLocation();
+  const { contexts, activeContext, isReady, getDefaultRoute } = useWorkspace();
+
+  if (!isReady) {
+    return <LoadingScreen message="Loading workspace..." />;
+  }
+
+  if (contexts.length === 0) {
+    return <Navigate to="/app/no-access" replace />;
+  }
+
+  if (location.pathname === '/') {
+    const targetContext = activeContext ?? contexts[0].contextKey;
+    return <Navigate to={getDefaultRoute(targetContext)} replace />;
+  }
+
+  for (const entry of ROUTE_MANIFEST) {
+    for (const legacyPath of entry.legacyPaths ?? []) {
+      const match = matchPath({ path: legacyPath, end: true }, location.pathname);
+      if (match) {
+        const canAccessContext = contexts.some((c) => c.contextKey === entry.context);
+        if (!canAccessContext) {
+          const fallback = activeContext ?? contexts[0].contextKey;
+          return <Navigate to={getDefaultRoute(fallback)} replace />;
+        }
+        const resolved = Object.entries(match.params).reduce((acc, [key, value]) => {
+          return acc.replace(`:${key}`, value ?? '');
+        }, entry.path);
+        return <Navigate to={resolved} replace />;
+      }
+    }
+  }
+
+  return <Navigate to="/app/choose-context" replace />;
+}

--- a/src/routes/manifest-route.tsx
+++ b/src/routes/manifest-route.tsx
@@ -1,0 +1,16 @@
+import { Suspense, lazy, type ComponentType, type LazyExoticComponent } from 'react';
+import { ROUTE_MANIFEST, type RouteManifestEntry } from '@/config/route-manifest';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+
+const LAZY_ROUTE_COMPONENTS: Record<string, LazyExoticComponent<ComponentType>> = Object.fromEntries(
+  ROUTE_MANIFEST.map((entry) => [entry.path, lazy(entry.component)]),
+);
+
+export function ManifestRoute({ entry }: { entry: RouteManifestEntry }) {
+  const Component = LAZY_ROUTE_COMPONENTS[entry.path];
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <Component />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- Phase A: canonical routes under `/app/:context/*`, centralized route manifest, workspace switcher (IT labels), legacy redirects, post-login context flow.
- Wires `GET /api/me/contexts` with JWT stub fallback in demo mode.

## Backend PR
https://github.com/casazen/backend/pull/190

## Test Plan
- [x] `npm test` (92 passed)
- [x] `npm run build`
- [x] `npm run test:e2e` (17 passed, 7 skipped)

## AC to E2E Coverage Table
| AC | Description | E2E file | Test name | Status |
|---|---|---|---|---|
| AC1 | Context-prefixed routes | context-workspace-switch.spec.ts | legacy /leases redirect | pass |
| AC2 | Route manifest nav | long-term-layer.spec.ts | AC1 short-stay nav | pass |
| AC3 | Workspace switcher | context-workspace-switch.spec.ts | dual-role switch | pass |
| AC4 | Post-login flow | long-term-layer.spec.ts | AC2 long-term home | pass |
| AC5 | 403/deep link guard | context-workspace-switch.spec.ts | long-rent blocked from short-rent | pass |
| AC6 | Backend auth | N/A (no UI) | — | N/A |
| AC7 | Legacy redirects | long-term-layer.spec.ts | AC5 /leases redirect | pass |

Closes casazen/backend#189