### PR TITLE
feat(connect): Stripe Connect payments settings (#222)

### DIFF
--- a/e2e/connect-onboarding.spec.ts
+++ b/e2e/connect-onboarding.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+import { demoUrl } from './helpers/demo-profile';
+import { mockCurrentUserWithOrg } from './helpers/org-api-mock';
+import type { ConnectStatus } from '../src/types/connect.types';
+
+const PAYMENTS_SETTINGS_URL = '/app/short-rent/settings/payments';
+
+function mockConnectStatus(page: import('@playwright/test').Page, status: ConnectStatus) {
+  return page.route('**/api/connect/status**', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(status),
+    });
+  });
+}
+
+test.describe('Stripe Connect onboarding (#222)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCurrentUserWithOrg(page, { name: 'Acme Stays', slug: 'acme-stays' });
+  });
+
+  test('shows disconnected state and checkout gate banner', async ({ page }) => {
+    await mockConnectStatus(page, {
+      connectedAccountId: null,
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      detailsSubmitted: false,
+      requirementsDue: [],
+    });
+
+    await page.goto(demoUrl(PAYMENTS_SETTINGS_URL, 'short-stay'));
+
+    await expect(page.getByTestId('connect-status-badge')).toHaveText('Non collegato');
+    await expect(page.getByTestId('connect-checkout-gate-banner')).toBeVisible();
+    await expect(page.getByTestId('connect-stripe-cta')).toHaveText('Collega Stripe');
+  });
+
+  test('shows pending state with requirements prompt', async ({ page }) => {
+    await mockConnectStatus(page, {
+      connectedAccountId: 'acct_test_1',
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      detailsSubmitted: false,
+      requirementsDue: ['individual.verification.document'],
+    });
+
+    await page.goto(demoUrl(PAYMENTS_SETTINGS_URL, 'short-stay'));
+
+    await expect(page.getByTestId('connect-status-badge')).toHaveText('In verifica');
+    await expect(page.getByTestId('connect-requirements-alert')).toBeVisible();
+    await expect(page.getByTestId('connect-stripe-cta')).toHaveText('Completa la verifica');
+  });
+
+  test('shows active state without gate banner', async ({ page }) => {
+    await mockConnectStatus(page, {
+      connectedAccountId: 'acct_test_1',
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      detailsSubmitted: true,
+      requirementsDue: [],
+    });
+
+    await page.goto(demoUrl(PAYMENTS_SETTINGS_URL, 'short-stay'));
+
+    await expect(page.getByTestId('connect-status-badge')).toHaveText('Attivo');
+    await expect(page.getByTestId('connect-checkout-gate-banner')).toHaveCount(0);
+    await expect(page.getByTestId('connect-stripe-cta')).toHaveCount(0);
+  });
+
+  test('Collega Stripe mints onboarding link and redirects', async ({ page }) => {
+    await mockConnectStatus(page, {
+      connectedAccountId: null,
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      detailsSubmitted: false,
+      requirementsDue: [],
+    });
+
+    await page.route('**/api/connect/account', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.fallback();
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          connectedAccountId: 'acct_test_new',
+          chargesEnabled: false,
+          payoutsEnabled: false,
+          detailsSubmitted: false,
+          requirementsDue: ['individual.verification.document'],
+        }),
+      });
+    });
+
+    let onboardingUrl = '';
+    await page.route('**/api/connect/onboarding-link', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.fallback();
+        return;
+      }
+
+      const body = route.request().postDataJSON() as { returnUrl?: string; refreshUrl?: string };
+      expect(body.returnUrl).toContain('stripe_return=1');
+      expect(body.refreshUrl).toContain('stripe_refresh=1');
+      onboardingUrl = 'https://connect.stripe.test/onboard/acct_test_new';
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ url: onboardingUrl }),
+      });
+    });
+
+    await page.goto(demoUrl(PAYMENTS_SETTINGS_URL, 'short-stay'));
+    await page.getByTestId('connect-stripe-cta').click();
+    await expect.poll(() => onboardingUrl).not.toBe('');
+  });
+});

--- a/src/api/connect.api.ts
+++ b/src/api/connect.api.ts
@@ -1,0 +1,13 @@
+import { ApiClient } from '@/api/client';
+import type { ConnectStatus, OnboardingLinkResponse } from '@/types/connect.types';
+
+export const ConnectApi = {
+  createAccount: (): Promise<ConnectStatus> =>
+    ApiClient.post<ConnectStatus>('/connect/account'),
+
+  createOnboardingLink: (returnUrl: string, refreshUrl: string): Promise<OnboardingLinkResponse> =>
+    ApiClient.post<OnboardingLinkResponse>('/connect/onboarding-link', { returnUrl, refreshUrl }),
+
+  getStatus: (refresh = true): Promise<ConnectStatus> =>
+    ApiClient.get<ConnectStatus>('/connect/status', { refresh }),
+};

--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -77,6 +77,16 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     }),
   },
   {
+    path: '/app/short-rent/settings/payments',
+    context: 'short-rent',
+    requiredPermissions: ['property.write'],
+    navLabel: 'Pagamenti',
+    icon: 'Wallet',
+    component: async () => ({
+      default: (await import('@/features/settings/payments-page')).ConnectPaymentsPage,
+    }),
+  },
+  {
     path: '/app/short-rent/bookings',
     context: 'short-rent',
     requiredPermissions: ['booking.read'],

--- a/src/features/settings/payments-page.tsx
+++ b/src/features/settings/payments-page.tsx
@@ -1,0 +1,152 @@
+import { AppShell } from '@/components/layout/app-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useCurrentUser } from '@/queries/use-users';
+import { CONNECT_STATUS_KEY, useConnectStatus, useStartConnectOnboarding } from '@/queries/use-connect';
+import { resolveConnectUiStatus } from '@/types/connect.types';
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, CheckCircle2, Clock, ExternalLink } from 'lucide-react';
+import { useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+
+const STATUS_LABEL: Record<ReturnType<typeof resolveConnectUiStatus>, string> = {
+  disconnected: 'Non collegato',
+  pending: 'In verifica',
+  active: 'Attivo',
+};
+
+const STATUS_VARIANT: Record<ReturnType<typeof resolveConnectUiStatus>, 'secondary' | 'outline' | 'default'> = {
+  disconnected: 'secondary',
+  pending: 'outline',
+  active: 'default',
+};
+
+export function ConnectPaymentsPage() {
+  const { org } = useCurrentUser();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
+  const stripeReturn = searchParams.get('stripe_return') === '1' || searchParams.get('stripe_refresh') === '1';
+
+  const { data: status, isLoading, isError } = useConnectStatus(stripeReturn);
+  const startOnboarding = useStartConnectOnboarding();
+
+  useEffect(() => {
+    if (!stripeReturn)
+      return;
+
+    void queryClient.invalidateQueries({ queryKey: CONNECT_STATUS_KEY });
+    setSearchParams({}, { replace: true });
+  }, [stripeReturn, queryClient, setSearchParams]);
+
+  const uiStatus = resolveConnectUiStatus(status);
+  const hasRequirements = (status?.requirementsDue?.length ?? 0) > 0;
+  const bookingSiteUrl = org?.slug ? `/book/${org.slug}` : null;
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-3xl space-y-6">
+        <PageHeader
+          title="Pagamenti / Payouts"
+          description="Collega il tuo account Stripe per ricevere i pagamenti degli ospiti direttamente sul tuo conto."
+        />
+
+        {!status?.chargesEnabled && (
+          <div
+            role="alert"
+            data-testid="connect-checkout-gate-banner"
+            className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm space-y-1"
+          >
+            <p className="font-medium text-destructive">Sito prenotazioni non ancora attivo</p>
+            <p className="text-muted-foreground">
+              Completa la verifica Stripe per abilitare il checkout sul sito prenotazioni
+              {bookingSiteUrl ? (
+                <>
+                  {' '}
+                  (<Link to={bookingSiteUrl} className="underline text-primary">
+                    {org?.name ?? 'sito brandizzato'}
+                  </Link>
+                  )
+                </>
+              ) : (
+                ' brandizzato'
+              )}
+              . Gli ospiti non potranno pagare finché l&apos;account non è attivo.
+            </p>
+          </div>
+        )}
+
+        <div className="rounded-lg border bg-card p-6 space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-sm text-muted-foreground">Stato connessione Stripe</p>
+              <div className="mt-1 flex items-center gap-2">
+                {uiStatus === 'active' ? (
+                  <CheckCircle2 className="h-5 w-5 text-green-600" aria-hidden />
+                ) : uiStatus === 'pending' ? (
+                  <Clock className="h-5 w-5 text-amber-600" aria-hidden />
+                ) : (
+                  <AlertCircle className="h-5 w-5 text-muted-foreground" aria-hidden />
+                )}
+                <Badge variant={STATUS_VARIANT[uiStatus]} data-testid="connect-status-badge">
+                  {STATUS_LABEL[uiStatus]}
+                </Badge>
+              </div>
+            </div>
+
+            {uiStatus !== 'active' && (
+              <Button
+                onClick={() => void startOnboarding.mutateAsync()}
+                disabled={startOnboarding.isPending || isLoading}
+                data-testid="connect-stripe-cta"
+              >
+                <ExternalLink className="mr-2 h-4 w-4" />
+                {uiStatus === 'disconnected' ? 'Collega Stripe' : 'Completa la verifica'}
+              </Button>
+            )}
+          </div>
+
+          {isLoading && <p className="text-sm text-muted-foreground">Caricamento stato pagamenti…</p>}
+          {isError && (
+            <p className="text-sm text-destructive">Impossibile caricare lo stato Stripe. Riprova tra poco.</p>
+          )}
+
+          {status?.connectedAccountId && (
+            <p className="text-xs text-muted-foreground">
+              Account Stripe: <code>{status.connectedAccountId}</code>
+            </p>
+          )}
+
+          {hasRequirements && uiStatus !== 'active' && (
+            <div
+              role="alert"
+              data-testid="connect-requirements-alert"
+              className="rounded-md border border-amber-500/50 bg-amber-500/10 px-4 py-3 text-sm space-y-1"
+            >
+              <p className="font-medium">Verifica incompleta</p>
+              <p className="text-muted-foreground">
+                Stripe richiede documenti aggiuntivi. Clicca &quot;Completa la verifica&quot; per continuare
+                l&apos;onboarding.
+              </p>
+            </div>
+          )}
+
+          {uiStatus === 'active' && (
+            <p className="text-sm text-muted-foreground">
+              Il tuo account può accettare pagamenti. I fondi vengono accreditati direttamente sul tuo conto Stripe
+              — CasaZen non trattiene i tuoi incassi.
+            </p>
+          )}
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          Gestisci il piano SaaS in{' '}
+          <Link to="/app/short-rent/settings/plan" className="underline">
+            Impostazioni piano
+          </Link>
+          .
+        </p>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/queries/use-connect.ts
+++ b/src/queries/use-connect.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ConnectApi } from '@/api/connect.api';
+import { toast } from 'sonner';
+
+export const CONNECT_STATUS_KEY = ['connect', 'status'] as const;
+
+export function useConnectStatus(refresh = true) {
+  return useQuery({
+    queryKey: [...CONNECT_STATUS_KEY, refresh],
+    queryFn: () => ConnectApi.getStatus(refresh),
+  });
+}
+
+export function useStartConnectOnboarding() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const base = `${window.location.origin}/app/short-rent/settings/payments`;
+      const returnUrl = `${base}?stripe_return=1`;
+      const refreshUrl = `${base}?stripe_refresh=1`;
+      await ConnectApi.createAccount();
+      return ConnectApi.createOnboardingLink(returnUrl, refreshUrl);
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: CONNECT_STATUS_KEY });
+      window.location.assign(data.url);
+    },
+    onError: () => {
+      toast.error('Impossibile avviare la connessione con Stripe');
+    },
+  });
+}

--- a/src/types/connect.types.ts
+++ b/src/types/connect.types.ts
@@ -1,0 +1,21 @@
+export interface ConnectStatus {
+  connectedAccountId?: string | null;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+  requirementsDue: string[];
+}
+
+export interface OnboardingLinkResponse {
+  url: string;
+}
+
+export type ConnectUiStatus = 'disconnected' | 'pending' | 'active';
+
+export function resolveConnectUiStatus(status: ConnectStatus | undefined): ConnectUiStatus {
+  if (!status?.connectedAccountId)
+    return 'disconnected';
+  if (!status.chargesEnabled)
+    return 'pending';
+  return 'active';
+}


### PR DESCRIPTION
## Summary
- Adds /app/short-rent/settings/payments page (Pagamenti / Payouts) with Italian status badges
- Collega Stripe CTA mints onboarding link and redirects to Stripe-hosted flow
- Checkout gate banner until chargesEnabled (AC10)
- Playwright E2E: connect-onboarding.spec.ts

Related: casazen/backend#222

## Test plan
- [x] npm run build
- [x] e2e/connect-onboarding.spec.ts (mocked API)
- [ ] Manual: open /app/short-rent/settings/payments after backend deploy

Made with [Cursor](https://cursor.com)