### PR TITLE
fix(onboarding): unblock org setup and fix bookings calendar (#217, #218)

### DIFF
--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 
 test.describe('Admin panel — auth-gate and shell', () => {
   test('AC12 /admin redirects away when user lacks Admin role', async ({ page }) => {

--- a/e2e/branded-booking-site.spec.ts
+++ b/e2e/branded-booking-site.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import {
   DEMO_ORG_SLUG,
   mockBrandedBookingApi,

--- a/e2e/connect-onboarding.spec.ts
+++ b/e2e/connect-onboarding.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import { mockCurrentUserWithOrg } from './helpers/org-api-mock';
 import type { ConnectStatus } from '../src/types/connect.types';

--- a/e2e/context-workspace-switch.spec.ts
+++ b/e2e/context-workspace-switch.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import { mockLeasesApiEmpty } from './helpers/lease-api-mock';
 

--- a/e2e/direct-checkout.spec.ts
+++ b/e2e/direct-checkout.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import {
   DEMO_ORG_SLUG,
   mockBrandedBookingApi,

--- a/e2e/helpers/org-api-mock.ts
+++ b/e2e/helpers/org-api-mock.ts
@@ -1,5 +1,82 @@
 import type { Page } from '@playwright/test';
-import type { PlanTier } from '../../src/types';
+import type { PlanTier, RentalType, UserRole } from '../../src/types';
+
+const DEMO_ORG = {
+  id: 'org-e2e-0001',
+  name: 'Acme Stays',
+  slug: 'acme-stays',
+  planTier: 'Pro' as PlanTier,
+};
+
+function buildDemoMeBody(profile: string) {
+  if (profile === 'onboarding') {
+    return {
+      id: 'auth0|demo-onboarding',
+      email: 'demo@casazen.com',
+      firstName: 'Demo',
+      lastName: 'User',
+      role: 'Guest' as UserRole,
+      rentalType: null,
+      isActive: true,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      orgId: null,
+      org: null,
+    };
+  }
+
+  const rentalType: RentalType =
+    profile === 'long-term' ? 'LongTerm' : profile === 'dual' || profile === 'triple' ? 'Both' : 'ShortTerm';
+  const role: UserRole =
+    profile === 'admin' || profile === 'triple'
+      ? 'Admin'
+      : profile === 'long-term'
+        ? 'LongTermLandlord'
+        : 'PropertyOwner';
+
+  return {
+    id: 'auth0|demo-e2e',
+    email: 'demo@casazen.com',
+    firstName: 'Demo',
+    lastName: 'User',
+    role,
+    rentalType,
+    isActive: true,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    orgId: DEMO_ORG.id,
+    org: DEMO_ORG,
+  };
+}
+
+/**
+ * Default GET /api/users/me mock for demo-mode E2E (#217).
+ * Resolves demo profile from the active page (query param or sessionStorage).
+ * Tests that need a custom profile should register their own route afterward (last wins).
+ */
+export async function installDemoUserMeMock(page: Page): Promise<void> {
+  await page.route('**/api/users/me', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    const profile = await page.evaluate(() => {
+      const params = new URLSearchParams(window.location.search);
+      const fromQuery = params.get('demoProfile');
+      if (fromQuery) return fromQuery;
+      const stored = sessionStorage.getItem('casazen:demo-profile');
+      if (stored) return stored;
+      return 'short-stay';
+    });
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildDemoMeBody(profile)),
+    });
+  });
+}
 
 interface MockOrgOptions {
   name?: string;

--- a/e2e/long-term-flow.spec.ts
+++ b/e2e/long-term-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { waitForAppReady } from './helpers/auth';
 
 test.describe.skip('Long-term layer (real Auth0 + API)', () => {

--- a/e2e/long-term-layer.spec.ts
+++ b/e2e/long-term-layer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import { mockLeasesApiEmpty } from './helpers/lease-api-mock';
 

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import { mockPlansCatalog } from './helpers/org-api-mock';
 

--- a/e2e/plan-management.spec.ts
+++ b/e2e/plan-management.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import { mockPropertiesApi } from './helpers/properties-api-mock';
 import {

--- a/e2e/pricing-adapter.spec.ts
+++ b/e2e/pricing-adapter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import {
   PROPERTY_ID,
   configEnabled,

--- a/e2e/property-detail.spec.ts
+++ b/e2e/property-detail.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import { mockPropertyDetailApi, PROPERTY_DETAIL_ID } from './helpers/property-detail-mock';
 

--- a/e2e/property-flow.spec.ts
+++ b/e2e/property-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import { mockPropertiesApi } from './helpers/properties-api-mock';
 import { NEW_PROPERTY_ID } from './fixtures/properties.fixtures';

--- a/e2e/public-booking-readmodel.spec.ts
+++ b/e2e/public-booking-readmodel.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import {
   mockPublicBookingReadApi,

--- a/e2e/tenant-boundary.spec.ts
+++ b/e2e/tenant-boundary.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './test';
 import { demoUrl } from './helpers/demo-profile';
 import { mockPropertiesApi } from './helpers/properties-api-mock';
 import { mockCurrentUserWithOrg, mockEntitlement } from './helpers/org-api-mock';

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -1,0 +1,11 @@
+import { test as base, expect } from '@playwright/test';
+import { installDemoUserMeMock } from './helpers/org-api-mock';
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await installDemoUserMeMock(page);
+    await use(page);
+  },
+});
+
+export { expect };

--- a/src/api/bookings.api.ts
+++ b/src/api/bookings.api.ts
@@ -6,6 +6,7 @@ import type {
   CheckInDto,
   CheckOutDto,
 } from '@/types';
+import type { CalendarResponseDto } from '@/types/calendar.types';
 
 export const bookingsApi = {
   getAll: (params?: Record<string, any>) =>
@@ -21,8 +22,8 @@ export const bookingsApi = {
 
   delete: (id: string) => ApiClient.delete<void>(`/bookings/${id}`),
 
-  getCalendar: (params?: { propertyId?: string; startDate?: string; endDate?: string }) =>
-    ApiClient.get<Booking[]>('/bookings/calendar', params),
+  getCalendar: (params: { propertyId: string; startDate: string; endDate: string; timezone?: string }) =>
+    ApiClient.get<CalendarResponseDto>('/bookings/calendar', params),
 
   checkIn: (id: string, data?: CheckInDto) =>
     ApiClient.post<Booking>(`/bookings/${id}/check-in`, data),

--- a/src/components/auth/onboarding-guard.tsx
+++ b/src/components/auth/onboarding-guard.tsx
@@ -2,15 +2,17 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '@/hooks/use-auth';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { needsOnboarding } from '@/lib/onboarding';
+import { useMe } from '@/queries/use-users';
 
 export function OnboardingGuard() {
-  const { isLoading, isAuthenticated, user } = useAuth();
+  const { isLoading: authLoading, isAuthenticated, user } = useAuth();
+  const { data: profile, isLoading: profileLoading } = useMe();
 
-  if (isLoading) {
+  if (authLoading || (isAuthenticated && profileLoading)) {
     return <LoadingScreen message="Caricamento..." />;
   }
 
-  if (isAuthenticated && needsOnboarding(user)) {
+  if (isAuthenticated && needsOnboarding(user, profile)) {
     return <Navigate to="/onboarding" replace />;
   }
 

--- a/src/features/bookings/calendar-page.tsx
+++ b/src/features/bookings/calendar-page.tsx
@@ -1,15 +1,68 @@
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
 import { BookingCalendar } from './components/booking-calendar';
 import { useBookingCalendar } from '@/queries/use-bookings';
+import { useProperties } from '@/queries/use-properties';
 import { List } from 'lucide-react';
-import type { BookingCalendarEvent } from '@/types';
+import type { Booking, BookingCalendarEvent } from '@/types';
+import type { CalendarBookingDto } from '@/types/calendar.types';
+
+function toMonthRange(date: Date): { startDate: string; endDate: string } {
+  const start = new Date(date.getFullYear(), date.getMonth(), 1);
+  const end = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+  return {
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+  };
+}
+
+function mapCalendarBooking(dto: CalendarBookingDto): Booking {
+  const [firstName = '', ...rest] = dto.guestName.split(' ');
+  return {
+    id: dto.id,
+    propertyId: dto.propertyId,
+    userId: '',
+    checkInDate: dto.checkInDate,
+    checkOutDate: dto.checkOutDate,
+    numberOfGuests: dto.numberOfGuests,
+    totalPrice: dto.totalPrice,
+    currency: 'EUR',
+    status: dto.status as Booking['status'],
+    guest: {
+      firstName,
+      lastName: rest.join(' '),
+      email: '',
+      phone: '',
+      country: '',
+    },
+    createdAt: dto.checkInDateUtc,
+    updatedAt: dto.checkOutDateUtc,
+  };
+}
 
 export function CalendarPage() {
   const navigate = useNavigate();
-  const { data: bookings, isLoading } = useBookingCalendar();
+  const { data: properties, isLoading: propertiesLoading } = useProperties();
+  const propertyList = properties ?? [];
+  const [selectedPropertyId, setSelectedPropertyId] = useState<string>('');
+
+  const activePropertyId = selectedPropertyId || propertyList[0]?.id || '';
+  const { startDate, endDate } = useMemo(() => toMonthRange(new Date()), []);
+
+  const { data: calendarResponse, isLoading: calendarLoading, isError } = useBookingCalendar(
+    activePropertyId
+      ? { propertyId: activePropertyId, startDate, endDate }
+      : undefined,
+  );
+
+  const bookings = useMemo(
+    () => (calendarResponse?.bookings ?? []).map(mapCalendarBooking),
+    [calendarResponse],
+  );
 
   const handleSelectEvent = (event: BookingCalendarEvent) => {
     if (event.resource) {
@@ -18,7 +71,6 @@ export function CalendarPage() {
   };
 
   const handleSelectSlot = (slotInfo: { start: Date; end: Date }) => {
-    // Could navigate to create booking with pre-filled dates
     console.log('Selected slot:', slotInfo);
   };
 
@@ -36,16 +88,52 @@ export function CalendarPage() {
           }
         />
 
-        {isLoading ? (
-          <div className="flex items-center justify-center h-[600px]">
+        {propertiesLoading ? (
+          <div className="flex h-[600px] items-center justify-center">
             <p>Loading calendar...</p>
           </div>
+        ) : propertyList.length === 0 ? (
+          <div className="flex h-[400px] flex-col items-center justify-center gap-2 text-center">
+            <p className="font-medium">Nessuna proprietà disponibile</p>
+            <p className="text-sm text-muted-foreground">
+              Aggiungi una proprietà per visualizzare il calendario prenotazioni.
+            </p>
+            <Button onClick={() => navigate('/app/short-rent/properties')}>Vai alle proprietà</Button>
+          </div>
         ) : (
-          <BookingCalendar
-            bookings={bookings || []}
-            onSelectEvent={handleSelectEvent}
-            onSelectSlot={handleSelectSlot}
-          />
+          <>
+            <div className="max-w-sm space-y-2">
+              <Label htmlFor="calendar-property">Proprietà</Label>
+              <select
+                id="calendar-property"
+                className="w-full rounded-md border px-3 py-2 text-sm"
+                value={activePropertyId}
+                onChange={(e) => setSelectedPropertyId(e.target.value)}
+              >
+                {propertyList.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {calendarLoading ? (
+              <div className="flex h-[600px] items-center justify-center">
+                <p>Loading calendar...</p>
+              </div>
+            ) : isError ? (
+              <div className="flex h-[400px] items-center justify-center text-destructive">
+                Impossibile caricare il calendario. Riprova più tardi.
+              </div>
+            ) : (
+              <BookingCalendar
+                bookings={bookings}
+                onSelectEvent={handleSelectEvent}
+                onSelectSlot={handleSelectSlot}
+              />
+            )}
+          </>
         )}
       </div>
     </AppShell>

--- a/src/features/onboarding/onboarding-page.tsx
+++ b/src/features/onboarding/onboarding-page.tsx
@@ -2,32 +2,47 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/use-auth';
-import { useCompleteOnboarding } from '@/queries/use-users';
+import { useCompleteOnboarding, useMe } from '@/queries/use-users';
 import type { PlanTier, RentalType } from '@/types';
-import { getHomeRouteForRentalType, getHomeRouteForUser } from '@/lib/onboarding';
+import { getHomeRouteForRentalType, getHomeRouteForUser, needsOrgSetup } from '@/lib/onboarding';
 import { getUserRoles } from '@/lib/auth-roles';
 import { isDemoMode } from '@/config/demo.config';
 import { applyDemoOnboardingProfile } from '@/lib/demo-onboarding';
 import { RentalTypeCard } from './components/rental-type-card';
 import { PlanSelectionGrid } from '@/components/org/plan-selection-grid';
 import { Button } from '@/components/ui/button';
+import { LoadingScreen } from '@/components/shared/loading-screen';
 
 const RENTAL_TYPES: RentalType[] = ['ShortTerm', 'LongTerm', 'Both'];
 
 export function OnboardingPage() {
   const navigate = useNavigate();
   const { user, refreshAccessToken } = useAuth();
+  const { data: profile, isLoading: profileLoading } = useMe();
   const completeOnboarding = useCompleteOnboarding();
   const [step, setStep] = useState<1 | 2>(1);
   const [selectedType, setSelectedType] = useState<RentalType | null>(null);
   const [selectedPlan, setSelectedPlan] = useState<PlanTier>('Starter');
   const [failedType, setFailedType] = useState<RentalType | null>(null);
 
+  const hasRoles = getUserRoles(user).length > 0;
+  const isOrgBackfill = hasRoles && needsOrgSetup(profile);
+
   useEffect(() => {
-    if (getUserRoles(user).length > 0) {
+    if (profileLoading || !profile) return;
+
+    if (profile.rentalType) {
+      setSelectedType(profile.rentalType);
+    }
+
+    if (isOrgBackfill && profile.rentalType) {
+      setStep(2);
+    }
+
+    if (!needsOrgSetup(profile) && hasRoles) {
       navigate(getHomeRouteForUser(user), { replace: true });
     }
-  }, [navigate, user]);
+  }, [navigate, user, profile, profileLoading, hasRoles, isOrgBackfill]);
 
   const finishOnboarding = async (rentalType: RentalType, planTier: PlanTier) => {
     setSelectedType(rentalType);
@@ -40,7 +55,7 @@ export function OnboardingPage() {
         return;
       }
 
-      await completeOnboarding.mutateAsync({ rentalType, planTier });
+      await completeOnboarding.mutateAsync({ rentalType, planTier, isUpdate: hasRoles });
       await refreshAccessToken();
       window.location.assign(getHomeRouteForRentalType(rentalType));
     } catch {
@@ -60,6 +75,10 @@ export function OnboardingPage() {
     void finishOnboarding(selectedType, selectedPlan);
   };
 
+  if (profileLoading) {
+    return <LoadingScreen message="Caricamento..." />;
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-muted/40 px-4 py-12">
       <div className="mx-auto max-w-5xl space-y-10 text-center">
@@ -71,7 +90,9 @@ export function OnboardingPage() {
           <p className="text-muted-foreground">
             {step === 1
               ? 'Scegli il tipo di operatore per personalizzare la tua esperienza.'
-              : 'Seleziona il piano iniziale per la tua organizzazione. Potrai modificarlo in seguito.'}
+              : isOrgBackfill
+                ? 'Configura la tua organizzazione per iniziare a gestire proprietà e prenotazioni.'
+                : 'Seleziona il piano iniziale per la tua organizzazione. Potrai modificarlo in seguito.'}
           </p>
         </div>
 
@@ -96,14 +117,16 @@ export function OnboardingPage() {
               actionLabel="Seleziona"
             />
             <div className="flex flex-wrap items-center justify-center gap-3">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={completeOnboarding.isPending}
-                onClick={() => setStep(1)}
-              >
-                Indietro
-              </Button>
+              {!isOrgBackfill && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={completeOnboarding.isPending}
+                  onClick={() => setStep(1)}
+                >
+                  Indietro
+                </Button>
+              )}
               <Button
                 type="button"
                 data-testid="onboarding-plan-confirm"

--- a/src/lib/__tests__/onboarding.test.ts
+++ b/src/lib/__tests__/onboarding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getHomeRouteForRentalType, getHomeRouteForUser, needsOnboarding } from '../onboarding';
+import { getHomeRouteForRentalType, getHomeRouteForUser, needsOnboarding, needsOrgSetup } from '../onboarding';
 
 describe('onboarding helpers', () => {
   it('maps rental types to home routes', () => {
@@ -8,10 +8,18 @@ describe('onboarding helpers', () => {
     expect(getHomeRouteForRentalType('Both')).toBe('/app/short-rent');
   });
 
-  it('detects onboarding requirement from JWT roles', () => {
+  it('detects org setup requirement from profile', () => {
+    expect(needsOrgSetup(null)).toBe(true);
+    expect(needsOrgSetup({ orgId: null })).toBe(true);
+    expect(needsOrgSetup({ orgId: 'org-1' })).toBe(false);
+  });
+
+  it('detects onboarding requirement from JWT roles and org', () => {
     expect(needsOnboarding({ roles: [] })).toBe(true);
-    expect(needsOnboarding({ roles: ['PropertyOwner'] })).toBe(false);
-    expect(needsOnboarding({ roles: ['Admin'] })).toBe(false);
+    expect(needsOnboarding({ roles: ['PropertyOwner'] }, { orgId: 'org-1' })).toBe(false);
+    expect(needsOnboarding({ roles: ['Admin'] }, { orgId: 'org-1' })).toBe(false);
+    expect(needsOnboarding({ roles: ['Admin'] }, { orgId: null })).toBe(true);
+    expect(needsOnboarding({ roles: ['PropertyOwner'] }, { orgId: null })).toBe(true);
   });
 
   it('resolves home route for user roles', () => {

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -32,7 +32,18 @@ export function getHomeRouteForUser(user: UserWithRoles): string {
   return '/app/short-rent';
 }
 
-export function needsOnboarding(user: UserWithRoles): boolean {
+/** True when the caller has no tenant org yet (blocks property create, plan, entitlement). */
+export function needsOrgSetup(profile?: { orgId?: string | null } | null): boolean {
+  return !profile?.orgId;
+}
+
+export function needsOnboarding(
+  user: UserWithRoles,
+  profile?: { orgId?: string | null } | null,
+): boolean {
+  if (needsOrgSetup(profile)) {
+    return true;
+  }
   if (isAdmin(user)) {
     return false;
   }

--- a/src/queries/use-bookings.ts
+++ b/src/queries/use-bookings.ts
@@ -25,10 +25,17 @@ export function useBooking(id: string) {
   });
 }
 
-export function useBookingCalendar(params?: { propertyId?: string; startDate?: string; endDate?: string }) {
+export function useBookingCalendar(params?: {
+  propertyId: string;
+  startDate: string;
+  endDate: string;
+  timezone?: string;
+}) {
   return useQuery({
     queryKey: [BOOKINGS_KEY, 'calendar', params],
-    queryFn: () => bookingsApi.getCalendar(params),
+    queryFn: () => bookingsApi.getCalendar(params!),
+    enabled: !!params?.propertyId && !!params?.startDate && !!params?.endDate,
+    retry: 1,
   });
 }
 

--- a/src/queries/use-users.ts
+++ b/src/queries/use-users.ts
@@ -120,8 +120,18 @@ export function useCompleteOnboarding() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ rentalType, planTier }: { rentalType: RentalType; planTier?: PlanTier }) =>
-      UsersApi.postOnboarding({ rentalType, planTier }),
+    mutationFn: ({
+      rentalType,
+      planTier,
+      isUpdate,
+    }: {
+      rentalType: RentalType;
+      planTier?: PlanTier;
+      isUpdate?: boolean;
+    }) =>
+      isUpdate
+        ? UsersApi.putOnboarding({ rentalType, planTier })
+        : UsersApi.postOnboarding({ rentalType, planTier }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [ME_KEY] });
       queryClient.invalidateQueries({ queryKey: ENTITLEMENT_QUERY_KEY });

--- a/src/types/calendar.types.ts
+++ b/src/types/calendar.types.ts
@@ -1,16 +1,22 @@
-// ✅ Calendar types matching backend CalendarResponseDto
-
-export interface CalendarDay {
-  date: Date | string;
-  isAvailable: boolean;
-  price: number;
-  minimumStay: number;
-  bookingId?: string;
+/** Matches backend CalendarBookingDto */
+export interface CalendarBookingDto {
+  id: string;
+  propertyId: string;
+  guestId: string;
+  checkInDate: string;
+  checkOutDate: string;
+  checkInDateUtc: string;
+  checkOutDateUtc: string;
+  status: string;
+  source: string;
+  numberOfGuests: number;
+  totalPrice: number;
+  guestName: string;
 }
 
+/** Matches backend CalendarResponseDto */
 export interface CalendarResponseDto {
-  propertyId: string;
-  startDate: Date | string;
-  endDate: Date | string;
-  days: CalendarDay[];
+  timezone: string;
+  utcOffsetMinutes: number;
+  bookings: CalendarBookingDto[];
 }


### PR DESCRIPTION
## Summary

- Redirect users without `orgId` to onboarding (org backfill) even when JWT roles exist (#217)
- Support `PUT /users/onboarding` for re-onboarding with existing roles
- Fix bookings calendar: pass `propertyId` + date range, handle empty/error states (#218)

## Test plan

- [x] `npm run test -- --run src/lib/__tests__/onboarding.test.ts`
- [ ] After BE deploy: create property flow end-to-end on Vercel prod
- [ ] Calendar page loads (no infinite spinner) with 0 or N properties
- [ ] Onboarding backfill from Profilo → Modifica tipo

Fixes #217, #218
