### PR TITLE
release: v1.1.6 (#202 tenant boundary UI)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run E2E tests
+      - name: Run E2E tests (demo mode)
         run: npm run test:e2e
 
       - name: Upload Playwright report
@@ -33,3 +33,44 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  e2e-deploy-smoke:
+    name: E2E deploy smoke (Vercel + Railway)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for Railway/Vercel deploy
+        run: sleep 90
+
+      - name: Vercel FE deploy smoke
+        env:
+          E2E_DEPLOY_SMOKE: '1'
+          E2E_DEPLOY_FE_URL: ${{ github.ref == 'refs/heads/main' && 'https://casazen-app.vercel.app' || 'https://casazen-app.vercel.app' }}
+        run: npm run test:e2e -- vercel-deploy-smoke
+
+      - name: Railway API regression (authenticated)
+        env:
+          E2E_STAGING: '1'
+          E2E_STAGING_API_URL: ${{ vars.RAILWAY_TEST_URL }}/api
+          E2E_AUTH0_EMAIL: ${{ secrets.E2E_AUTH0_EMAIL }}
+          E2E_AUTH0_PASSWORD: ${{ secrets.E2E_AUTH0_PASSWORD }}
+        run: |
+          if [ -z "$E2E_AUTH0_EMAIL" ] || [ -z "$E2E_AUTH0_PASSWORD" ]; then
+            echo "::warning::E2E_AUTH0_EMAIL/PASSWORD not set — skipping authenticated Railway API regression."
+            echo "Add GitHub secrets to catch EF migration 500s on authenticated routes."
+            exit 0
+          fi
+          npm run test:e2e -- api-regression-smoke property-staging

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,10 +68,16 @@ jobs:
           E2E_STAGING_API_URL: ${{ vars.RAILWAY_TEST_URL }}/api
           E2E_AUTH0_EMAIL: ${{ secrets.E2E_AUTH0_EMAIL }}
           E2E_AUTH0_PASSWORD: ${{ secrets.E2E_AUTH0_PASSWORD }}
+          VITE_AUTH0_DOMAIN: ${{ vars.VITE_AUTH0_DOMAIN }}
+          VITE_AUTH0_CLIENT_ID: ${{ vars.VITE_AUTH0_CLIENT_ID }}
+          VITE_AUTH0_AUDIENCE: ${{ vars.VITE_AUTH0_AUDIENCE }}
         run: |
           if [ -z "$E2E_AUTH0_EMAIL" ] || [ -z "$E2E_AUTH0_PASSWORD" ]; then
             echo "::warning::E2E_AUTH0_EMAIL/PASSWORD not set — skipping authenticated Railway API regression."
             echo "Add GitHub secrets to catch EF migration 500s on authenticated routes."
             exit 0
           fi
-          npm run test:e2e -- api-regression-smoke property-staging
+          export VITE_AUTH0_DOMAIN="${VITE_AUTH0_DOMAIN:-dev-mp6wadq7j6bophl5.us.auth0.com}"
+          export VITE_AUTH0_CLIENT_ID="${VITE_AUTH0_CLIENT_ID:-xmZPesTR04r349c14n77MgJ2iSCeFaJb}"
+          export VITE_AUTH0_AUDIENCE="${VITE_AUTH0_AUDIENCE:-https://casazen-api}"
+          npx playwright test e2e/api-regression-smoke.spec.ts --project=setup --project=staging

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
   e2e-deploy-smoke:
     name: E2E deploy smoke (Vercel + Railway)
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   push:
     branches: [main, develop]
+  workflow_dispatch:
 
 jobs:
   e2e:

--- a/e2e/api-regression-smoke.spec.ts
+++ b/e2e/api-regression-smoke.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { requireE2eCredentials } from './helpers/env';
+
+const STAGING_API =
+  process.env.E2E_STAGING_API_URL ?? 'https://casazen-api-test.up.railway.app/api';
+
+const PROTECTED_ENDPOINTS = [
+  '/properties',
+  '/bookings',
+  '/users/me',
+  '/me/contexts',
+] as const;
+
+/**
+ * Live API regression — authenticated requests must never return 500.
+ * Catches missing EF migrations and schema drift on Railway test/prod.
+ *
+ * Run: E2E_STAGING=1 npm run test:e2e -- api-regression-smoke
+ */
+test.describe('API regression smoke (live Railway)', () => {
+  test.skip(!process.env.E2E_STAGING, 'Set E2E_STAGING=1 to run live API regression');
+  test.setTimeout(120_000);
+
+  test.beforeEach(() => {
+    requireE2eCredentials();
+  });
+
+  async function getAccessToken(page: import('@playwright/test').Page): Promise<string | null> {
+    return page.evaluate(() => {
+      for (const key of Object.keys(localStorage)) {
+        if (!key.includes('auth0spajs')) continue;
+        try {
+          const parsed = JSON.parse(localStorage.getItem(key) ?? '{}');
+          const token = parsed?.body?.access_token;
+          if (typeof token === 'string') return token;
+        } catch {
+          // continue
+        }
+      }
+      return null;
+    });
+  }
+
+  test('authenticated core endpoints never return 500', async ({ page }) => {
+    await page.goto('/app/short-rent');
+    await expect(page.locator('body')).toBeVisible({ timeout: 60_000 });
+
+    const token = await getAccessToken(page);
+    expect(token, 'Auth0 access token must be present after login').toBeTruthy();
+
+    const results = await page.evaluate(
+      async ({ apiBase, paths, bearer }) => {
+        const out: Record<string, number> = {};
+        for (const path of paths) {
+          const res = await fetch(`${apiBase}${path}`, {
+            headers: { Authorization: `Bearer ${bearer}` },
+          });
+          out[path] = res.status;
+        }
+        return out;
+      },
+      { apiBase: STAGING_API, paths: [...PROTECTED_ENDPOINTS], bearer: token! },
+    );
+
+    for (const path of PROTECTED_ENDPOINTS) {
+      const status = results[path];
+      expect(status, `${path} must not return 500 (likely pending EF migration)`).not.toBe(500);
+      expect(status, `${path} should be reachable when authenticated`).toBeGreaterThanOrEqual(200);
+      expect(status, `${path} should not be 401 when authenticated`).not.toBe(401);
+    }
+  });
+});

--- a/e2e/helpers/org-api-mock.ts
+++ b/e2e/helpers/org-api-mock.ts
@@ -1,0 +1,83 @@
+import type { Page } from '@playwright/test';
+import type { PlanTier } from '../../src/types';
+
+interface MockOrgOptions {
+  name?: string;
+  slug?: string;
+  planTier?: PlanTier;
+  orgId?: string;
+}
+
+/**
+ * Mocks GET /api/users/me so the caller profile carries an Org (#202, AC9/AC11).
+ * Non-GET verbs fall through. Register before navigation.
+ */
+export async function mockCurrentUserWithOrg(page: Page, options: MockOrgOptions = {}): Promise<void> {
+  const org = {
+    id: options.orgId ?? 'org-e2e-0001',
+    name: options.name ?? 'Acme Stays',
+    slug: options.slug ?? 'acme-stays',
+    planTier: options.planTier ?? 'Pro',
+  };
+
+  await page.route('**/api/users/me', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'auth0|demo-e2e',
+        email: 'demo@casazen.com',
+        firstName: 'Demo',
+        lastName: 'User',
+        role: 'PropertyOwner',
+        rentalType: 'ShortTerm',
+        isActive: true,
+        createdAt: '2026-01-01T00:00:00Z',
+        phoneNumber: null,
+        updatedAt: '2026-01-01T00:00:00Z',
+        orgId: org.id,
+        org,
+      }),
+    });
+  });
+}
+
+interface MockEntitlementOptions {
+  planTier?: PlanTier;
+  maxProperties?: number;
+  properties?: number;
+  canAddProperty?: boolean;
+  orgId?: string;
+}
+
+/** Mocks GET /api/orgs/me/entitlement (#202, AC8) — limits, usage, and create gating. */
+export async function mockEntitlement(page: Page, options: MockEntitlementOptions = {}): Promise<void> {
+  const maxProperties = options.maxProperties ?? 3;
+  const properties = options.properties ?? maxProperties;
+
+  const body = {
+    orgId: options.orgId ?? 'org-e2e-0001',
+    planTier: options.planTier ?? 'Starter',
+    limits: { maxProperties },
+    usage: { properties },
+    canAddProperty: options.canAddProperty ?? properties < maxProperties,
+  };
+
+  await page.route('**/api/orgs/me/entitlement', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}

--- a/e2e/tenant-boundary.spec.ts
+++ b/e2e/tenant-boundary.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { demoUrl } from './helpers/demo-profile';
+import { mockPropertiesApi } from './helpers/properties-api-mock';
+import { mockCurrentUserWithOrg, mockEntitlement } from './helpers/org-api-mock';
+
+const PROPERTIES_URL = '/app/short-rent/properties';
+const PROPERTY_CREATE_URL = '/app/short-rent/properties/create';
+
+test.describe('Multi-tenant Org boundary (#202)', () => {
+  test('AC11 header surfaces the caller org name and plan badge', async ({ page }) => {
+    await mockCurrentUserWithOrg(page, { name: 'Acme Stays', planTier: 'Pro' });
+    await mockPropertiesApi(page);
+
+    await page.goto(demoUrl(PROPERTIES_URL, 'short-stay'));
+
+    const badge = page.getByTestId('org-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText('Acme Stays');
+    await expect(page.getByTestId('plan-badge')).toContainText('Pro');
+  });
+
+  test('AC12 property create is blocked with an Italian plan-limit message and upgrade CTA', async ({ page }) => {
+    await mockCurrentUserWithOrg(page, { name: 'Acme Stays', planTier: 'Starter' });
+    await mockEntitlement(page, {
+      planTier: 'Starter',
+      maxProperties: 3,
+      properties: 3,
+      canAddProperty: false,
+    });
+
+    await page.goto(demoUrl(PROPERTY_CREATE_URL, 'short-stay'));
+
+    const alert = page.getByTestId('plan-limit-alert');
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText('Hai raggiunto il limite del tuo piano');
+    await expect(page.getByRole('link', { name: 'Passa a un piano superiore' })).toBeVisible();
+
+    // Server stays the source of truth, but the client pre-disables submit while over the limit.
+    await expect(page.getByRole('button', { name: 'Create Property' })).toBeDisabled();
+  });
+});

--- a/e2e/vercel-deploy-smoke.spec.ts
+++ b/e2e/vercel-deploy-smoke.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const FE_URL =
+  process.env.E2E_DEPLOY_FE_URL ??
+  (process.env.E2E_STAGING === '1'
+    ? 'https://casazen-app.vercel.app'
+    : 'http://localhost:5173');
+
+/**
+ * Verifies deployed Vercel FE serves the React SPA (not a broken .env or placeholder).
+ * Run in CI: E2E_DEPLOY_SMOKE=1 E2E_DEPLOY_FE_URL=https://casazen-app.vercel.app
+ */
+test.describe('Vercel deploy smoke', () => {
+  test.skip(!process.env.E2E_DEPLOY_SMOKE, 'Set E2E_DEPLOY_SMOKE=1 for live FE deploy checks');
+
+  test('serves React root on deployed URL', async ({ page }) => {
+    await page.goto(FE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#root')).toBeAttached({ timeout: 30_000 });
+    const html = await page.content();
+    expect(html).not.toContain('GEMINI_API_KEY');
+    expect(html).not.toMatch(/VITE_[A-Z_]+=placeholder/i);
+  });
+
+  test('login page or app shell loads without console 500 storms', async ({ page }) => {
+    const serverErrors: string[] = [];
+    page.on('response', (res) => {
+      if (res.status() >= 500 && res.url().includes('/api/')) {
+        serverErrors.push(`${res.status()} ${res.url()}`);
+      }
+    });
+
+    await page.goto(FE_URL, { waitUntil: 'networkidle', timeout: 60_000 });
+    await expect(page.locator('#root')).toBeAttached();
+
+    expect(
+      serverErrors,
+      `API 500 responses on page load: ${serverErrors.join(', ')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ import { defineConfig, devices } from '@playwright/test';
  * @see https://playwright.dev/docs/test-configuration
  */
 const isStagingRun = process.env.E2E_STAGING === '1';
+const isDeploySmokeRun = process.env.E2E_DEPLOY_SMOKE === '1';
 
 export default defineConfig({
   testDir: './e2e',
@@ -24,7 +25,18 @@ export default defineConfig({
     viewport: { width: 1280, height: 720 },
   },
 
-  projects: isStagingRun
+  projects: isDeploySmokeRun
+    ? [
+        {
+          name: 'deploy-smoke',
+          testMatch: '**/vercel-deploy-smoke.spec.ts',
+          use: {
+            ...devices['Desktop Chrome'],
+            baseURL: process.env.E2E_DEPLOY_FE_URL ?? 'https://casazen-app.vercel.app',
+          },
+        },
+      ]
+    : isStagingRun
     ? [
         {
           name: 'setup',
@@ -32,7 +44,7 @@ export default defineConfig({
         },
         {
           name: 'staging',
-          testMatch: '**/property-staging.spec.ts',
+          testMatch: /\/(property-staging|api-regression-smoke)\.spec\.ts/,
           dependencies: ['setup'],
           use: {
             ...devices['Desktop Chrome'],
@@ -44,12 +56,18 @@ export default defineConfig({
     : [
         {
           name: 'chromium',
-          testIgnore: ['**/property-staging.spec.ts'],
+          testIgnore: [
+            '**/property-staging.spec.ts',
+            '**/api-regression-smoke.spec.ts',
+            '**/vercel-deploy-smoke.spec.ts',
+          ],
           use: { ...devices['Desktop Chrome'] },
         },
       ],
 
-  webServer: isStagingRun
+  webServer: isDeploySmokeRun
+    ? undefined
+    : isStagingRun
     ? {
         command: 'npm run dev',
         url: 'http://localhost:5173',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,6 +76,12 @@ export default defineConfig({
         env: {
           VITE_API_BASE_URL:
             process.env.E2E_STAGING_API_URL ?? 'https://casazen-api-test.up.railway.app/api',
+          VITE_AUTH0_DOMAIN:
+            process.env.VITE_AUTH0_DOMAIN ?? 'dev-mp6wadq7j6bophl5.us.auth0.com',
+          VITE_AUTH0_CLIENT_ID:
+            process.env.VITE_AUTH0_CLIENT_ID ?? 'xmZPesTR04r349c14n77MgJ2iSCeFaJb',
+          VITE_AUTH0_AUDIENCE:
+            process.env.VITE_AUTH0_AUDIENCE ?? 'https://casazen-api',
         },
       }
     : {

--- a/src/api/orgs.api.ts
+++ b/src/api/orgs.api.ts
@@ -1,0 +1,8 @@
+import { ApiClient } from '@/api/client';
+import type { Entitlement } from '@/types';
+
+export const OrgsApi = {
+  /** GET /api/orgs/me/entitlement — resolved plan limits + usage for the caller's org (#202, AC8). */
+  getMyEntitlement: (): Promise<Entitlement> =>
+    ApiClient.get<Entitlement>('/orgs/me/entitlement'),
+};

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
 import { UserMenu } from '@/components/auth/user-menu';
 import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { OrgBadge } from '@/components/org/org-badge';
 import { useUiStore } from '@/store/ui-store';
 
 interface HeaderProps {
@@ -22,7 +23,10 @@ export function Header({ slotStart }: HeaderProps) {
       </Button>
       {slotStart}
       <div className="flex-1" />
-      <UserMenu />
+      <div className="flex items-center gap-3">
+        <OrgBadge />
+        <UserMenu />
+      </div>
     </header>
   );
 }

--- a/src/components/org/__tests__/org-badge.test.tsx
+++ b/src/components/org/__tests__/org-badge.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { OrgBadge } from '../org-badge';
+import { PlanBadge } from '../plan-badge';
+import * as useUsers from '@/queries/use-users';
+
+vi.mock('@/queries/use-users');
+
+const mocked = vi.mocked(useUsers);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('OrgBadge (#202 AC11)', () => {
+  it('renders the org name and plan badge when the caller has an org', () => {
+    mocked.useCurrentUser.mockReturnValue({
+      org: { id: 'o1', name: 'Acme Stays', slug: 'acme-stays', planTier: 'Pro' },
+      planTier: 'Pro',
+      user: null,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUsers.useCurrentUser>);
+
+    render(<OrgBadge />);
+
+    expect(screen.getByTestId('org-badge')).toBeInTheDocument();
+    expect(screen.getByText('Acme Stays')).toBeInTheDocument();
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent('Pro');
+  });
+
+  it('renders nothing while the current user is loading', () => {
+    mocked.useCurrentUser.mockReturnValue({
+      org: null,
+      planTier: null,
+      user: null,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useUsers.useCurrentUser>);
+
+    const { container } = render(<OrgBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the caller has no org yet (pre-backfill safety)', () => {
+    mocked.useCurrentUser.mockReturnValue({
+      org: null,
+      planTier: null,
+      user: null,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUsers.useCurrentUser>);
+
+    const { container } = render(<OrgBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('PlanBadge (#202 AC11)', () => {
+  it('renders the tier label for each plan', () => {
+    const { rerender } = render(<PlanBadge planTier="Starter" />);
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent('Starter');
+
+    rerender(<PlanBadge planTier="Scale" />);
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent('Scale');
+  });
+});

--- a/src/components/org/org-badge.tsx
+++ b/src/components/org/org-badge.tsx
@@ -1,0 +1,22 @@
+import { useCurrentUser } from '@/queries/use-users';
+import { PlanBadge } from './plan-badge';
+
+/**
+ * Org + plan indicator for the app header (#202, AC11).
+ * Renders nothing while loading or when the caller has no org (pre-backfill), so the
+ * header degrades gracefully instead of breaking for tenant-less users.
+ */
+export function OrgBadge() {
+  const { org, isLoading } = useCurrentUser();
+
+  if (isLoading || !org) return null;
+
+  return (
+    <div className="flex items-center gap-2" data-testid="org-badge">
+      <span className="hidden max-w-[12rem] truncate text-sm font-medium text-foreground sm:inline">
+        {org.name}
+      </span>
+      <PlanBadge planTier={org.planTier} />
+    </div>
+  );
+}

--- a/src/components/org/plan-badge.tsx
+++ b/src/components/org/plan-badge.tsx
@@ -1,0 +1,26 @@
+import { Badge, type BadgeProps } from '@/components/ui/badge';
+import type { PlanTier } from '@/types';
+
+const TIER_VARIANT: Record<PlanTier, BadgeProps['variant']> = {
+  Starter: 'secondary',
+  Pro: 'default',
+  Scale: 'success',
+};
+
+interface PlanBadgeProps {
+  planTier: PlanTier;
+  className?: string;
+}
+
+/** Read-only plan indicator (#202, AC11). */
+export function PlanBadge({ planTier, className }: PlanBadgeProps) {
+  return (
+    <Badge
+      variant={TIER_VARIANT[planTier] ?? 'secondary'}
+      className={className}
+      data-testid="plan-badge"
+    >
+      {planTier}
+    </Badge>
+  );
+}

--- a/src/features/properties/components/property-form.tsx
+++ b/src/features/properties/components/property-form.tsx
@@ -15,9 +15,11 @@ interface PropertyFormProps {
   onSubmit: (data: PropertyFormValues) => void;
   onCancel?: () => void;
   isLoading?: boolean;
+  /** When true, the submit action is blocked (e.g. plan limit reached, #202). */
+  disabled?: boolean;
 }
 
-export function PropertyForm({ property, onSubmit, onCancel, isLoading }: PropertyFormProps) {
+export function PropertyForm({ property, onSubmit, onCancel, isLoading, disabled }: PropertyFormProps) {
   const {
     register,
     handleSubmit,
@@ -308,7 +310,7 @@ export function PropertyForm({ property, onSubmit, onCancel, isLoading }: Proper
         <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading}>
           Cancel
         </Button>
-        <Button type="submit" disabled={isLoading}>
+        <Button type="submit" disabled={isLoading || disabled}>
           {isLoading ? 'Saving...' : property ? 'Update Property' : 'Create Property'}
         </Button>
       </div>

--- a/src/features/properties/properties-page.tsx
+++ b/src/features/properties/properties-page.tsx
@@ -13,9 +13,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { MoreHorizontal, Plus } from 'lucide-react';
+import { toast } from 'sonner';
 import { useProperties, useUpdateProperty, useCreateProperty } from '@/queries/use-properties';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { PropertyForm } from './components/property-form';
+import { isPlanLimitError, PLAN_LIMIT_MESSAGE } from '@/lib/entitlement-error';
 import type { Property } from '@/types';
 import type { PropertyFormValues } from './schemas/property.schema';
 
@@ -41,7 +43,13 @@ export function PropertiesPage() {
       await createProperty.mutateAsync(data);
       setIsDialogOpen(false);
     } catch (error) {
-      // Error toast already handled by mutation
+      // Plan-limit (403/409) is suppressed by the mutation's onError; surface the Italian
+      // message here so the dialog still informs the owner (#202, AC12).
+      if (isPlanLimitError(error)) {
+        toast.error(PLAN_LIMIT_MESSAGE);
+        return;
+      }
+      // Other errors already surfaced by the mutation's onError toast.
     }
   };
 

--- a/src/features/properties/property-create-page.tsx
+++ b/src/features/properties/property-create-page.tsx
@@ -1,28 +1,71 @@
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { PropertyForm } from './components/property-form';
 import { useCreateProperty } from '@/queries/use-properties';
+import { useEntitlement } from '@/queries/use-users';
+import {
+  isPlanLimitError,
+  PLAN_LIMIT_MESSAGE,
+  PLAN_UPGRADE_CTA,
+  PLAN_UPGRADE_PATH,
+} from '@/lib/entitlement-error';
 import type { PropertyFormValues } from './schemas/property.schema';
 
 export function PropertyCreatePage() {
   const navigate = useNavigate();
   const createProperty = useCreateProperty();
+  const { data: entitlement } = useEntitlement();
+  const [planLimitHit, setPlanLimitHit] = useState(false);
+
+  // Block on a proactive entitlement read OR a server 403/409 we just caught.
+  // The server stays the source of truth — a stale client cannot bypass the limit (AC8/AC12).
+  const blockedByPlan = planLimitHit || entitlement?.canAddProperty === false;
 
   const handleSubmit = async (data: PropertyFormValues) => {
-    await createProperty.mutateAsync(data);
-    navigate('/app/short-rent/properties');
+    setPlanLimitHit(false);
+    try {
+      await createProperty.mutateAsync(data);
+      navigate('/app/short-rent/properties');
+    } catch (error) {
+      if (isPlanLimitError(error)) {
+        setPlanLimitHit(true);
+        return;
+      }
+      throw error;
+    }
   };
 
   return (
     <AppShell>
       <div className="space-y-6 max-w-4xl mx-auto">
         <PageHeader
-          title="Create Property"
-          description="Add a new vacation rental property to your portfolio"
+          title="Crea proprietà"
+          description="Aggiungi una nuova struttura ricettiva al tuo portfolio"
         />
 
-        <PropertyForm onSubmit={handleSubmit} isLoading={createProperty.isPending} />
+        {blockedByPlan && (
+          <div
+            role="alert"
+            data-testid="plan-limit-alert"
+            className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm"
+          >
+            <p className="font-medium text-destructive">{PLAN_LIMIT_MESSAGE}</p>
+            <Link
+              to={PLAN_UPGRADE_PATH}
+              className="mt-1 inline-block font-medium text-primary underline underline-offset-2"
+            >
+              {PLAN_UPGRADE_CTA}
+            </Link>
+          </div>
+        )}
+
+        <PropertyForm
+          onSubmit={handleSubmit}
+          isLoading={createProperty.isPending}
+          disabled={blockedByPlan}
+        />
       </div>
     </AppShell>
   );

--- a/src/lib/__tests__/entitlement-error.test.ts
+++ b/src/lib/__tests__/entitlement-error.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { isPlanLimitError } from '../entitlement-error';
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+  const error = new AxiosError('request failed');
+  error.response = {
+    status,
+    data,
+    statusText: '',
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
+
+describe('isPlanLimitError (#202 AC12)', () => {
+  it('is true for a 403 with code plan_limit_reached', () => {
+    expect(isPlanLimitError(axiosErrorWith(403, { code: 'plan_limit_reached' }))).toBe(true);
+  });
+
+  it('is true for a 409 race with code plan_limit_reached', () => {
+    expect(isPlanLimitError(axiosErrorWith(409, { code: 'plan_limit_reached' }))).toBe(true);
+  });
+
+  it('is false for a 403 that is not a plan-limit (e.g. missing permission)', () => {
+    expect(isPlanLimitError(axiosErrorWith(403, { code: 'no_org_context' }))).toBe(false);
+  });
+
+  it('is false for a 400 validation error even if the code matches', () => {
+    expect(isPlanLimitError(axiosErrorWith(400, { code: 'plan_limit_reached' }))).toBe(false);
+  });
+
+  it('is false for non-axios errors', () => {
+    expect(isPlanLimitError(new Error('boom'))).toBe(false);
+    expect(isPlanLimitError(null)).toBe(false);
+    expect(isPlanLimitError(undefined)).toBe(false);
+  });
+});

--- a/src/lib/entitlement-error.ts
+++ b/src/lib/entitlement-error.ts
@@ -1,0 +1,28 @@
+import { AxiosError } from 'axios';
+
+/** Italian end-user copy shown when a write is blocked by the org's plan limit (#202, AC8/AC12). */
+export const PLAN_LIMIT_MESSAGE = 'Hai raggiunto il limite del tuo piano';
+
+/** Italian CTA label pointing at the (billing-spec-owned) upgrade route. */
+export const PLAN_UPGRADE_CTA = 'Passa a un piano superiore';
+
+/** Target route for the upgrade CTA. Route is owned by spec-saas-billing; we only link to it. */
+export const PLAN_UPGRADE_PATH = '/app/billing/upgrade';
+
+interface EntitlementErrorBody {
+  code?: string;
+  error?: string;
+  planTier?: string;
+  limit?: number;
+}
+
+/**
+ * True when the backend rejected a write because the org hit its plan limit.
+ * The server returns 403 (property create) or 409 with code "plan_limit_reached".
+ */
+export function isPlanLimitError(error: unknown): boolean {
+  if (!(error instanceof AxiosError)) return false;
+  const status = error.response?.status;
+  const code = (error.response?.data as EntitlementErrorBody | undefined)?.code;
+  return (status === 403 || status === 409) && code === 'plan_limit_reached';
+}

--- a/src/queries/use-properties.ts
+++ b/src/queries/use-properties.ts
@@ -7,6 +7,8 @@ import type {
   PropertyDocumentType,
 } from '@/types';
 import { toast } from 'sonner';
+import { ENTITLEMENT_QUERY_KEY } from '@/queries/use-users';
+import { isPlanLimitError } from '@/lib/entitlement-error';
 
 const PROPERTIES_KEY = 'properties';
 
@@ -40,9 +42,14 @@ export function useCreateProperty() {
     mutationFn: (data: CreatePropertyDto) => propertiesApi.create(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [PROPERTIES_KEY] });
+      // Usage changed → plan badge / create gating must refetch (#202, AC8).
+      queryClient.invalidateQueries({ queryKey: ENTITLEMENT_QUERY_KEY });
       toast.success('Property created successfully');
     },
-    onError: () => {
+    onError: (error: unknown) => {
+      // Plan-limit (403/409) is surfaced as an Italian message + upgrade CTA by the call site
+      // (create page inline alert / list dialog toast), so skip the generic error toast here.
+      if (isPlanLimitError(error)) return;
       toast.error('Failed to create property');
     },
   });

--- a/src/queries/use-users.ts
+++ b/src/queries/use-users.ts
@@ -1,10 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { UsersApi } from '@/api/users.api';
+import { OrgsApi } from '@/api/orgs.api';
 import type { RentalType, UpdateProfileRequest } from '@/types';
 import { toast } from 'sonner';
 
 const USERS_KEY = 'users';
 const ME_KEY = 'me';
+
+/** Query key for the caller's resolved plan entitlement (#202). Exported so writes can invalidate it. */
+export const ENTITLEMENT_QUERY_KEY = ['entitlement'] as const;
 
 interface GetUsersParams {
   page?: number;
@@ -33,6 +37,28 @@ export function useMe() {
   return useQuery({
     queryKey: [ME_KEY],
     queryFn: () => UsersApi.getMe(),
+  });
+}
+
+/**
+ * Convenience wrapper over {@link useMe} that surfaces the caller's org + plan (#202, AC9/AC11).
+ * Returns null org for users with no tenant yet (pre-backfill) so the UI can fail gracefully.
+ */
+export function useCurrentUser() {
+  const query = useMe();
+  return {
+    ...query,
+    user: query.data ?? null,
+    org: query.data?.org ?? null,
+    planTier: query.data?.org?.planTier ?? null,
+  };
+}
+
+/** Resolved plan entitlement (limits + usage) for the caller's org (#202, AC8). */
+export function useEntitlement() {
+  return useQuery({
+    queryKey: ENTITLEMENT_QUERY_KEY,
+    queryFn: () => OrgsApi.getMyEntitlement(),
   });
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,3 +12,4 @@ export * from './pricing-adapter.types';
 export * from './lease.types';
 export * from './admin.types';
 export * from './users.types';
+export * from './org.types';

--- a/src/types/org.types.ts
+++ b/src/types/org.types.ts
@@ -1,0 +1,28 @@
+// US-004 (#202) tenant boundary — org + plan entitlement surfaced read-only on the frontend.
+
+export type PlanTier = 'Starter' | 'Pro' | 'Scale';
+
+/** Public projection of the caller's organization (AC9/AC11). Never carries Stripe/billing ids. */
+export interface Org {
+  id: string;
+  name: string;
+  slug: string;
+  planTier: PlanTier;
+}
+
+export interface EntitlementLimits {
+  maxProperties: number;
+}
+
+export interface EntitlementUsage {
+  properties: number;
+}
+
+/** Resolved plan entitlement for the caller's org (AC8). Backs the plan badge + create gating. */
+export interface Entitlement {
+  orgId: string;
+  planTier: PlanTier;
+  limits: EntitlementLimits;
+  usage: EntitlementUsage;
+  canAddProperty: boolean;
+}

--- a/src/types/users.types.ts
+++ b/src/types/users.types.ts
@@ -1,3 +1,5 @@
+import type { Org } from './org.types';
+
 export type UserRole =
   | 'Admin'
   | 'PropertyOwner'
@@ -22,6 +24,9 @@ export interface UserSummary {
 export interface UserDetail extends UserSummary {
   phoneNumber?: string;
   updatedAt: string;
+  // Tenant boundary (#202, AC9). Nullable: a brand-new user pre-backfill has no org yet.
+  orgId?: string | null;
+  org?: Org | null;
 }
 
 export interface UpdateProfileRequest {


### PR DESCRIPTION
## Release v1.1.6

Promotes **develop → main** for Issue casazen/backend#202 (tenant boundary UI).

### Included
- Org/plan badges in header
- Entitlement error handling on property create
- E2E tenant-boundary specs (AC11/AC12)

### Staging validation
- npm run test:e2e: 38 passed, 7 skipped

Related: casazen/backend#202
