### PR TITLE
feat(search): public property read-model on search page (#212)

### DIFF
--- a/e2e/helpers/public-booking-readmodel-mock.ts
+++ b/e2e/helpers/public-booking-readmodel-mock.ts
@@ -1,0 +1,92 @@
+import type { Page } from '@playwright/test';
+import type { PublicPropertyDto } from '../../src/types';
+
+export const PUBLIC_SEARCH_PROPERTY_ID = '11111111-1111-1111-1111-111111111111';
+
+export const mockPublicSearchResults: PublicPropertyDto[] = [
+  {
+    id: PUBLIC_SEARCH_PROPERTY_ID,
+    name: 'Trastevere Loft',
+    description: 'Bright apartment in the heart of Rome.',
+    city: 'Rome',
+    postalCode: '00153',
+    latitude: 41.889,
+    longitude: 12.469,
+    bedrooms: 2,
+    bathrooms: 1,
+    maxGuests: 4,
+    nightlyRate: 145,
+    cleaningFee: 50,
+    amenities: ['Wifi', 'Parking'],
+    photoUrls: ['https://cdn.example.com/trastevere.jpg'],
+    cinCode: 'IT-12345-0123456789',
+    cinStatus: 'Valid',
+    timezone: 'Europe/Rome',
+  },
+  {
+    id: '22222222-2222-2222-2222-222222222222',
+    name: 'Duomo View',
+    description: 'Steps from the cathedral.',
+    city: 'Milan',
+    postalCode: '20121',
+    bedrooms: 1,
+    bathrooms: 1,
+    maxGuests: 2,
+    nightlyRate: 120,
+    cleaningFee: 40,
+    amenities: ['Wifi'],
+    photoUrls: [],
+    cinCode: null,
+    cinStatus: 'Missing',
+    timezone: 'Europe/Rome',
+  },
+];
+
+/**
+ * Mocks anonymous public booking read endpoints (#212).
+ */
+export async function mockPublicBookingReadApi(
+  page: Page,
+  results: PublicPropertyDto[] = mockPublicSearchResults,
+): Promise<void> {
+  await page.route('**/api/properties/search**', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(results),
+    });
+  });
+
+  await page.route('**/api/properties/*/public', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    const match = route.request().url().match(/\/api\/properties\/([^/]+)\/public/);
+    const id = match?.[1];
+    const property = results.find((p) => p.id === id);
+
+    if (!property) {
+      await route.fulfill({ status: 404, body: JSON.stringify({ title: 'Not Found' }) });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...property,
+        houseRules: 'No parties.',
+        cancellationPolicySummary: 'Free cancellation up to 7 days before check-in.',
+        minNights: null,
+        currency: 'EUR',
+      }),
+    });
+  });
+}

--- a/e2e/public-booking-readmodel.spec.ts
+++ b/e2e/public-booking-readmodel.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { demoUrl } from './helpers/demo-profile';
+import {
+  mockPublicBookingReadApi,
+  mockPublicSearchResults,
+  PUBLIC_SEARCH_PROPERTY_ID,
+} from './helpers/public-booking-readmodel-mock';
+
+const SEARCH_URL = '/search';
+
+test.describe('Public booking read-model (#212)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPublicBookingReadApi(page);
+  });
+
+  test('AC11: search results show CIN badge, city, price, and capacity without operator identity', async ({ page }) => {
+    await page.goto(demoUrl(SEARCH_URL, 'short-stay'));
+
+    await expect(page.getByRole('heading', { name: 'Trastevere Loft' })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('CIN valido')).toBeVisible();
+    await expect(page.getByText('Rome (00153)')).toBeVisible();
+    await expect(page.getByText('CIN mancante')).toBeVisible();
+
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText.toLowerCase()).not.toContain('ownerid');
+    expect(bodyText.toLowerCase()).not.toContain('auth0');
+  });
+
+  test('AC12: public search request is sent without Authorization header', async ({ page }) => {
+    let authHeader: string | undefined;
+
+    await page.route('**/api/properties/search**', async (route) => {
+      authHeader = route.request().headers()['authorization'];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockPublicSearchResults),
+      });
+    });
+
+    await page.goto(demoUrl(SEARCH_URL, 'short-stay'));
+    await expect(page.getByRole('heading', { name: 'Trastevere Loft' })).toBeVisible({ timeout: 15_000 });
+
+    expect(authHeader).toBeUndefined();
+  });
+
+  test('AC12: public detail request is sent without Authorization header', async ({ page }) => {
+    let authHeader: string | undefined;
+
+    await page.route(`**/api/properties/${PUBLIC_SEARCH_PROPERTY_ID}/public`, async (route) => {
+      authHeader = route.request().headers()['authorization'];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockPublicSearchResults[0],
+          houseRules: 'Quiet hours after 22:00.',
+          cancellationPolicySummary: 'Flexible',
+          minNights: null,
+          currency: 'EUR',
+        }),
+      });
+    });
+
+    await page.goto(demoUrl(SEARCH_URL, 'short-stay'));
+    await page.evaluate(async (id) => {
+      await fetch(`/api/properties/${id}/public`);
+    }, PUBLIC_SEARCH_PROPERTY_ID);
+
+    expect(authHeader).toBeUndefined();
+  });
+});

--- a/src/api/__tests__/properties.api.test.ts
+++ b/src/api/__tests__/properties.api.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { propertiesApi } from '../properties.api';
+import { ApiClient } from '../client';
+import type { PublicPropertyDetailDto, PublicPropertyDto } from '@/types';
+
+vi.mock('../client');
+
+const mockListItem: PublicPropertyDto = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Trastevere Loft',
+  description: 'Bright apartment',
+  city: 'Rome',
+  postalCode: '00153',
+  bedrooms: 2,
+  bathrooms: 1,
+  maxGuests: 4,
+  nightlyRate: 145,
+  cleaningFee: 50,
+  amenities: ['Wifi'],
+  photoUrls: ['https://cdn.example.com/photo.jpg'],
+  cinCode: 'IT-12345-0123456789',
+  cinStatus: 'Valid',
+  timezone: 'Europe/Rome',
+};
+
+const mockDetail: PublicPropertyDetailDto = {
+  ...mockListItem,
+  houseRules: 'No smoking',
+  cancellationPolicySummary: 'Flexible',
+  minNights: null,
+  currency: 'EUR',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('propertiesApi public read-model (#212)', () => {
+  it('AC10: search maps minBedrooms to bedrooms and returns PublicPropertyDto[]', async () => {
+    vi.mocked(ApiClient.get).mockResolvedValueOnce([mockListItem]);
+
+    const result = await propertiesApi.search({ city: 'Rome', minBedrooms: 2, maxPrice: 200 });
+
+    expect(ApiClient.get).toHaveBeenCalledWith('/properties/search', {
+      city: 'Rome',
+      bedrooms: 2,
+      maxPrice: 200,
+    });
+    expect(result).toEqual([mockListItem]);
+    expect(result[0]).not.toHaveProperty('ownerId');
+  });
+
+  it('AC10: getPublicProperty calls GET /properties/:id/public', async () => {
+    vi.mocked(ApiClient.get).mockResolvedValueOnce(mockDetail);
+
+    const result = await propertiesApi.getPublicProperty(mockListItem.id);
+
+    expect(ApiClient.get).toHaveBeenCalledWith(`/properties/${mockListItem.id}/public`);
+    expect(result.currency).toBe('EUR');
+    expect(result).not.toHaveProperty('ownerId');
+  });
+});

--- a/src/api/properties.api.ts
+++ b/src/api/properties.api.ts
@@ -8,6 +8,8 @@ import type {
   PropertyDocument,
   PropertyDetailDto,
   PropertyDocumentDto,
+  PublicPropertyDto,
+  PublicPropertyDetailDto,
 } from '@/types';
 
 export const propertiesApi = {
@@ -24,8 +26,16 @@ export const propertiesApi = {
 
   delete: (id: string) => ApiClient.delete<void>(`/properties/${id}`),
 
-  search: (params: PropertySearchParams) =>
-    ApiClient.get<Property[]>('/properties/search', params),
+  search: (params: PropertySearchParams) => {
+    const apiParams: Record<string, string | number | undefined> = {};
+    if (params.city) apiParams.city = params.city;
+    if (params.minBedrooms !== undefined) apiParams.bedrooms = params.minBedrooms;
+    if (params.maxPrice !== undefined) apiParams.maxPrice = params.maxPrice;
+    return ApiClient.get<PublicPropertyDto[]>('/properties/search', apiParams);
+  },
+
+  getPublicProperty: (id: string) =>
+    ApiClient.get<PublicPropertyDetailDto>(`/properties/${id}/public`),
 
   getDocuments: (id: string) =>
     ApiClient.get<PropertyDocument[]>(`/properties/${id}/documents`),

--- a/src/features/search/components/property-search-card.tsx
+++ b/src/features/search/components/property-search-card.tsx
@@ -3,20 +3,31 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { MapPin, Bed, Bath, Users, Euro } from 'lucide-react';
 import { formatCurrency } from '@/lib/utils';
-import type { Property } from '@/types';
+import { PropertyCinBadge } from '@/features/properties/components/property-cin-badge';
+import type { PublicPropertyDto } from '@/types';
 
 interface PropertySearchCardProps {
-  property: Property;
-  onViewDetails: (property: Property) => void;
+  property: PublicPropertyDto;
+  onViewDetails: (property: PublicPropertyDto) => void;
 }
 
 export function PropertySearchCard({ property, onViewDetails }: PropertySearchCardProps) {
+  const heroPhoto = property.photoUrls[0];
+
   return (
     <Card className="overflow-hidden hover:shadow-lg transition-shadow">
       <CardHeader className="p-0">
-        <div className="h-48 bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
-          <div className="text-6xl">🏠</div>
-        </div>
+        {heroPhoto ? (
+          <img
+            src={heroPhoto}
+            alt={property.name}
+            className="h-48 w-full object-cover"
+          />
+        ) : (
+          <div className="h-48 bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
+            <div className="text-6xl">🏠</div>
+          </div>
+        )}
       </CardHeader>
 
       <CardContent className="p-4 space-y-3">
@@ -25,10 +36,13 @@ export function PropertySearchCard({ property, onViewDetails }: PropertySearchCa
           <div className="flex items-center gap-1 text-sm text-muted-foreground">
             <MapPin className="h-3 w-3" />
             <span className="line-clamp-1">
-              {property.address}, {property.city}
+              {property.city}
+              {property.postalCode ? ` (${property.postalCode})` : ''}
             </span>
           </div>
         </div>
+
+        <PropertyCinBadge cinStatus={property.cinStatus} cinCode={property.cinCode} />
 
         {property.description && (
           <p className="text-sm text-muted-foreground line-clamp-2">

--- a/src/features/search/components/search-results.tsx
+++ b/src/features/search/components/search-results.tsx
@@ -2,12 +2,12 @@ import { PropertySearchCard } from './property-search-card';
 import { EmptyState } from '@/components/shared/empty-state';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Search } from 'lucide-react';
-import type { Property } from '@/types';
+import type { PublicPropertyDto } from '@/types';
 
 interface SearchResultsProps {
-  properties: Property[];
+  properties: PublicPropertyDto[];
   isLoading?: boolean;
-  onViewDetails: (property: Property) => void;
+  onViewDetails: (property: PublicPropertyDto) => void;
 }
 
 export function SearchResults({ properties, isLoading, onViewDetails }: SearchResultsProps) {

--- a/src/features/search/search-page.tsx
+++ b/src/features/search/search-page.tsx
@@ -5,7 +5,7 @@ import { SearchFilters } from './components/search-filters';
 import { SearchResults } from './components/search-results';
 import { useSearchProperties } from '@/queries/use-properties';
 import type { SearchFiltersFormValues } from './schemas/search.schema';
-import type { Property } from '@/types';
+import type { PublicPropertyDto } from '@/types';
 
 export function SearchPage() {
   const [filters, setFilters] = useState<SearchFiltersFormValues>({});
@@ -19,7 +19,7 @@ export function SearchPage() {
     setFilters({});
   };
 
-  const handleViewDetails = (property: Property) => {
+  const handleViewDetails = (property: PublicPropertyDto) => {
     // In a real app, this would navigate to a public property detail page
     console.log('View property details:', property);
   };

--- a/src/lib/__tests__/axios.test.ts
+++ b/src/lib/__tests__/axios.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { InternalAxiosRequestConfig } from 'axios';
+
+const mockGetAccessToken = vi.fn<() => Promise<string | undefined>>();
+
+vi.mock('@/config/api.config', () => ({
+  apiConfig: { baseURL: '/api', timeout: 5000 },
+}));
+
+vi.mock('axios', () => {
+  const instance = {
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+    get: vi.fn(),
+    post: vi.fn(),
+  };
+
+  return {
+    default: {
+      create: vi.fn(() => instance),
+    },
+  };
+});
+
+describe('axios public endpoint allowlist (#212)', () => {
+  let requestInterceptor: (config: InternalAxiosRequestConfig) => Promise<InternalAxiosRequestConfig>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockGetAccessToken.mockResolvedValue('test-token');
+
+    const axiosModule = await import('../axios');
+    axiosModule.setAccessTokenGetter(mockGetAccessToken);
+
+    const axios = (await import('axios')).default;
+    const instance = axios.create();
+    const useMock = vi.mocked(instance.interceptors.request.use);
+    requestInterceptor = useMock.mock.calls[0][0] as typeof requestInterceptor;
+  });
+
+  it('AC12: skips auth for /properties/search', async () => {
+    const config = { url: '/properties/search', headers: {} } as InternalAxiosRequestConfig;
+    const result = await requestInterceptor(config);
+
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+    expect(result.headers?.Authorization).toBeUndefined();
+  });
+
+  it('AC12: skips auth for /properties/:id/public', async () => {
+    const config = {
+      url: '/properties/11111111-1111-1111-1111-111111111111/public',
+      headers: {},
+    } as InternalAxiosRequestConfig;
+
+    await requestInterceptor(config);
+
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('AC12: attaches auth for protected property endpoints', async () => {
+    const config = { url: '/properties', headers: {} } as InternalAxiosRequestConfig;
+    await requestInterceptor(config);
+
+    expect(mockGetAccessToken).toHaveBeenCalled();
+  });
+});

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -30,7 +30,9 @@ axiosInstance.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
     // Skip auth for public endpoints
     const publicEndpoints = ['/health', '/auth/', '/properties/search'];
-    const isPublicEndpoint = publicEndpoints.some(endpoint => config.url?.includes(endpoint));
+    const isPublicEndpoint =
+      publicEndpoints.some((endpoint) => config.url?.includes(endpoint)) ||
+      (config.url?.includes('/properties/') && config.url.includes('/public'));
     
     if (!isPublicEndpoint && getAccessToken) {
       try {

--- a/src/queries/use-properties.ts
+++ b/src/queries/use-properties.ts
@@ -95,6 +95,14 @@ export function useSearchProperties(params?: PropertySearchParams) {
   });
 }
 
+export function usePublicProperty(id: string) {
+  return useQuery({
+    queryKey: [PROPERTIES_KEY, id, 'public'],
+    queryFn: () => propertiesApi.getPublicProperty(id),
+    enabled: !!id,
+  });
+}
+
 export function useUploadPropertyDocument() {
   const queryClient = useQueryClient();
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -96,7 +96,11 @@ export const router = createBrowserRouter([
   },
   {
     path: '/search',
-    element: <SearchPage />,
+    element: (
+      <WorkspaceProvider>
+        <SearchPage />
+      </WorkspaceProvider>
+    ),
   },
   {
     element: (

--- a/src/types/property.types.ts
+++ b/src/types/property.types.ts
@@ -68,6 +68,35 @@ export interface PropertyDocument {
 
 export type CinStatus = 'Valid' | 'Missing' | 'Invalid';
 
+/** Public list read-model (US-001 #212) — no ownerId or internal fields. */
+export interface PublicPropertyDto {
+  id: string;
+  name: string;
+  description: string;
+  city: string;
+  postalCode: string;
+  latitude?: number;
+  longitude?: number;
+  bedrooms: number;
+  bathrooms: number;
+  maxGuests: number;
+  nightlyRate: number;
+  cleaningFee: number;
+  amenities: string[];
+  photoUrls: string[];
+  cinCode: string | null;
+  cinStatus: CinStatus;
+  timezone: string;
+}
+
+/** Public detail read-model for branded site / checkout (US-001 #212). */
+export interface PublicPropertyDetailDto extends PublicPropertyDto {
+  houseRules: string;
+  cancellationPolicySummary: string;
+  minNights: number | null;
+  currency: string;
+}
+
 export type OtaSyncStatus = 'Pending' | 'InProgress' | 'Success' | 'Failed' | null;
 
 export interface PropertyDocumentDto {


### PR DESCRIPTION
## Summary
- Add `PublicPropertyDto` / `PublicPropertyDetailDto` types without `ownerId` (AC9)
- Type `propertiesApi.search` and add `getPublicProperty`; add `usePublicProperty` hook (AC10)
- Search cards show city, photo, CIN badge via `PropertyCinBadge` (AC11)
- Axios skips auth for `/properties/*/public` paths (AC12)
- Wrap `/search` in `WorkspaceProvider` so public AppShell renders in demo/E2E

## Backend PR
https://github.com/casazen/backend/pull/213

## Test Plan
- [ ] Visit `/search?demoProfile=short-stay` — results show CIN badge, city, price; no operator identity
- [ ] Network tab: search/public requests have no Authorization header

## Acceptance criteria coverage
| AC | Test |
|---|---|
| AC9 | property.types.ts + search components typed to PublicPropertyDto |
| AC10 | src/api/__tests__/properties.api.test.ts |
| AC11 | e2e/public-booking-readmodel.spec.ts (AC11) |
| AC12 | src/lib/__tests__/axios.test.ts + e2e/public-booking-readmodel.spec.ts (AC12) |

## Gate status
| Gate | Status |
|---|---|
| G5 npm test | pass (112 passed) |
| G6 tsc | pass |
| G7 lint | fail (47 pre-existing repo errors unrelated to this PR) |
| G8 build | pass |
| G9 E2E | pass (public-booking-readmodel.spec.ts 3/3) |

Closes casazen/backend#212
