### PR TITLE
feat(public-booking): direct checkout flow (#226)

### DIFF
--- a/e2e/branded-booking-site.spec.ts
+++ b/e2e/branded-booking-site.spec.ts
@@ -73,7 +73,7 @@ test.describe('Branded booking site (#215)', () => {
     await page.locator('#check-out').fill('2026-07-04');
     await page.getByRole('button', { name: 'Procedi al checkout' }).click();
 
-    await expect(page.getByTestId('checkout-placeholder')).toBeVisible();
+    await expect(page.getByTestId('direct-checkout-page')).toBeVisible();
     await expect(page).not.toHaveURL(/\/login/);
   });
 

--- a/e2e/direct-checkout.spec.ts
+++ b/e2e/direct-checkout.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import {
+  DEMO_ORG_SLUG,
+  mockBrandedBookingApi,
+  mockOrgPropertyId,
+} from './helpers/branded-booking-mock';
+import { mockDirectCheckoutApi } from './helpers/direct-checkout-mock';
+
+test.describe('Direct checkout (#226)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBrandedBookingApi(page);
+    await mockDirectCheckoutApi(page);
+    await page.addInitScript(() => {
+      localStorage.removeItem('casazen_cookie_consent');
+    });
+  });
+
+  test('AC10/AC13: guest step shows consent, price breakdown, and Italian labels', async ({ page }) => {
+    await page.goto(
+      `/book/${DEMO_ORG_SLUG}/property/${mockOrgPropertyId}/checkout?checkIn=2026-07-01&checkOut=2026-07-04`,
+    );
+
+    await expect(page.getByTestId('direct-checkout-page')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('price-breakdown')).toBeVisible();
+    await expect(page.getByTestId('gdpr-consent')).toBeVisible();
+    await expect(page.getByText('Tassa di soggiorno')).toBeVisible();
+    await expect(page.getByText('Acconsento al trattamento')).toBeVisible();
+  });
+
+  test('AC11/AC12: createDirectBooking without auth and demo payment confirmation', async ({ page }) => {
+    let bookingAuthHeader: string | undefined;
+
+    await page.route('**/api/public/bookings', async (route) => {
+      bookingAuthHeader = route.request().headers()['authorization'];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          bookingId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          clientSecret: 'pi_test_secret_direct',
+          connectedAccountPublishableContext: {
+            publishableKey: 'pk_test_demo',
+            stripeAccountId: 'acct_test_demo',
+          },
+          amount: 557,
+          currency: 'EUR',
+          touristTaxAmount: 6,
+          basePrice: 551,
+        }),
+      });
+    });
+
+    await page.goto(
+      `/book/${DEMO_ORG_SLUG}/property/${mockOrgPropertyId}/checkout?checkIn=2026-07-01&checkOut=2026-07-04`,
+    );
+
+    await expect(page.getByTestId('checkout-guest-step')).toBeVisible({ timeout: 15_000 });
+
+    await page.locator('#firstName').fill('Mario');
+    await page.locator('#lastName').fill('Rossi');
+    await page.locator('#email').fill('mario.rossi@example.com');
+    await page.locator('#phone').fill('+393331234567');
+    await page.getByRole('checkbox').click();
+    await page.getByRole('button', { name: 'Continua al pagamento' }).click();
+
+    await expect(page.getByTestId('checkout-payment-step')).toBeVisible();
+    expect(bookingAuthHeader).toBeUndefined();
+
+    await page.getByRole('button', { name: 'Paga ora' }).click();
+    await expect(page.getByTestId('checkout-confirmation')).toBeVisible();
+    await expect(page.getByText('Prenotazione confermata')).toBeVisible();
+  });
+});

--- a/e2e/helpers/direct-checkout-mock.ts
+++ b/e2e/helpers/direct-checkout-mock.ts
@@ -1,0 +1,41 @@
+import type { Page } from '@playwright/test';
+import type { DirectBookingResponse } from '../../src/types';
+
+export const DIRECT_CHECKOUT_CONSENT_VERSION = '2026-06-direct-checkout-v1';
+
+export function mockDirectBookingResponse(overrides?: Partial<DirectBookingResponse>): DirectBookingResponse {
+  return {
+    bookingId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    clientSecret: 'pi_test_secret_direct',
+    connectedAccountPublishableContext: {
+      publishableKey: 'pk_test_demo',
+      stripeAccountId: 'acct_test_demo',
+    },
+    amount: 650,
+    currency: 'EUR',
+    touristTaxAmount: 8,
+    basePrice: 642,
+    ...overrides,
+  };
+}
+
+export async function mockDirectCheckoutApi(page: Page): Promise<void> {
+  await page.route('**/api/public/bookings', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+
+    const authHeader = route.request().headers()['authorization'];
+    if (authHeader) {
+      await route.fulfill({ status: 401, body: '{}' });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockDirectBookingResponse()),
+    });
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@stripe/react-stripe-js": "^6.6.0",
+        "@stripe/stripe-js": "^9.8.0",
         "@tanstack/react-query": "^5.95.2",
         "autoprefixer": "^10.4.27",
         "axios": "^1.13.6",
@@ -2995,6 +2997,29 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.6.0.tgz",
+      "integrity": "sha512-utODPiu2/JGjCnh5BX1M1F2uyjCwDKum4Bo8CeWdTCNOlzM0980YadzBMe7YoIwjfu3uadX4PMe3L2SderejqA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=9.5.0 <10.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.8.0.tgz",
+      "integrity": "sha512-DHJpol/98VKyojNSYmpkB5vOMnlf87hPe0wPxyaYTNiTMk5QjKMXDfSZLwGctYIXAgAWDFeRABc8lFAj0BELyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@stripe/react-stripe-js": "^6.6.0",
+    "@stripe/stripe-js": "^9.8.0",
     "@tanstack/react-query": "^5.95.2",
     "autoprefixer": "^10.4.27",
     "axios": "^1.13.6",

--- a/src/api/public-booking.api.ts
+++ b/src/api/public-booking.api.ts
@@ -1,0 +1,7 @@
+import { ApiClient } from './client';
+import type { CreateDirectBookingPayload, DirectBookingResponse } from '@/types';
+
+export const publicBookingApi = {
+  createDirectBooking: (payload: CreateDirectBookingPayload) =>
+    ApiClient.post<DirectBookingResponse>('/public/bookings', payload),
+};

--- a/src/features/public-booking/checkout-page.tsx
+++ b/src/features/public-booking/checkout-page.tsx
@@ -1,0 +1,270 @@
+import { useMemo, useState } from 'react';
+import { Link, useOutletContext, useParams, useSearchParams } from 'react-router-dom';
+import { loadStripe } from '@stripe/stripe-js';
+import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js';
+import { useOrgPublicProperty } from '@/queries/use-public-org';
+import { useCreateDirectBooking } from '@/queries/use-public-booking';
+import { ConsentCheckbox } from '@/features/public-booking/components/consent-checkbox';
+import { PriceBreakdown } from '@/features/public-booking/components/price-breakdown';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { isDemoMode } from '@/config/demo.config';
+import type { DirectBookingResponse, PublicOrgDto } from '@/types';
+import { DIRECT_CHECKOUT_CONSENT_VERSION } from '@/types/direct-booking.types';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+
+interface PublicBookingContext {
+  org: PublicOrgDto;
+}
+
+function nightsBetween(checkIn: string, checkOut: string): number {
+  if (!checkIn || !checkOut) return 0;
+  const diff = new Date(checkOut).getTime() - new Date(checkIn).getTime();
+  return diff > 0 ? Math.ceil(diff / (1000 * 60 * 60 * 24)) : 0;
+}
+
+function DemoPaymentStep({
+  onSuccess,
+}: {
+  onSuccess: () => void;
+}) {
+  return (
+    <div className="space-y-4" data-testid="checkout-payment-step">
+      <p className="text-sm text-muted-foreground">
+        Modalità demo: il pagamento Stripe è simulato localmente.
+      </p>
+      <Button className="w-full" onClick={onSuccess}>
+        Paga ora
+      </Button>
+    </div>
+  );
+}
+
+function StripePaymentStep({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: () => void;
+  onError: (message: string) => void;
+}) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [processing, setProcessing] = useState(false);
+
+  const handlePay = async () => {
+    if (!stripe || !elements) return;
+
+    setProcessing(true);
+    const { error } = await stripe.confirmPayment({
+      elements,
+      confirmParams: { return_url: window.location.href },
+      redirect: 'if_required',
+    });
+    setProcessing(false);
+
+    if (error) {
+      onError(error.message ?? 'Pagamento non riuscito');
+      return;
+    }
+
+    onSuccess();
+  };
+
+  return (
+    <div className="space-y-4" data-testid="checkout-payment-step">
+      <PaymentElement />
+      <Button className="w-full" onClick={handlePay} disabled={processing}>
+        {processing ? 'Elaborazione…' : 'Paga ora'}
+      </Button>
+    </div>
+  );
+}
+
+export function CheckoutPage() {
+  const { orgSlug, propertyId } = useParams<{ orgSlug: string; propertyId: string }>();
+  const { org } = useOutletContext<PublicBookingContext>();
+  const [searchParams] = useSearchParams();
+  const checkIn = searchParams.get('checkIn') ?? '';
+  const checkOut = searchParams.get('checkOut') ?? '';
+  const nights = useMemo(() => nightsBetween(checkIn, checkOut), [checkIn, checkOut]);
+
+  const { data: property, isLoading } = useOrgPublicProperty(orgSlug, propertyId);
+  const createBooking = useCreateDirectBooking();
+
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [country] = useState('IT');
+  const [adults, setAdults] = useState(2);
+  const [children, setChildren] = useState(0);
+  const [consent, setConsent] = useState(false);
+  const [bookingResult, setBookingResult] = useState<DirectBookingResponse | null>(null);
+  const [confirmed, setConfirmed] = useState(false);
+  const [paymentError, setPaymentError] = useState<string | null>(null);
+
+  const stripePromise = useMemo(() => {
+    if (!bookingResult || isDemoMode) return null;
+    const { publishableKey, stripeAccountId } = bookingResult.connectedAccountPublishableContext;
+    return loadStripe(publishableKey, { stripeAccount: stripeAccountId });
+  }, [bookingResult]);
+
+  const handleCreateBooking = async () => {
+    if (!propertyId || !checkIn || !checkOut || nights <= 0) return;
+
+    setPaymentError(null);
+    try {
+      const result = await createBooking.mutateAsync({
+        propertyId,
+        checkInDate: checkIn,
+        checkOutDate: checkOut,
+        numberOfAdults: adults,
+        numberOfChildren: children,
+        guest: { firstName, lastName, email, phone, country },
+        consent: { dataProcessing: true, consentVersion: DIRECT_CHECKOUT_CONSENT_VERSION },
+      });
+      setBookingResult(result);
+    } catch {
+      setPaymentError('Impossibile avviare il checkout. Verifica i dati e riprova.');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (confirmed && bookingResult) {
+    return (
+      <div className="mx-auto max-w-lg space-y-4 text-center" data-testid="checkout-confirmation">
+        <h2 className="text-2xl font-bold">Prenotazione confermata</h2>
+        <p className="text-muted-foreground">
+          Grazie! Il tuo soggiorno presso {org.displayName} è confermato.
+        </p>
+        <p className="font-mono text-sm">Riferimento: {bookingResult.bookingId}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-6" data-testid="direct-checkout-page">
+      <Button asChild variant="ghost" className="px-0">
+        <Link to={`/book/${orgSlug}/property/${propertyId}`}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Torna alla struttura
+        </Link>
+      </Button>
+
+      <h2 className="text-2xl font-bold">Checkout — {property?.name ?? 'Struttura'}</h2>
+
+      {checkIn && checkOut && (
+        <p className="text-muted-foreground">
+          Date: {checkIn} → {checkOut} ({nights} notte{nights !== 1 ? 'i' : ''})
+        </p>
+      )}
+
+      {!bookingResult ? (
+        <div className="space-y-4" data-testid="checkout-guest-step">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="firstName">Nome</Label>
+              <Input id="firstName" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="lastName">Cognome</Label>
+              <Input id="lastName" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="phone">Telefono</Label>
+            <Input id="phone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="adults">Adulti</Label>
+              <Input
+                id="adults"
+                type="number"
+                min={1}
+                value={adults}
+                onChange={(e) => setAdults(Number(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="children">Bambini</Label>
+              <Input
+                id="children"
+                type="number"
+                min={0}
+                value={children}
+                onChange={(e) => setChildren(Number(e.target.value))}
+              />
+            </div>
+          </div>
+
+          {property && nights > 0 && (
+            <PriceBreakdown
+              nights={nights}
+              nightlyRate={property.nightlyRate}
+              cleaningFee={property.cleaningFee}
+              touristTaxAmount={0}
+              totalAmount={property.nightlyRate * nights + property.cleaningFee}
+              currency={property.currency ?? 'EUR'}
+            />
+          )}
+
+          <ConsentCheckbox checked={consent} onCheckedChange={setConsent} />
+
+          {paymentError && <p className="text-sm text-destructive">{paymentError}</p>}
+
+          <Button
+            className="w-full"
+            disabled={
+              !consent ||
+              !firstName ||
+              !lastName ||
+              !email ||
+              nights <= 0 ||
+              createBooking.isPending
+            }
+            onClick={handleCreateBooking}
+          >
+            {createBooking.isPending ? 'Preparazione pagamento…' : 'Continua al pagamento'}
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <PriceBreakdown
+            nights={nights}
+            nightlyRate={property?.nightlyRate ?? 0}
+            cleaningFee={property?.cleaningFee ?? 0}
+            touristTaxAmount={bookingResult.touristTaxAmount}
+            totalAmount={bookingResult.amount}
+            currency={bookingResult.currency}
+          />
+
+          {isDemoMode ? (
+            <DemoPaymentStep onSuccess={() => setConfirmed(true)} />
+          ) : stripePromise ? (
+            <Elements stripe={stripePromise} options={{ clientSecret: bookingResult.clientSecret }}>
+              <StripePaymentStep
+                onSuccess={() => setConfirmed(true)}
+                onError={setPaymentError}
+              />
+            </Elements>
+          ) : null}
+
+          {paymentError && <p className="text-sm text-destructive">{paymentError}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/public-booking/components/consent-checkbox.tsx
+++ b/src/features/public-booking/components/consent-checkbox.tsx
@@ -1,0 +1,23 @@
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+interface ConsentCheckboxProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export function ConsentCheckbox({ checked, onCheckedChange }: ConsentCheckboxProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-md border p-4" data-testid="gdpr-consent">
+      <Checkbox
+        id="data-consent"
+        checked={checked}
+        onCheckedChange={(value) => onCheckedChange(value === true)}
+      />
+      <Label htmlFor="data-consent" className="text-sm leading-relaxed cursor-pointer">
+        Acconsento al trattamento dei miei dati personali per la gestione della prenotazione, in
+        conformità con l&apos;informativa privacy dell&apos;operatore.
+      </Label>
+    </div>
+  );
+}

--- a/src/features/public-booking/components/price-breakdown.tsx
+++ b/src/features/public-booking/components/price-breakdown.tsx
@@ -1,0 +1,45 @@
+import { formatCurrency } from '@/lib/utils';
+
+interface PriceBreakdownProps {
+  nights: number;
+  nightlyRate: number;
+  cleaningFee: number;
+  touristTaxAmount: number;
+  totalAmount: number;
+  currency?: string;
+}
+
+export function PriceBreakdown({
+  nights,
+  nightlyRate,
+  cleaningFee,
+  touristTaxAmount,
+  totalAmount,
+  currency = 'EUR',
+}: PriceBreakdownProps) {
+  const lodgingTotal = nightlyRate * nights;
+
+  return (
+    <div className="space-y-2 rounded-lg border p-4 text-sm" data-testid="price-breakdown">
+      <h3 className="font-semibold">Riepilogo prezzi</h3>
+      <div className="flex justify-between">
+        <span>
+          {nights} notte{nights !== 1 ? 'i' : ''} × {formatCurrency(nightlyRate, currency)}
+        </span>
+        <span>{formatCurrency(lodgingTotal, currency)}</span>
+      </div>
+      <div className="flex justify-between">
+        <span>Pulizia</span>
+        <span>{formatCurrency(cleaningFee, currency)}</span>
+      </div>
+      <div className="flex justify-between">
+        <span>Tassa di soggiorno</span>
+        <span>{formatCurrency(touristTaxAmount, currency)}</span>
+      </div>
+      <div className="flex justify-between border-t pt-2 text-base font-semibold">
+        <span>Totale</span>
+        <span>{formatCurrency(totalAmount, currency)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -29,7 +29,7 @@ const axiosInstance: AxiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
     // Skip auth for public endpoints
-    const publicEndpoints = ['/health', '/auth/', '/properties/search', '/public/orgs'];
+    const publicEndpoints = ['/health', '/auth/', '/properties/search', '/public/orgs', '/public/bookings'];
     const isPublicEndpoint =
       publicEndpoints.some((endpoint) => config.url?.includes(endpoint)) ||
       (config.url?.includes('/properties/') && config.url.includes('/public'));

--- a/src/queries/use-public-booking.ts
+++ b/src/queries/use-public-booking.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { publicBookingApi } from '@/api/public-booking.api';
+import type { CreateDirectBookingPayload } from '@/types';
+
+export function useCreateDirectBooking() {
+  return useMutation({
+    mutationFn: (payload: CreateDirectBookingPayload) =>
+      publicBookingApi.createDirectBooking(payload),
+  });
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,7 +15,7 @@ import { ManifestRoute } from './manifest-route';
 import { PublicBookingShell } from '@/components/layout/public-booking-shell';
 import { OrgLandingPage } from '@/features/public-booking/org-landing-page';
 import { PublicPropertyPage } from '@/features/public-booking/public-property-page';
-import { CheckoutPlaceholderPage } from '@/features/public-booking/checkout-placeholder-page';
+import { CheckoutPage } from '@/features/public-booking/checkout-page';
 
 function buildContextChildren(contextKey: AppContextKey): RouteObject[] {
   const prefix = `/app/${contextKey}`;
@@ -112,7 +112,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <OrgLandingPage /> },
       { path: 'property/:propertyId', element: <PublicPropertyPage /> },
-      { path: 'property/:propertyId/checkout', element: <CheckoutPlaceholderPage /> },
+      { path: 'property/:propertyId/checkout', element: <CheckoutPage /> },
     ],
   },
   {

--- a/src/types/direct-booking.types.ts
+++ b/src/types/direct-booking.types.ts
@@ -1,0 +1,40 @@
+export interface DirectBookingGuestPayload {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  country: string;
+}
+
+export interface DirectBookingConsentPayload {
+  dataProcessing: boolean;
+  consentVersion: string;
+}
+
+export interface CreateDirectBookingPayload {
+  propertyId: string;
+  checkInDate: string;
+  checkOutDate: string;
+  numberOfAdults: number;
+  numberOfChildren: number;
+  guest: DirectBookingGuestPayload;
+  consent: DirectBookingConsentPayload;
+  specialRequests?: string;
+}
+
+export interface ConnectedAccountPublishableContext {
+  publishableKey: string;
+  stripeAccountId: string;
+}
+
+export interface DirectBookingResponse {
+  bookingId: string;
+  clientSecret: string;
+  connectedAccountPublishableContext: ConnectedAccountPublishableContext;
+  amount: number;
+  currency: string;
+  touristTaxAmount: number;
+  basePrice: number;
+}
+
+export const DIRECT_CHECKOUT_CONSENT_VERSION = '2026-06-direct-checkout-v1';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,3 +13,4 @@ export * from './lease.types';
 export * from './admin.types';
 export * from './users.types';
 export * from './org.types';
+export * from './direct-booking.types';


### PR DESCRIPTION
## Summary
- Replace checkout placeholder with guest → consent → payment flow (Stripe Elements / demo mode)
- `createDirectBooking()` public API client without auth header
- Italian GDPR consent + price breakdown (tassa di soggiorno)
- Playwright E2E: `direct-checkout.spec.ts` + branded-site checkout route update

## Backend PR
https://github.com/casazen/backend/pull/227

## Test Plan
- [x] `npm test` (113 pass)
- [x] `npm run build`
- [x] `npm run test:e2e -- direct-checkout branded-booking-site`

Closes casazen/backend#226
