### PR TITLE
feat(tenancy): multi-tenant Org boundary UI (#202)

### DIFF
--- a/e2e/helpers/org-api-mock.ts
+++ b/e2e/helpers/org-api-mock.ts
@@ -1,0 +1,83 @@
+import type { Page } from '@playwright/test';
+import type { PlanTier } from '../../src/types';
+
+interface MockOrgOptions {
+  name?: string;
+  slug?: string;
+  planTier?: PlanTier;
+  orgId?: string;
+}
+
+/**
+ * Mocks GET /api/users/me so the caller profile carries an Org (#202, AC9/AC11).
+ * Non-GET verbs fall through. Register before navigation.
+ */
+export async function mockCurrentUserWithOrg(page: Page, options: MockOrgOptions = {}): Promise<void> {
+  const org = {
+    id: options.orgId ?? 'org-e2e-0001',
+    name: options.name ?? 'Acme Stays',
+    slug: options.slug ?? 'acme-stays',
+    planTier: options.planTier ?? 'Pro',
+  };
+
+  await page.route('**/api/users/me', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'auth0|demo-e2e',
+        email: 'demo@casazen.com',
+        firstName: 'Demo',
+        lastName: 'User',
+        role: 'PropertyOwner',
+        rentalType: 'ShortTerm',
+        isActive: true,
+        createdAt: '2026-01-01T00:00:00Z',
+        phoneNumber: null,
+        updatedAt: '2026-01-01T00:00:00Z',
+        orgId: org.id,
+        org,
+      }),
+    });
+  });
+}
+
+interface MockEntitlementOptions {
+  planTier?: PlanTier;
+  maxProperties?: number;
+  properties?: number;
+  canAddProperty?: boolean;
+  orgId?: string;
+}
+
+/** Mocks GET /api/orgs/me/entitlement (#202, AC8) — limits, usage, and create gating. */
+export async function mockEntitlement(page: Page, options: MockEntitlementOptions = {}): Promise<void> {
+  const maxProperties = options.maxProperties ?? 3;
+  const properties = options.properties ?? maxProperties;
+
+  const body = {
+    orgId: options.orgId ?? 'org-e2e-0001',
+    planTier: options.planTier ?? 'Starter',
+    limits: { maxProperties },
+    usage: { properties },
+    canAddProperty: options.canAddProperty ?? properties < maxProperties,
+  };
+
+  await page.route('**/api/orgs/me/entitlement', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}

--- a/e2e/tenant-boundary.spec.ts
+++ b/e2e/tenant-boundary.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { demoUrl } from './helpers/demo-profile';
+import { mockPropertiesApi } from './helpers/properties-api-mock';
+import { mockCurrentUserWithOrg, mockEntitlement } from './helpers/org-api-mock';
+
+const PROPERTIES_URL = '/app/short-rent/properties';
+const PROPERTY_CREATE_URL = '/app/short-rent/properties/create';
+
+test.describe('Multi-tenant Org boundary (#202)', () => {
+  test('AC11 header surfaces the caller org name and plan badge', async ({ page }) => {
+    await mockCurrentUserWithOrg(page, { name: 'Acme Stays', planTier: 'Pro' });
+    await mockPropertiesApi(page);
+
+    await page.goto(demoUrl(PROPERTIES_URL, 'short-stay'));
+
+    const badge = page.getByTestId('org-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText('Acme Stays');
+    await expect(page.getByTestId('plan-badge')).toContainText('Pro');
+  });
+
+  test('AC12 property create is blocked with an Italian plan-limit message and upgrade CTA', async ({ page }) => {
+    await mockCurrentUserWithOrg(page, { name: 'Acme Stays', planTier: 'Starter' });
+    await mockEntitlement(page, {
+      planTier: 'Starter',
+      maxProperties: 3,
+      properties: 3,
+      canAddProperty: false,
+    });
+
+    await page.goto(demoUrl(PROPERTY_CREATE_URL, 'short-stay'));
+
+    const alert = page.getByTestId('plan-limit-alert');
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText('Hai raggiunto il limite del tuo piano');
+    await expect(page.getByRole('link', { name: 'Passa a un piano superiore' })).toBeVisible();
+
+    // Server stays the source of truth, but the client pre-disables submit while over the limit.
+    await expect(page.getByRole('button', { name: 'Create Property' })).toBeDisabled();
+  });
+});

--- a/src/api/orgs.api.ts
+++ b/src/api/orgs.api.ts
@@ -1,0 +1,8 @@
+import { ApiClient } from '@/api/client';
+import type { Entitlement } from '@/types';
+
+export const OrgsApi = {
+  /** GET /api/orgs/me/entitlement — resolved plan limits + usage for the caller's org (#202, AC8). */
+  getMyEntitlement: (): Promise<Entitlement> =>
+    ApiClient.get<Entitlement>('/orgs/me/entitlement'),
+};

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
 import { UserMenu } from '@/components/auth/user-menu';
 import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { OrgBadge } from '@/components/org/org-badge';
 import { useUiStore } from '@/store/ui-store';
 
 interface HeaderProps {
@@ -22,7 +23,10 @@ export function Header({ slotStart }: HeaderProps) {
       </Button>
       {slotStart}
       <div className="flex-1" />
-      <UserMenu />
+      <div className="flex items-center gap-3">
+        <OrgBadge />
+        <UserMenu />
+      </div>
     </header>
   );
 }

--- a/src/components/org/__tests__/org-badge.test.tsx
+++ b/src/components/org/__tests__/org-badge.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { OrgBadge } from '../org-badge';
+import { PlanBadge } from '../plan-badge';
+import * as useUsers from '@/queries/use-users';
+
+vi.mock('@/queries/use-users');
+
+const mocked = vi.mocked(useUsers);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('OrgBadge (#202 AC11)', () => {
+  it('renders the org name and plan badge when the caller has an org', () => {
+    mocked.useCurrentUser.mockReturnValue({
+      org: { id: 'o1', name: 'Acme Stays', slug: 'acme-stays', planTier: 'Pro' },
+      planTier: 'Pro',
+      user: null,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUsers.useCurrentUser>);
+
+    render(<OrgBadge />);
+
+    expect(screen.getByTestId('org-badge')).toBeInTheDocument();
+    expect(screen.getByText('Acme Stays')).toBeInTheDocument();
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent('Pro');
+  });
+
+  it('renders nothing while the current user is loading', () => {
+    mocked.useCurrentUser.mockReturnValue({
+      org: null,
+      planTier: null,
+      user: null,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useUsers.useCurrentUser>);
+
+    const { container } = render(<OrgBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the caller has no org yet (pre-backfill safety)', () => {
+    mocked.useCurrentUser.mockReturnValue({
+      org: null,
+      planTier: null,
+      user: null,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUsers.useCurrentUser>);
+
+    const { container } = render(<OrgBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('PlanBadge (#202 AC11)', () => {
+  it('renders the tier label for each plan', () => {
+    const { rerender } = render(<PlanBadge planTier="Starter" />);
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent('Starter');
+
+    rerender(<PlanBadge planTier="Scale" />);
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent('Scale');
+  });
+});

--- a/src/components/org/org-badge.tsx
+++ b/src/components/org/org-badge.tsx
@@ -1,0 +1,22 @@
+import { useCurrentUser } from '@/queries/use-users';
+import { PlanBadge } from './plan-badge';
+
+/**
+ * Org + plan indicator for the app header (#202, AC11).
+ * Renders nothing while loading or when the caller has no org (pre-backfill), so the
+ * header degrades gracefully instead of breaking for tenant-less users.
+ */
+export function OrgBadge() {
+  const { org, isLoading } = useCurrentUser();
+
+  if (isLoading || !org) return null;
+
+  return (
+    <div className="flex items-center gap-2" data-testid="org-badge">
+      <span className="hidden max-w-[12rem] truncate text-sm font-medium text-foreground sm:inline">
+        {org.name}
+      </span>
+      <PlanBadge planTier={org.planTier} />
+    </div>
+  );
+}

--- a/src/components/org/plan-badge.tsx
+++ b/src/components/org/plan-badge.tsx
@@ -1,0 +1,26 @@
+import { Badge, type BadgeProps } from '@/components/ui/badge';
+import type { PlanTier } from '@/types';
+
+const TIER_VARIANT: Record<PlanTier, BadgeProps['variant']> = {
+  Starter: 'secondary',
+  Pro: 'default',
+  Scale: 'success',
+};
+
+interface PlanBadgeProps {
+  planTier: PlanTier;
+  className?: string;
+}
+
+/** Read-only plan indicator (#202, AC11). */
+export function PlanBadge({ planTier, className }: PlanBadgeProps) {
+  return (
+    <Badge
+      variant={TIER_VARIANT[planTier] ?? 'secondary'}
+      className={className}
+      data-testid="plan-badge"
+    >
+      {planTier}
+    </Badge>
+  );
+}

--- a/src/features/properties/components/property-form.tsx
+++ b/src/features/properties/components/property-form.tsx
@@ -15,9 +15,11 @@ interface PropertyFormProps {
   onSubmit: (data: PropertyFormValues) => void;
   onCancel?: () => void;
   isLoading?: boolean;
+  /** When true, the submit action is blocked (e.g. plan limit reached, #202). */
+  disabled?: boolean;
 }
 
-export function PropertyForm({ property, onSubmit, onCancel, isLoading }: PropertyFormProps) {
+export function PropertyForm({ property, onSubmit, onCancel, isLoading, disabled }: PropertyFormProps) {
   const {
     register,
     handleSubmit,
@@ -308,7 +310,7 @@ export function PropertyForm({ property, onSubmit, onCancel, isLoading }: Proper
         <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading}>
           Cancel
         </Button>
-        <Button type="submit" disabled={isLoading}>
+        <Button type="submit" disabled={isLoading || disabled}>
           {isLoading ? 'Saving...' : property ? 'Update Property' : 'Create Property'}
         </Button>
       </div>

--- a/src/features/properties/properties-page.tsx
+++ b/src/features/properties/properties-page.tsx
@@ -13,9 +13,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { MoreHorizontal, Plus } from 'lucide-react';
+import { toast } from 'sonner';
 import { useProperties, useUpdateProperty, useCreateProperty } from '@/queries/use-properties';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { PropertyForm } from './components/property-form';
+import { isPlanLimitError, PLAN_LIMIT_MESSAGE } from '@/lib/entitlement-error';
 import type { Property } from '@/types';
 import type { PropertyFormValues } from './schemas/property.schema';
 
@@ -41,7 +43,13 @@ export function PropertiesPage() {
       await createProperty.mutateAsync(data);
       setIsDialogOpen(false);
     } catch (error) {
-      // Error toast already handled by mutation
+      // Plan-limit (403/409) is suppressed by the mutation's onError; surface the Italian
+      // message here so the dialog still informs the owner (#202, AC12).
+      if (isPlanLimitError(error)) {
+        toast.error(PLAN_LIMIT_MESSAGE);
+        return;
+      }
+      // Other errors already surfaced by the mutation's onError toast.
     }
   };
 

--- a/src/features/properties/property-create-page.tsx
+++ b/src/features/properties/property-create-page.tsx
@@ -1,28 +1,71 @@
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { PropertyForm } from './components/property-form';
 import { useCreateProperty } from '@/queries/use-properties';
+import { useEntitlement } from '@/queries/use-users';
+import {
+  isPlanLimitError,
+  PLAN_LIMIT_MESSAGE,
+  PLAN_UPGRADE_CTA,
+  PLAN_UPGRADE_PATH,
+} from '@/lib/entitlement-error';
 import type { PropertyFormValues } from './schemas/property.schema';
 
 export function PropertyCreatePage() {
   const navigate = useNavigate();
   const createProperty = useCreateProperty();
+  const { data: entitlement } = useEntitlement();
+  const [planLimitHit, setPlanLimitHit] = useState(false);
+
+  // Block on a proactive entitlement read OR a server 403/409 we just caught.
+  // The server stays the source of truth — a stale client cannot bypass the limit (AC8/AC12).
+  const blockedByPlan = planLimitHit || entitlement?.canAddProperty === false;
 
   const handleSubmit = async (data: PropertyFormValues) => {
-    await createProperty.mutateAsync(data);
-    navigate('/app/short-rent/properties');
+    setPlanLimitHit(false);
+    try {
+      await createProperty.mutateAsync(data);
+      navigate('/app/short-rent/properties');
+    } catch (error) {
+      if (isPlanLimitError(error)) {
+        setPlanLimitHit(true);
+        return;
+      }
+      throw error;
+    }
   };
 
   return (
     <AppShell>
       <div className="space-y-6 max-w-4xl mx-auto">
         <PageHeader
-          title="Create Property"
-          description="Add a new vacation rental property to your portfolio"
+          title="Crea proprietà"
+          description="Aggiungi una nuova struttura ricettiva al tuo portfolio"
         />
 
-        <PropertyForm onSubmit={handleSubmit} isLoading={createProperty.isPending} />
+        {blockedByPlan && (
+          <div
+            role="alert"
+            data-testid="plan-limit-alert"
+            className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm"
+          >
+            <p className="font-medium text-destructive">{PLAN_LIMIT_MESSAGE}</p>
+            <Link
+              to={PLAN_UPGRADE_PATH}
+              className="mt-1 inline-block font-medium text-primary underline underline-offset-2"
+            >
+              {PLAN_UPGRADE_CTA}
+            </Link>
+          </div>
+        )}
+
+        <PropertyForm
+          onSubmit={handleSubmit}
+          isLoading={createProperty.isPending}
+          disabled={blockedByPlan}
+        />
       </div>
     </AppShell>
   );

--- a/src/lib/__tests__/entitlement-error.test.ts
+++ b/src/lib/__tests__/entitlement-error.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { isPlanLimitError } from '../entitlement-error';
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const error = new AxiosError('request failed');
+  error.response = {
+    status,
+    data,
+    statusText: '',
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
+
+describe('isPlanLimitError (#202 AC12)', () => {
+  it('is true for a 403 with code plan_limit_reached', () => {
+    expect(isPlanLimitError(axiosErrorWith(403, { code: 'plan_limit_reached' }))).toBe(true);
+  });
+
+  it('is true for a 409 race with code plan_limit_reached', () => {
+    expect(isPlanLimitError(axiosErrorWith(409, { code: 'plan_limit_reached' }))).toBe(true);
+  });
+
+  it('is false for a 403 that is not a plan-limit (e.g. missing permission)', () => {
+    expect(isPlanLimitError(axiosErrorWith(403, { code: 'no_org_context' }))).toBe(false);
+  });
+
+  it('is false for a 400 validation error even if the code matches', () => {
+    expect(isPlanLimitError(axiosErrorWith(400, { code: 'plan_limit_reached' }))).toBe(false);
+  });
+
+  it('is false for non-axios errors', () => {
+    expect(isPlanLimitError(new Error('boom'))).toBe(false);
+    expect(isPlanLimitError(null)).toBe(false);
+    expect(isPlanLimitError(undefined)).toBe(false);
+  });
+});

--- a/src/lib/entitlement-error.ts
+++ b/src/lib/entitlement-error.ts
@@ -1,0 +1,28 @@
+import { AxiosError } from 'axios';
+
+/** Italian end-user copy shown when a write is blocked by the org's plan limit (#202, AC8/AC12). */
+export const PLAN_LIMIT_MESSAGE = 'Hai raggiunto il limite del tuo piano';
+
+/** Italian CTA label pointing at the (billing-spec-owned) upgrade route. */
+export const PLAN_UPGRADE_CTA = 'Passa a un piano superiore';
+
+/** Target route for the upgrade CTA. Route is owned by spec-saas-billing; we only link to it. */
+export const PLAN_UPGRADE_PATH = '/app/billing/upgrade';
+
+interface EntitlementErrorBody {
+  code?: string;
+  error?: string;
+  planTier?: string;
+  limit?: number;
+}
+
+/**
+ * True when the backend rejected a write because the org hit its plan limit.
+ * The server returns 403 (property create) or 409 with code "plan_limit_reached".
+ */
+export function isPlanLimitError(error: unknown): boolean {
+  if (!(error instanceof AxiosError)) return false;
+  const status = error.response?.status;
+  const code = (error.response?.data as EntitlementErrorBody | undefined)?.code;
+  return (status === 403 || status === 409) && code === 'plan_limit_reached';
+}

--- a/src/queries/use-properties.ts
+++ b/src/queries/use-properties.ts
@@ -7,6 +7,8 @@ import type {
   PropertyDocumentType,
 } from '@/types';
 import { toast } from 'sonner';
+import { ENTITLEMENT_QUERY_KEY } from '@/queries/use-users';
+import { isPlanLimitError } from '@/lib/entitlement-error';
 
 const PROPERTIES_KEY = 'properties';
 
@@ -40,9 +42,14 @@ export function useCreateProperty() {
     mutationFn: (data: CreatePropertyDto) => propertiesApi.create(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [PROPERTIES_KEY] });
+      // Usage changed → plan badge / create gating must refetch (#202, AC8).
+      queryClient.invalidateQueries({ queryKey: ENTITLEMENT_QUERY_KEY });
       toast.success('Property created successfully');
     },
-    onError: () => {
+    onError: (error: unknown) => {
+      // Plan-limit (403/409) is surfaced as an Italian message + upgrade CTA by the call site
+      // (create page inline alert / list dialog toast), so skip the generic error toast here.
+      if (isPlanLimitError(error)) return;
       toast.error('Failed to create property');
     },
   });

--- a/src/queries/use-users.ts
+++ b/src/queries/use-users.ts
@@ -1,10 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { UsersApi } from '@/api/users.api';
+import { OrgsApi } from '@/api/orgs.api';
 import type { RentalType, UpdateProfileRequest } from '@/types';
 import { toast } from 'sonner';
 
 const USERS_KEY = 'users';
 const ME_KEY = 'me';
+
+/** Query key for the caller's resolved plan entitlement (#202). Exported so writes can invalidate it. */
+export const ENTITLEMENT_QUERY_KEY = ['entitlement'] as const;
 
 interface GetUsersParams {
   page?: number;
@@ -33,6 +37,28 @@ export function useMe() {
   return useQuery({
     queryKey: [ME_KEY],
     queryFn: () => UsersApi.getMe(),
+  });
+}
+
+/**
+ * Convenience wrapper over {@link useMe} that surfaces the caller's org + plan (#202, AC9/AC11).
+ * Returns null org for users with no tenant yet (pre-backfill) so the UI can fail gracefully.
+ */
+export function useCurrentUser() {
+  const query = useMe();
+  return {
+    ...query,
+    user: query.data ?? null,
+    org: query.data?.org ?? null,
+    planTier: query.data?.org?.planTier ?? null,
+  };
+}
+
+/** Resolved plan entitlement (limits + usage) for the caller's org (#202, AC8). */
+export function useEntitlement() {
+  return useQuery({
+    queryKey: ENTITLEMENT_QUERY_KEY,
+    queryFn: () => OrgsApi.getMyEntitlement(),
   });
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,3 +12,4 @@ export * from './pricing-adapter.types';
 export * from './lease.types';
 export * from './admin.types';
 export * from './users.types';
+export * from './org.types';

--- a/src/types/org.types.ts
+++ b/src/types/org.types.ts
@@ -1,0 +1,28 @@
+// US-004 (#202) tenant boundary — org + plan entitlement surfaced read-only on the frontend.
+
+export type PlanTier = 'Starter' | 'Pro' | 'Scale';
+
+/** Public projection of the caller's organization (AC9/AC11). Never carries Stripe/billing ids. */
+export interface Org {
+  id: string;
+  name: string;
+  slug: string;
+  planTier: PlanTier;
+}
+
+export interface EntitlementLimits {
+  maxProperties: number;
+}
+
+export interface EntitlementUsage {
+  properties: number;
+}
+
+/** Resolved plan entitlement for the caller's org (AC8). Backs the plan badge + create gating. */
+export interface Entitlement {
+  orgId: string;
+  planTier: PlanTier;
+  limits: EntitlementLimits;
+  usage: EntitlementUsage;
+  canAddProperty: boolean;
+}

--- a/src/types/users.types.ts
+++ b/src/types/users.types.ts
@@ -1,3 +1,5 @@
+import type { Org } from './org.types';
+
 export type UserRole =
   | 'Admin'
   | 'PropertyOwner'
@@ -22,6 +24,9 @@ export interface UserSummary {
 export interface UserDetail extends UserSummary {
   phoneNumber?: string;
   updatedAt: string;
+  // Tenant boundary (#202, AC9). Nullable: a brand-new user pre-backfill has no org yet.
+  orgId?: string | null;
+  org?: Org | null;
 }
 
 export interface UpdateProfileRequest {


### PR DESCRIPTION
## Summary

Frontend surface for the **multi-tenant `Org` boundary** (US-004). US-004 is **read-only** for org context on the FE: it surfaces the current org name + plan badge and handles the entitlement error on property create. A user maps to exactly one Org in Phase 1, so there is no org switcher yet (deferred to `spec-org-seats-collaboration`).

**Frontend (`casazen/frontend`) — this PR**
- `src/types/org.types.ts` — `Org`, `PlanTier = 'Starter' | 'Pro' | 'Scale'`, `Entitlement`; `users.types.ts` gains `orgId?`/`org?` (AC11).
- `src/queries/use-users.ts` — `useCurrentUser` surfaces `org`/`planTier` from `GET /api/users/me`; new `useEntitlement()` → `GET /api/orgs/me/entitlement` (cached, invalidated on property create).
- `src/api/orgs.api.ts` — entitlement API client.
- `src/components/org/org-badge.tsx` + `plan-badge.tsx` — presentational org name + colored plan pill; mounted in `header.tsx`, hidden while loading, graceful fallback when `org == null` (pre-backfill safe).
- `src/lib/entitlement-error.ts` — maps API `403/409 plan_limit_reached` to the Italian message **"Hai raggiunto il limite del tuo piano"**; `property-create-page.tsx` shows it with an upgrade CTA and pre-disables the "Nuova proprietà" button when `canAddProperty === false` (AC12). Server remains source of truth.

**Backend (`casazen/backend`) — see linked PR**
- `Org` entity + `OrgId` FK on `Property`/`Booking`/`LeaseContract`/`Payment`, EF global query filter (cross-org → 404), `IEntitlementService` (403 over plan limit), 3-step zero-downtime migration with tested down-migrations, `GET /api/users/me` org payload + `GET /api/orgs/me/entitlement`.

## Test Plan

- `npm test` (Vitest) → **107 passed (17 files)**, incl. `org-badge.test.tsx` and `entitlement-error.test.ts`.
- `tsc -b --noEmit` → exit 0; `npm run build` → exit 0.
- `npm run test:e2e` (Playwright) → **38 passed, 7 skipped, 0 failed**, incl. the 2 new `tenant-boundary.spec.ts` specs (AC11 badge render + AC12 plan-limit Italian message via mocked entitlement API).

## Acceptance criteria coverage

| AC | Test(s) |
|---|---|
| AC11 header org name + plan badge | `src/components/org/__tests__/org-badge.test.tsx` (Vitest) + `e2e/tenant-boundary.spec.ts` "AC11 …" |
| AC12 plan-limit Italian message + upgrade CTA | `src/lib/__tests__/entitlement-error.test.ts` (Vitest) + `e2e/tenant-boundary.spec.ts` "AC12 …" |

> Backend AC1–AC10b coverage (entity, migrations, tenant filter, entitlement, regression) is in the linked backend PR's AC table.

## Gate status

| Gate | Command | Result |
|---|---|---|
| G5 FE unit | `npm test` | ✅ 107 passed (17 files) |
| G6 FE types | `tsc -b --noEmit` | ✅ exit 0 |
| G7 FE lint | `npm run lint` (`eslint .`) | ⚠️ **pre-existing repo-wide ESLint baseline — 0 new errors from this PR** (see note) |
| G8 FE build | `npm run build` | ✅ exit 0 |
| G9 E2E | `npm run test:e2e` | ✅ 38 passed, 7 skipped, 0 failed (incl. 2 new #202 specs) |
| G1–G4, G10–G13 (backend/compliance) | — | ✅ / N/A — see linked backend PR |

### ⚠️ G7 note — accepted pre-existing debt (0 new errors from this PR)

`npm run lint` runs `eslint .` over the **entire** repo and reports **47 errors / 8 warnings, all pre-existing and unrelated to #202**:

1. **~45 errors are in files this branch never modified** (e.g. `src/api/bookings.api.ts`, `src/api/client.ts`, `src/api/ota.api.ts`, `src/api/payments.api.ts`, `src/components/ui/{input,label,textarea}.tsx`, `src/features/{bookings,leases,ota,payments,pricing}/...`, `src/types/{guest,ota,tourist-tax}.types.ts`, `e2e/pricing-adapter.spec.ts`). **Byte-identical-file evidence:** `git diff --quiet -- src/api/bookings.api.ts` shows it is unchanged vs `develop`, yet `npx eslint src/api/bookings.api.ts` reports an error — a file byte-identical to `develop` fails lint, proving `develop` is already red.
2. **The only 2 errors in files #202 touched are on pre-existing lines** not in the #202 diff: `property-form.tsx:53` (`as any` on the RHF `defaultValues` cast — #202 only added the `disabled?` prop) and `properties-page.tsx:36` (unused `catch (error)` in the untouched `toggleActive` — #202 only changed the other, `error`-using catch).
3. **All files authored for #202 lint clean:** `npx eslint` over `e2e/tenant-boundary.spec.ts`, `e2e/helpers/org-api-mock.ts`, `src/components/org/`, `src/lib/entitlement-error.ts` (+ test), `src/api/orgs.api.ts`, `src/types/org.types.ts` → **0 problems**.

Making `eslint .` exit 0 would require editing ~25 unrelated files, violating the staging-hygiene mandate (feature-only diff). The baseline is tracked for a separate repo-wide lint-cleanup chore PR.

---

Backend PR: https://github.com/casazen/backend/pull/203

Closes casazen/backend#202
