### PR TITLE
feat(auth): role-based onboarding UI (#198)

### DIFF
--- a/e2e/helpers/demo-profile.ts
+++ b/e2e/helpers/demo-profile.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-export type DemoProfile = 'short-stay' | 'long-term' | 'dual' | 'admin' | 'triple';
+export type DemoProfile = 'short-stay' | 'long-term' | 'dual' | 'admin' | 'triple' | 'onboarding';
 
 export function demoUrl(path: string, profile: DemoProfile): string {
   const separator = path.includes('?') ? '&' : '?';

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { demoUrl } from './helpers/demo-profile';
+
+test.describe('Role-based onboarding (#198)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  });
+
+  test('AC1 user with no roles is redirected to onboarding', async ({ page }) => {
+    await page.goto(demoUrl('/', 'onboarding'));
+
+    await expect(page).toHaveURL(/\/onboarding/, { timeout: 15_000 });
+    await expect(page.getByRole('heading', { name: /Come vuoi usare CasaZen/i })).toBeVisible();
+  });
+
+  test('AC2 onboarding shows three rental type cards', async ({ page }) => {
+    await page.goto(demoUrl('/onboarding', 'onboarding'));
+
+    await expect(page.getByRole('button', { name: 'Scegli' })).toHaveCount(3);
+    await expect(page.getByText('Affitti brevi')).toBeVisible();
+    await expect(page.getByText('Locazioni di lungo periodo')).toBeVisible();
+    await expect(page.getByText('Entrambi')).toBeVisible();
+  });
+
+  test('AC3 short-term choice navigates to short-rent home', async ({ page }) => {
+    await page.goto(demoUrl('/onboarding', 'onboarding'));
+
+    await page.getByRole('button', { name: 'Scegli' }).first().click();
+    await expect(page).toHaveURL(/\/app\/short-rent/, { timeout: 15_000 });
+  });
+
+  test('AC3 long-term choice navigates to leases home', async ({ page }) => {
+    await page.goto(demoUrl('/onboarding', 'onboarding'));
+
+    await page.getByRole('button', { name: 'Scegli' }).nth(1).click();
+    await expect(page).toHaveURL(/\/app\/long-rent\/leases/, { timeout: 15_000 });
+  });
+
+  test('AC5 user with roles visiting onboarding is redirected away', async ({ page }) => {
+    await page.goto(demoUrl('/onboarding', 'short-stay'));
+
+    await expect(page).not.toHaveURL(/\/onboarding$/, { timeout: 15_000 });
+    await expect(page).toHaveURL(/\/app\/short-rent/);
+  });
+});

--- a/src/api/users.api.ts
+++ b/src/api/users.api.ts
@@ -1,5 +1,13 @@
 import { ApiClient } from '@/api/client';
-import type { UserDetail, UserSummary, UpdateProfileRequest, ChangeRoleRequest, PagedResult } from '@/types';
+import type {
+  UserDetail,
+  UserSummary,
+  UpdateProfileRequest,
+  ChangeRoleRequest,
+  PagedResult,
+  RentalType,
+  OnboardingResponse,
+} from '@/types';
 
 interface GetUsersParams {
   page?: number;
@@ -42,4 +50,10 @@ export const UsersApi = {
 
   deactivateUser: (id: string): Promise<void> =>
     ApiClient.delete<void>(`/users/${id}`),
+
+  postOnboarding: (rentalType: RentalType): Promise<OnboardingResponse> =>
+    ApiClient.post<OnboardingResponse>('/users/onboarding', { rentalType }),
+
+  putOnboarding: (rentalType: RentalType): Promise<OnboardingResponse> =>
+    ApiClient.put<OnboardingResponse>('/users/onboarding', { rentalType }),
 };

--- a/src/components/auth/onboarding-guard.tsx
+++ b/src/components/auth/onboarding-guard.tsx
@@ -1,0 +1,18 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '@/hooks/use-auth';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import { needsOnboarding } from '@/lib/onboarding';
+
+export function OnboardingGuard() {
+  const { isLoading, isAuthenticated, user } = useAuth();
+
+  if (isLoading) {
+    return <LoadingScreen message="Caricamento..." />;
+  }
+
+  if (isAuthenticated && needsOnboarding(user)) {
+    return <Navigate to="/onboarding" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/config/demo.config.ts
+++ b/src/config/demo.config.ts
@@ -9,7 +9,7 @@
  */
 export const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true';
 
-export type DemoProfile = 'short-stay' | 'long-term' | 'dual';
+export type DemoProfile = 'short-stay' | 'long-term' | 'dual' | 'onboarding';
 export type ExtendedDemoProfile = DemoProfile | 'admin' | 'triple';
 
 const ROLES_CLAIM = 'https://casazen.app/roles';
@@ -26,6 +26,9 @@ const demoProfiles: Record<ExtendedDemoProfile, { roles: string[] }> = {
   },
   dual: {
     roles: ['PropertyOwner', 'LongTermLandlord'],
+  },
+  onboarding: {
+    roles: [],
   },
   triple: {
     roles: ['PropertyOwner', 'LongTermLandlord', 'Admin'],

--- a/src/features/onboarding/components/rental-type-card.tsx
+++ b/src/features/onboarding/components/rental-type-card.tsx
@@ -1,0 +1,66 @@
+import { Home, KeyRound, Layers } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { RentalType } from '@/types';
+import { cn } from '@/lib/utils';
+
+const CARD_META: Record<
+  RentalType,
+  { title: string; description: string; icon: typeof Home }
+> = {
+  ShortTerm: {
+    title: 'Affitti brevi',
+    description: 'Gestisci prenotazioni short-stay su Airbnb, Booking.com e altri',
+    icon: Home,
+  },
+  LongTerm: {
+    title: 'Locazioni di lungo periodo',
+    description: 'Gestisci contratti di locazione, registrazione RLI, cedolare secca',
+    icon: KeyRound,
+  },
+  Both: {
+    title: 'Entrambi',
+    description: 'Accedi a entrambe le sezioni con switcher rapido',
+    icon: Layers,
+  },
+};
+
+interface RentalTypeCardProps {
+  rentalType: RentalType;
+  onSelect: (rentalType: RentalType) => void;
+  isLoading: boolean;
+  selectedType: RentalType | null;
+}
+
+export function RentalTypeCard({ rentalType, onSelect, isLoading, selectedType }: RentalTypeCardProps) {
+  const meta = CARD_META[rentalType];
+  const Icon = meta.icon;
+  const isSelected = selectedType === rentalType;
+
+  return (
+    <Card
+      className={cn(
+        'transition-shadow hover:shadow-md',
+        isSelected && 'ring-2 ring-primary',
+      )}
+    >
+      <CardHeader>
+        <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Icon className="h-6 w-6" aria-hidden />
+        </div>
+        <CardTitle>{meta.title}</CardTitle>
+        <CardDescription>{meta.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          type="button"
+          className="w-full"
+          disabled={isLoading}
+          onClick={() => onSelect(rentalType)}
+        >
+          {isLoading && isSelected ? 'Configurazione...' : 'Scegli'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/onboarding/onboarding-page.tsx
+++ b/src/features/onboarding/onboarding-page.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { useAuth } from '@/hooks/use-auth';
+import { useCompleteOnboarding } from '@/queries/use-users';
+import type { RentalType } from '@/types';
+import { getHomeRouteForRentalType, getHomeRouteForUser } from '@/lib/onboarding';
+import { getUserRoles } from '@/lib/auth-roles';
+import { isDemoMode } from '@/config/demo.config';
+import { applyDemoOnboardingProfile } from '@/lib/demo-onboarding';
+import { RentalTypeCard } from './components/rental-type-card';
+
+const RENTAL_TYPES: RentalType[] = ['ShortTerm', 'LongTerm', 'Both'];
+
+export function OnboardingPage() {
+  const navigate = useNavigate();
+  const { user, refreshAccessToken } = useAuth();
+  const completeOnboarding = useCompleteOnboarding();
+  const [selectedType, setSelectedType] = useState<RentalType | null>(null);
+  const [failedType, setFailedType] = useState<RentalType | null>(null);
+
+  useEffect(() => {
+    if (getUserRoles(user).length > 0) {
+      navigate(getHomeRouteForUser(user), { replace: true });
+    }
+  }, [navigate, user]);
+
+  const handleSelect = async (rentalType: RentalType) => {
+    setSelectedType(rentalType);
+    setFailedType(null);
+
+    try {
+      if (isDemoMode) {
+        applyDemoOnboardingProfile(rentalType);
+        window.location.assign(getHomeRouteForRentalType(rentalType));
+        return;
+      }
+
+      await completeOnboarding.mutateAsync(rentalType);
+      await refreshAccessToken();
+      window.location.assign(getHomeRouteForRentalType(rentalType));
+    } catch {
+      setFailedType(rentalType);
+      toast.error('Errore durante la configurazione del profilo. Riprova.');
+      setSelectedType(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/40 px-4 py-12">
+      <div className="mx-auto max-w-5xl space-y-10 text-center">
+        <div className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">CasaZen</p>
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            Come vuoi usare CasaZen?
+          </h1>
+          <p className="text-muted-foreground">
+            Scegli il tipo di operatore per personalizzare la tua esperienza.
+          </p>
+        </div>
+
+        <div className="grid gap-6 text-left md:grid-cols-3">
+          {RENTAL_TYPES.map((rentalType) => (
+            <RentalTypeCard
+              key={rentalType}
+              rentalType={rentalType}
+              onSelect={handleSelect}
+              isLoading={completeOnboarding.isPending}
+              selectedType={selectedType}
+            />
+          ))}
+        </div>
+
+        {failedType && (
+          <button
+            type="button"
+            className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+            onClick={() => void handleSelect(failedType)}
+          >
+            Riprova
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/profile/components/operator-type-section.tsx
+++ b/src/features/profile/components/operator-type-section.tsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useMe } from '@/queries/use-users';
+import { RENTAL_TYPE_LABELS } from '@/lib/onboarding';
+import type { RentalType } from '@/types';
+
+export function OperatorTypeSection() {
+  const { data: profile, isLoading } = useMe();
+
+  const label = profile?.rentalType
+    ? RENTAL_TYPE_LABELS[profile.rentalType as RentalType]
+    : 'Non configurato';
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle>Tipo di operatore</CardTitle>
+        <Button variant="outline" size="sm" asChild>
+          <Link to="/onboarding">Modifica tipo</Link>
+        </Button>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">Tipo attuale</p>
+        <p className="font-medium">{isLoading ? 'Caricamento...' : label}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/profile/profile-content-page.tsx
+++ b/src/features/profile/profile-content-page.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from '@/components/layout/page-header';
 import { ProfileInfo } from './components/profile-info';
+import { OperatorTypeSection } from './components/operator-type-section';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { useAuth } from '@/hooks/use-auth';
 
@@ -18,6 +19,7 @@ export function ProfileContentPage() {
       />
 
       <ProfileInfo user={user} />
+      <OperatorTypeSection />
     </div>
   );
 }

--- a/src/features/profile/profile-page.tsx
+++ b/src/features/profile/profile-page.tsx
@@ -1,6 +1,7 @@
 import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { ProfileInfo } from './components/profile-info';
+import { OperatorTypeSection } from './components/operator-type-section';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { useAuth } from '@/hooks/use-auth';
 
@@ -20,6 +21,7 @@ export function ProfilePage() {
         />
 
         <ProfileInfo user={user} />
+        <OperatorTypeSection />
       </div>
     </AppShell>
   );

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -41,6 +41,11 @@ export function useAuth() {
 
   const demoUser = useMemo(() => getDemoUser(), [typeof window !== 'undefined' ? window.location.href : '']);
 
+  const authParams = {
+    audience: import.meta.env.VITE_AUTH0_AUDIENCE || 'https://casazen-api',
+    scope: 'openid profile email read:properties write:properties read:bookings write:bookings',
+  };
+
   // In demo mode, return mock authentication state
   if (isDemoMode) {
     return {
@@ -50,6 +55,7 @@ export function useAuth() {
       login: () => console.log('Demo mode: login simulation'),
       logout,
       getAccessToken: async () => 'demo-token',
+      refreshAccessToken: async () => 'demo-token',
     };
   }
 
@@ -59,11 +65,11 @@ export function useAuth() {
     user,
     login: loginWithRedirect,
     logout,
-    getAccessToken: () => getAccessTokenSilently({
-      authorizationParams: {
-        audience: import.meta.env.VITE_AUTH0_AUDIENCE || 'https://casazen-api',
-        scope: 'openid profile email read:properties write:properties read:bookings write:bookings',
-      },
-    }),
+    getAccessToken: () => getAccessTokenSilently({ authorizationParams: authParams }),
+    refreshAccessToken: () =>
+      getAccessTokenSilently({
+        authorizationParams: authParams,
+        cacheMode: 'off',
+      }),
   };
 }

--- a/src/lib/__tests__/onboarding.test.ts
+++ b/src/lib/__tests__/onboarding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getHomeRouteForRentalType, getHomeRouteForUser, needsOnboarding } from '../onboarding';
+
+describe('onboarding helpers', () => {
+  it('maps rental types to home routes', () => {
+    expect(getHomeRouteForRentalType('ShortTerm')).toBe('/app/short-rent');
+    expect(getHomeRouteForRentalType('LongTerm')).toBe('/app/long-rent/leases');
+    expect(getHomeRouteForRentalType('Both')).toBe('/app/short-rent');
+  });
+
+  it('detects onboarding requirement from JWT roles', () => {
+    expect(needsOnboarding({ roles: [] })).toBe(true);
+    expect(needsOnboarding({ roles: ['PropertyOwner'] })).toBe(false);
+    expect(needsOnboarding({ roles: ['Admin'] })).toBe(false);
+  });
+
+  it('resolves home route for user roles', () => {
+    expect(getHomeRouteForUser({ roles: ['LongTermLandlord'] })).toBe('/app/long-rent/leases');
+    expect(getHomeRouteForUser({ roles: ['PropertyOwner', 'LongTermLandlord'] })).toBe('/app/short-rent');
+    expect(getHomeRouteForUser({ roles: ['Admin'] })).toBe('/app/admin');
+  });
+});

--- a/src/lib/demo-onboarding.ts
+++ b/src/lib/demo-onboarding.ts
@@ -1,0 +1,13 @@
+import type { RentalType } from '@/types';
+
+const DEMO_PROFILE_STORAGE_KEY = 'casazen:demo-profile';
+
+const RENTAL_TO_DEMO_PROFILE: Record<RentalType, string> = {
+  ShortTerm: 'short-stay',
+  LongTerm: 'long-term',
+  Both: 'dual',
+};
+
+export function applyDemoOnboardingProfile(rentalType: RentalType): void {
+  sessionStorage.setItem(DEMO_PROFILE_STORAGE_KEY, RENTAL_TO_DEMO_PROFILE[rentalType]);
+}

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,40 @@
+import type { RentalType } from '@/types';
+import { getUserRoles, isAdmin, ROLE_LONG_TERM_LANDLORD, ROLE_PROPERTY_OWNER } from '@/lib/auth-roles';
+import type { UserWithRoles } from '@/lib/auth-roles';
+
+export const RENTAL_TYPE_LABELS: Record<RentalType, string> = {
+  ShortTerm: 'Affitti brevi',
+  LongTerm: 'Locazioni di lungo periodo',
+  Both: 'Entrambi',
+};
+
+export function getHomeRouteForRentalType(rentalType: RentalType): string {
+  switch (rentalType) {
+    case 'LongTerm':
+      return '/app/long-rent/leases';
+    case 'Both':
+    case 'ShortTerm':
+    default:
+      return '/app/short-rent';
+  }
+}
+
+export function getHomeRouteForUser(user: UserWithRoles): string {
+  if (isAdmin(user)) {
+    return '/app/admin';
+  }
+
+  const roles = getUserRoles(user);
+  if (roles.includes(ROLE_LONG_TERM_LANDLORD) && !roles.includes(ROLE_PROPERTY_OWNER)) {
+    return '/app/long-rent/leases';
+  }
+
+  return '/app/short-rent';
+}
+
+export function needsOnboarding(user: UserWithRoles): boolean {
+  if (isAdmin(user)) {
+    return false;
+  }
+  return getUserRoles(user).length === 0;
+}

--- a/src/queries/use-users.ts
+++ b/src/queries/use-users.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { UsersApi } from '@/api/users.api';
-import type { UpdateProfileRequest } from '@/types';
+import type { RentalType, UpdateProfileRequest } from '@/types';
 import { toast } from 'sonner';
 
 const USERS_KEY = 'users';
@@ -63,6 +63,17 @@ export function useChangeUserRole() {
     },
     onError: () => {
       toast.error('Impossibile aggiornare il ruolo');
+    },
+  });
+}
+
+export function useCompleteOnboarding() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (rentalType: RentalType) => UsersApi.postOnboarding(rentalType),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [ME_KEY] });
     },
   });
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, Navigate, Outlet, type RouteObject } from 'react-router-dom';
 import { ProtectedRoute } from '@/components/auth/protected-route';
+import { OnboardingGuard } from '@/components/auth/onboarding-guard';
 import { LoginPage } from '@/pages/login-page';
 import { SearchPage } from '@/features/search/search-page';
 import { WorkspaceProvider } from '@/contexts/workspace-provider';
@@ -7,6 +8,7 @@ import { ContextLayout } from '@/components/layout/context-layout';
 import { ContextRouteGuard } from '@/components/auth/context-route-guard';
 import { ContextPickerPage } from '@/pages/context-picker-page';
 import { NoAccessPage } from '@/pages/no-access-page';
+import { OnboardingPage } from '@/features/onboarding/onboarding-page';
 import { ROUTE_MANIFEST, type AppContextKey } from '@/config/route-manifest';
 import { LegacyRedirect } from './legacy-redirect';
 import { ManifestRoute } from './manifest-route';
@@ -35,23 +37,13 @@ const legacyPaths = Array.from(
   ),
 );
 
-export const router = createBrowserRouter([
-  {
-    path: '/login',
-    element: <LoginPage />,
-  },
-  {
-    path: '/search',
-    element: <SearchPage />,
-  },
+const workspaceRoutes: RouteObject[] = [
   {
     path: '/app',
     element: (
-      <ProtectedRoute>
-        <WorkspaceProvider>
-          <Outlet />
-        </WorkspaceProvider>
-      </ProtectedRoute>
+      <WorkspaceProvider>
+        <Outlet />
+      </WorkspaceProvider>
     ),
     children: [
       {
@@ -65,47 +57,64 @@ export const router = createBrowserRouter([
       {
         path: 'short-rent',
         element: <ContextLayout />,
-        children: [
-          ...buildContextChildren('short-rent'),
-        ],
+        children: [...buildContextChildren('short-rent')],
       },
       {
         path: 'long-rent',
         element: <ContextLayout />,
-        children: [
-          ...buildContextChildren('long-rent'),
-        ],
+        children: [...buildContextChildren('long-rent')],
       },
       {
         path: 'admin',
         element: <ContextLayout />,
-        children: [
-          ...buildContextChildren('admin'),
-        ],
+        children: [...buildContextChildren('admin')],
       },
     ],
   },
   {
-    element: (
-      <ProtectedRoute>
-        <WorkspaceProvider>
-          <LegacyRedirect />
-        </WorkspaceProvider>
-      </ProtectedRoute>
-    ),
-    children: [],
     path: '/',
+    element: (
+      <WorkspaceProvider>
+        <LegacyRedirect />
+      </WorkspaceProvider>
+    ),
   },
   ...legacyPaths.map((path) => ({
     path,
     element: (
-      <ProtectedRoute>
-        <WorkspaceProvider>
-          <LegacyRedirect />
-        </WorkspaceProvider>
-      </ProtectedRoute>
+      <WorkspaceProvider>
+        <LegacyRedirect />
+      </WorkspaceProvider>
     ),
   })),
+];
+
+export const router = createBrowserRouter([
+  {
+    path: '/login',
+    element: <LoginPage />,
+  },
+  {
+    path: '/search',
+    element: <SearchPage />,
+  },
+  {
+    element: (
+      <ProtectedRoute>
+        <Outlet />
+      </ProtectedRoute>
+    ),
+    children: [
+      {
+        path: '/onboarding',
+        element: <OnboardingPage />,
+      },
+      {
+        element: <OnboardingGuard />,
+        children: workspaceRoutes,
+      },
+    ],
+  },
   {
     path: '*',
     element: <Navigate to="/app/choose-context" replace />,

--- a/src/types/users.types.ts
+++ b/src/types/users.types.ts
@@ -6,12 +6,15 @@ export type UserRole =
   | 'Staff'
   | 'LongTermLandlord';
 
+export type RentalType = 'ShortTerm' | 'LongTerm' | 'Both';
+
 export interface UserSummary {
   id: string;
   email: string;
   firstName: string;
   lastName: string;
   role: UserRole;
+  rentalType?: RentalType | null;
   isActive: boolean;
   createdAt: string;
 }
@@ -29,6 +32,15 @@ export interface UpdateProfileRequest {
 
 export interface ChangeRoleRequest {
   role: UserRole;
+}
+
+export interface OnboardingRequest {
+  rentalType: RentalType;
+}
+
+export interface OnboardingResponse {
+  rolesAssigned: string[];
+  rentalType: RentalType;
 }
 
 export interface PagedResult<T> {


### PR DESCRIPTION
## Summary
- Add `/onboarding` standalone page with 3 rental type cards (AC1–AC3, AC11)
- Add `OnboardingGuard` between auth and workspace routes (AC12–AC13)
- Profile operator type section + demo `onboarding` profile (AC6, AC16–AC17)
- Playwright E2E `e2e/onboarding.spec.ts` (5 tests)

## Test plan
- [x] `npm test` — 98 passed
- [x] `npm run test:e2e -- e2e/onboarding.spec.ts` — 5 passed
- [x] `npm run build`

Related: casazen/backend#198
