### PR TITLE
test(e2e): API regression + Vercel deploy smoke in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run E2E tests
+      - name: Run E2E tests (demo mode)
         run: npm run test:e2e
 
       - name: Upload Playwright report
@@ -33,3 +33,44 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  e2e-deploy-smoke:
+    name: E2E deploy smoke (Vercel + Railway)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for Railway/Vercel deploy
+        run: sleep 90
+
+      - name: Vercel FE deploy smoke
+        env:
+          E2E_DEPLOY_SMOKE: '1'
+          E2E_DEPLOY_FE_URL: ${{ github.ref == 'refs/heads/main' && 'https://casazen-app.vercel.app' || 'https://casazen-app.vercel.app' }}
+        run: npm run test:e2e -- vercel-deploy-smoke
+
+      - name: Railway API regression (authenticated)
+        env:
+          E2E_STAGING: '1'
+          E2E_STAGING_API_URL: ${{ vars.RAILWAY_TEST_URL }}/api
+          E2E_AUTH0_EMAIL: ${{ secrets.E2E_AUTH0_EMAIL }}
+          E2E_AUTH0_PASSWORD: ${{ secrets.E2E_AUTH0_PASSWORD }}
+        run: |
+          if [ -z "$E2E_AUTH0_EMAIL" ] || [ -z "$E2E_AUTH0_PASSWORD" ]; then
+            echo "::warning::E2E_AUTH0_EMAIL/PASSWORD not set — skipping authenticated Railway API regression."
+            echo "Add GitHub secrets to catch EF migration 500s on authenticated routes."
+            exit 0
+          fi
+          npm run test:e2e -- api-regression-smoke property-staging

--- a/e2e/api-regression-smoke.spec.ts
+++ b/e2e/api-regression-smoke.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { requireE2eCredentials } from './helpers/env';
+
+const STAGING_API =
+  process.env.E2E_STAGING_API_URL ?? 'https://casazen-api-test.up.railway.app/api';
+
+const PROTECTED_ENDPOINTS = [
+  '/properties',
+  '/bookings',
+  '/users/me',
+  '/me/contexts',
+] as const;
+
+/**
+ * Live API regression — authenticated requests must never return 500.
+ * Catches missing EF migrations and schema drift on Railway test/prod.
+ *
+ * Run: E2E_STAGING=1 npm run test:e2e -- api-regression-smoke
+ */
+test.describe('API regression smoke (live Railway)', () => {
+  test.skip(!process.env.E2E_STAGING, 'Set E2E_STAGING=1 to run live API regression');
+  test.setTimeout(120_000);
+
+  test.beforeEach(() => {
+    requireE2eCredentials();
+  });
+
+  async function getAccessToken(page: import('@playwright/test').Page): Promise<string | null> {
+    return page.evaluate(() => {
+      for (const key of Object.keys(localStorage)) {
+        if (!key.includes('auth0spajs')) continue;
+        try {
+          const parsed = JSON.parse(localStorage.getItem(key) ?? '{}');
+          const token = parsed?.body?.access_token;
+          if (typeof token === 'string') return token;
+        } catch {
+          // continue
+        }
+      }
+      return null;
+    });
+  }
+
+  test('authenticated core endpoints never return 500', async ({ page }) => {
+    await page.goto('/app/short-rent');
+    await expect(page.locator('body')).toBeVisible({ timeout: 60_000 });
+
+    const token = await getAccessToken(page);
+    expect(token, 'Auth0 access token must be present after login').toBeTruthy();
+
+    const results = await page.evaluate(
+      async ({ apiBase, paths, bearer }) => {
+        const out: Record<string, number> = {};
+        for (const path of paths) {
+          const res = await fetch(`${apiBase}${path}`, {
+            headers: { Authorization: `Bearer ${bearer}` },
+          });
+          out[path] = res.status;
+        }
+        return out;
+      },
+      { apiBase: STAGING_API, paths: [...PROTECTED_ENDPOINTS], bearer: token! },
+    );
+
+    for (const path of PROTECTED_ENDPOINTS) {
+      const status = results[path];
+      expect(status, `${path} must not return 500 (likely pending EF migration)`).not.toBe(500);
+      expect(status, `${path} should be reachable when authenticated`).toBeGreaterThanOrEqual(200);
+      expect(status, `${path} should not be 401 when authenticated`).not.toBe(401);
+    }
+  });
+});

--- a/e2e/vercel-deploy-smoke.spec.ts
+++ b/e2e/vercel-deploy-smoke.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const FE_URL =
+  process.env.E2E_DEPLOY_FE_URL ??
+  (process.env.E2E_STAGING === '1'
+    ? 'https://casazen-app.vercel.app'
+    : 'http://localhost:5173');
+
+/**
+ * Verifies deployed Vercel FE serves the React SPA (not a broken .env or placeholder).
+ * Run in CI: E2E_DEPLOY_SMOKE=1 E2E_DEPLOY_FE_URL=https://casazen-app.vercel.app
+ */
+test.describe('Vercel deploy smoke', () => {
+  test.skip(!process.env.E2E_DEPLOY_SMOKE, 'Set E2E_DEPLOY_SMOKE=1 for live FE deploy checks');
+
+  test('serves React root on deployed URL', async ({ page }) => {
+    await page.goto(FE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#root')).toBeAttached({ timeout: 30_000 });
+    const html = await page.content();
+    expect(html).not.toContain('GEMINI_API_KEY');
+    expect(html).not.toMatch(/VITE_[A-Z_]+=placeholder/i);
+  });
+
+  test('login page or app shell loads without console 500 storms', async ({ page }) => {
+    const serverErrors: string[] = [];
+    page.on('response', (res) => {
+      if (res.status() >= 500 && res.url().includes('/api/')) {
+        serverErrors.push(`${res.status()} ${res.url()}`);
+      }
+    });
+
+    await page.goto(FE_URL, { waitUntil: 'networkidle', timeout: 60_000 });
+    await expect(page.locator('#root')).toBeAttached();
+
+    expect(
+      serverErrors,
+      `API 500 responses on page load: ${serverErrors.join(', ')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ import { defineConfig, devices } from '@playwright/test';
  * @see https://playwright.dev/docs/test-configuration
  */
 const isStagingRun = process.env.E2E_STAGING === '1';
+const isDeploySmokeRun = process.env.E2E_DEPLOY_SMOKE === '1';
 
 export default defineConfig({
   testDir: './e2e',
@@ -24,7 +25,18 @@ export default defineConfig({
     viewport: { width: 1280, height: 720 },
   },
 
-  projects: isStagingRun
+  projects: isDeploySmokeRun
+    ? [
+        {
+          name: 'deploy-smoke',
+          testMatch: '**/vercel-deploy-smoke.spec.ts',
+          use: {
+            ...devices['Desktop Chrome'],
+            baseURL: process.env.E2E_DEPLOY_FE_URL ?? 'https://casazen-app.vercel.app',
+          },
+        },
+      ]
+    : isStagingRun
     ? [
         {
           name: 'setup',
@@ -32,7 +44,7 @@ export default defineConfig({
         },
         {
           name: 'staging',
-          testMatch: '**/property-staging.spec.ts',
+          testMatch: /\/(property-staging|api-regression-smoke)\.spec\.ts/,
           dependencies: ['setup'],
           use: {
             ...devices['Desktop Chrome'],
@@ -44,12 +56,18 @@ export default defineConfig({
     : [
         {
           name: 'chromium',
-          testIgnore: ['**/property-staging.spec.ts'],
+          testIgnore: [
+            '**/property-staging.spec.ts',
+            '**/api-regression-smoke.spec.ts',
+            '**/vercel-deploy-smoke.spec.ts',
+          ],
           use: { ...devices['Desktop Chrome'] },
         },
       ],
 
-  webServer: isStagingRun
+  webServer: isDeploySmokeRun
+    ? undefined
+    : isStagingRun
     ? {
         command: 'npm run dev',
         url: 'http://localhost:5173',


### PR DESCRIPTION
## Changes
- api-regression-smoke: authenticated Railway endpoints must not 500
- vercel-deploy-smoke: prod FE serves #root
- CI job e2e-deploy-smoke on push to develop/main

Made with [Cursor](https://cursor.com)