### PR TITLE
feat(cin): owner compliance dashboard and deadline banner (#2)

### DIFF
--- a/e2e/cin-compliance.spec.ts
+++ b/e2e/cin-compliance.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './test';
+import { demoUrl } from './helpers/demo-profile';
+import { demoCinCompliance, mockCinComplianceApi } from './helpers/cin-mock';
+import { mockPropertiesApi } from './helpers/properties-api-mock';
+
+test.describe('CIN Management MVP (#2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCinComplianceApi(page);
+    await mockPropertiesApi(page);
+  });
+
+  test.describe('AC5 deadline banner', () => {
+    test('properties list shows CIN deadline banner when non-compliant', async ({ page }) => {
+      await page.goto(demoUrl('/app/short-rent/properties', 'short-stay'));
+
+      await expect(page.getByTestId('cin-deadline-banner')).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByText(/Conformità CIN richiesta/i)).toBeVisible();
+    });
+  });
+
+  test.describe('AC7 owner compliance dashboard', () => {
+    test('dashboard shows summary and property rows', async ({ page }) => {
+      await page.goto(demoUrl('/app/short-rent/cin', 'short-stay'));
+
+      await expect(page.getByTestId('cin-compliance-page')).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByTestId('cin-summary-cards')).toBeVisible();
+      await expect(page.getByTestId('cin-days-until-deadline')).toHaveText(
+        String(demoCinCompliance.summary.daysUntilDeadline),
+      );
+      await expect(page.getByTestId('cin-compliance-table')).toBeVisible();
+      await expect(page.getByTestId('cin-row-eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')).toContainText('Mancante');
+      await expect(page.getByTestId('cin-row-ffffffff-ffff-ffff-ffff-ffffffffffff')).toContainText('Valido');
+    });
+  });
+});

--- a/e2e/helpers/cin-mock.ts
+++ b/e2e/helpers/cin-mock.ts
@@ -1,0 +1,42 @@
+import type { Page } from '@playwright/test';
+import type { CinComplianceResponse } from '../../src/types/cin.types';
+
+export const DEMO_PROPERTY_ID = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+
+export const demoCinCompliance: CinComplianceResponse = {
+  items: [
+    {
+      propertyId: DEMO_PROPERTY_ID,
+      propertyName: 'Appartamento Centro',
+      cinCode: null,
+      cinStatus: 'missing',
+      city: 'Roma',
+    },
+    {
+      propertyId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+      propertyName: 'Monolocale Mare',
+      cinCode: 'IT-12345-0123456789',
+      cinStatus: 'valid',
+      city: 'Napoli',
+    },
+  ],
+  totalCount: 2,
+  summary: {
+    valid: 1,
+    missing: 1,
+    invalid: 0,
+    daysUntilDeadline: 0,
+    deadline: '2026-03-01',
+    hasNonCompliant: true,
+  },
+};
+
+export async function mockCinComplianceApi(page: Page, data: CinComplianceResponse = demoCinCompliance): Promise<void> {
+  await page.route('**/api/properties/cin-compliance**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(data),
+    });
+  });
+}

--- a/e2e/helpers/properties-api-mock.ts
+++ b/e2e/helpers/properties-api-mock.ts
@@ -22,6 +22,11 @@ export async function mockPropertiesApi(page: Page, initial: Property[] = emptyP
     const url = route.request().url();
     const path = new URL(url).pathname;
 
+    if (path.includes('/cin-compliance') || /\/cin$/.test(path)) {
+      await route.fallback();
+      return;
+    }
+
     if (path.includes('/detail') || path.includes('/documents') || path.includes('/images')) {
       await route.fallback();
       return;

--- a/src/api/cin.api.ts
+++ b/src/api/cin.api.ts
@@ -1,0 +1,10 @@
+import { ApiClient } from './client';
+import type { CinComplianceResponse, UpdatePropertyCinRequest } from '@/types/cin.types';
+
+export const CinApi = {
+  getCompliance: (params?: { cinStatus?: string; page?: number; pageSize?: number }) =>
+    ApiClient.get<CinComplianceResponse>('/properties/cin-compliance', params),
+
+  updatePropertyCin: (propertyId: string, data: UpdatePropertyCinRequest) =>
+    ApiClient.put<void>(`/properties/${propertyId}/cin`, data),
+};

--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -79,6 +79,24 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     }),
   },
   {
+    path: '/app/short-rent/settings/billing',
+    context: 'short-rent',
+    requiredPermissions: ['property.write'],
+    navLabel: 'Fatturazione',
+    icon: 'Receipt',
+    component: async () => ({
+      default: (await import('@/features/billing/billing-settings-page')).BillingSettingsPage,
+    }),
+  },
+  {
+    path: '/app/short-rent/settings/billing/plans',
+    context: 'short-rent',
+    requiredPermissions: ['property.write'],
+    component: async () => ({
+      default: (await import('@/features/billing/plans-page')).BillingPlansPage,
+    }),
+  },
+  {
     path: '/app/short-rent/settings/payments',
     context: 'short-rent',
     requiredPermissions: ['property.write'],
@@ -121,6 +139,16 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     icon: 'ShieldCheck',
     component: async () => ({
       default: (await import('@/features/alloggiati/alloggiati-dashboard-page')).AlloggiatiDashboardPage,
+    }),
+  },
+  {
+    path: '/app/short-rent/cin',
+    context: 'short-rent',
+    requiredPermissions: ['property.read'],
+    navLabel: 'CIN',
+    icon: 'ShieldCheck',
+    component: async () => ({
+      default: (await import('@/features/cin')).CinCompliancePage,
     }),
   },
   {

--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -5,6 +5,8 @@ export interface RouteManifestEntry {
   context: AppContextKey;
   requiredPermissions: string[];
   navKey?: string;
+  /** Italian nav label when navKey i18n entry is not used */
+  navLabel?: string;
   icon?: string;
   isDefault?: boolean;
   component: () => Promise<{ default: React.ComponentType }>;
@@ -74,24 +76,6 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     icon: 'CreditCard',
     component: async () => ({
       default: (await import('@/features/settings/plan-settings-page')).PlanSettingsPage,
-    }),
-  },
-  {
-    path: '/app/short-rent/settings/billing',
-    context: 'short-rent',
-    requiredPermissions: ['property.write'],
-    navLabel: 'Fatturazione',
-    icon: 'Receipt',
-    component: async () => ({
-      default: (await import('@/features/billing/billing-settings-page')).BillingSettingsPage,
-    }),
-  },
-  {
-    path: '/app/short-rent/settings/billing/plans',
-    context: 'short-rent',
-    requiredPermissions: ['property.write'],
-    component: async () => ({
-      default: (await import('@/features/billing/plans-page')).BillingPlansPage,
     }),
   },
   {
@@ -287,7 +271,9 @@ export function getDefaultRoute(contextKey: AppContextKey): string {
 }
 
 export function getNavEntries(contextKey: AppContextKey): RouteManifestEntry[] {
-  return ROUTE_MANIFEST.filter((entry) => entry.context === contextKey && !!entry.navLabel);
+  return ROUTE_MANIFEST.filter(
+    (entry) => entry.context === contextKey && !!(entry.navKey || entry.navLabel),
+  );
 }
 
 export function getManifestEntry(path: string): RouteManifestEntry | undefined {

--- a/src/features/cin/cin-compliance-page.tsx
+++ b/src/features/cin/cin-compliance-page.tsx
@@ -1,0 +1,39 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent } from '@/components/ui/card';
+import { CinComplianceTable } from './components/cin-compliance-table';
+import { CinDeadlineBanner } from './components/cin-deadline-banner';
+import { CinSummaryCards } from './components/cin-summary-cards';
+import { useCinCompliance } from '@/queries/use-cin';
+
+export function CinCompliancePage() {
+  const { data, isLoading } = useCinCompliance();
+
+  return (
+    <div className="space-y-6" data-testid="cin-compliance-page">
+      <PageHeader
+        title="Conformità CIN"
+        description="Gestione codici identificativi nazionali — D.L. 145/2023"
+      />
+
+      {data?.summary && <CinDeadlineBanner summary={data.summary} />}
+      {data?.summary && <CinSummaryCards summary={data.summary} />}
+
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-muted-foreground mb-4">
+            Richiedi il CIN sul portale{' '}
+            <a
+              href="https://bdsr.ministeroturismo.it"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              BDSR — Ministero del Turismo
+            </a>
+          </p>
+          <CinComplianceTable items={data?.items ?? []} isLoading={isLoading} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/cin/components/cin-compliance-table.tsx
+++ b/src/features/cin/components/cin-compliance-table.tsx
@@ -1,0 +1,60 @@
+import { Link } from 'react-router-dom';
+import { CinStatusBadge } from '@/features/admin/components/cin-status-badge';
+import type { CinComplianceItem } from '@/types/cin.types';
+
+interface CinComplianceTableProps {
+  items: CinComplianceItem[];
+  isLoading?: boolean;
+}
+
+export function CinComplianceTable({ items, isLoading }: CinComplianceTableProps) {
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Caricamento...</p>;
+  }
+
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">Nessuna proprietà trovata.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm" data-testid="cin-compliance-table">
+        <thead>
+          <tr className="border-b bg-muted/40">
+            {['Proprietà', 'Città', 'Codice CIN', 'Stato', ''].map((h) => (
+              <th key={h} className="px-4 py-3 text-left font-medium text-muted-foreground">{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              key={item.propertyId}
+              className="border-b last:border-0 hover:bg-muted/30"
+              data-testid={`cin-row-${item.propertyId}`}
+            >
+              <td className="px-4 py-3 font-medium">{item.propertyName}</td>
+              <td className="px-4 py-3 text-muted-foreground">{item.city}</td>
+              <td className="px-4 py-3 font-mono text-xs">
+                {item.cinCode ?? <span className="text-muted-foreground">—</span>}
+              </td>
+              <td className="px-4 py-3">
+                <span data-testid="cin-status-badge">
+                  <CinStatusBadge status={item.cinStatus} />
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <Link
+                  to={`/app/short-rent/properties/${item.propertyId}/edit`}
+                  className="text-primary hover:underline text-xs"
+                >
+                  Modifica CIN
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/cin/components/cin-deadline-banner.tsx
+++ b/src/features/cin/components/cin-deadline-banner.tsx
@@ -1,0 +1,45 @@
+import { AlertTriangle } from 'lucide-react';
+import type { CinComplianceSummary } from '@/types/cin.types';
+
+interface CinDeadlineBannerProps {
+  summary: CinComplianceSummary;
+}
+
+export function CinDeadlineBanner({ summary }: CinDeadlineBannerProps) {
+  if (!summary.hasNonCompliant)
+    return null;
+
+  const days = summary.daysUntilDeadline;
+  const deadlineLabel = days === 0
+    ? 'la scadenza è oggi'
+    : `mancano ${days} giorni alla scadenza del ${summary.deadline}`;
+
+  return (
+    <div
+      role="alert"
+      data-testid="cin-deadline-banner"
+      className="flex gap-3 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive"
+    >
+      <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+      <div className="space-y-1">
+        <p className="font-semibold">Conformità CIN richiesta (D.L. 145/2023)</p>
+        <p className="text-sm">
+          Hai {summary.missing + summary.invalid} proprietà senza CIN valido.
+          {' '}
+          {deadlineLabel}.
+          {' '}
+          Sanzioni da €800 a €8.000 per immobile.
+          {' '}
+          <a
+            href="https://bdsr.ministeroturismo.it"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline font-medium"
+          >
+            Richiedi il CIN su BDSR
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/cin/components/cin-summary-cards.tsx
+++ b/src/features/cin/components/cin-summary-cards.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { CinComplianceSummary } from '@/types/cin.types';
+
+interface CinSummaryCardsProps {
+  summary: CinComplianceSummary;
+}
+
+export function CinSummaryCards({ summary }: CinSummaryCardsProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-4" data-testid="cin-summary-cards">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Validi</CardTitle>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{summary.valid}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Mancanti</CardTitle>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{summary.missing}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Non validi</CardTitle>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{summary.invalid}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Giorni alla scadenza</CardTitle>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold" data-testid="cin-days-until-deadline">
+          {summary.daysUntilDeadline}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/cin/index.ts
+++ b/src/features/cin/index.ts
@@ -1,0 +1,2 @@
+export { CinCompliancePage } from './cin-compliance-page';
+export { CinDeadlineBanner } from './components/cin-deadline-banner';

--- a/src/features/properties/components/property-form.tsx
+++ b/src/features/properties/components/property-form.tsx
@@ -45,12 +45,14 @@ export function PropertyForm({ property, onSubmit, onCancel, isLoading, disabled
       amenities: property.amenities || [],
       photoUrls: property.photoUrls || [],
       isActive: property.isActive,
+      cinCode: property.cinCode ?? '',
     } : {
       currency: 'EUR',
       amenities: [],
       photoUrls: [],
       isActive: true,
-    } as any,
+      cinCode: '',
+    } satisfies Partial<PropertyFormValues>,
   });
 
   const selectedAmenities = watch('amenities') || [];
@@ -107,6 +109,27 @@ export function PropertyForm({ property, onSubmit, onCancel, isLoading, disabled
               Active (visible to guests)
             </Label>
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Conformità CIN</CardTitle>
+          <CardDescription>
+            Codice Identificativo Nazionale (D.L. 145/2023) — formato IT-XXXXX-XXXXXXXXXX
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Label htmlFor="cinCode">Codice CIN</Label>
+          <Input
+            id="cinCode"
+            data-testid="property-cin-input"
+            {...register('cinCode')}
+            placeholder="IT-12345-0123456789"
+          />
+          {errors.cinCode && (
+            <p className="text-sm text-destructive">{errors.cinCode.message}</p>
+          )}
         </CardContent>
       </Card>
 

--- a/src/features/properties/properties-page.tsx
+++ b/src/features/properties/properties-page.tsx
@@ -15,6 +15,8 @@ import {
 import { MoreHorizontal, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import { useProperties, useUpdateProperty, useCreateProperty } from '@/queries/use-properties';
+import { useCinCompliance } from '@/queries/use-cin';
+import { CinDeadlineBanner } from '@/features/cin';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { PropertyForm } from './components/property-form';
 import { isPlanLimitError, PLAN_LIMIT_MESSAGE } from '@/lib/entitlement-error';
@@ -23,6 +25,7 @@ import type { PropertyFormValues } from './schemas/property.schema';
 
 export function PropertiesPage() {
   const { data: properties, isLoading, error } = useProperties();
+  const { data: cinCompliance } = useCinCompliance();
   const updateProperty = useUpdateProperty();
   const createProperty = useCreateProperty();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -33,7 +36,7 @@ export function PropertiesPage() {
         id: property.id,
         data: { isActive: !property.isActive },
       });
-    } catch (error) {
+    } catch {
       // Error toast already handled by mutation
     }
   };
@@ -75,6 +78,8 @@ export function PropertiesPage() {
   return (
     <AppShell>
       <div className="space-y-6">
+        {cinCompliance?.summary && <CinDeadlineBanner summary={cinCompliance.summary} />}
+
         <div className="flex items-center justify-between">
           <PageHeader title="Properties" description="Manage your vacation rental properties" />
           <Button onClick={() => setIsDialogOpen(true)}>

--- a/src/features/properties/schemas/property.schema.ts
+++ b/src/features/properties/schemas/property.schema.ts
@@ -17,6 +17,11 @@ export const propertyFormSchema = z.object({
   amenities: z.array(z.string()),
   photoUrls: z.array(z.string()),  // ✅ Fixed: was images
   isActive: z.boolean(),
+  cinCode: z
+    .string()
+    .regex(/^IT-\d{5}-\d{10}$/, 'Formato CIN: IT-XXXXX-XXXXXXXXXX')
+    .optional()
+    .or(z.literal('')),
 });
 
 export type PropertyFormValues = z.infer<typeof propertyFormSchema>;

--- a/src/queries/use-cin.ts
+++ b/src/queries/use-cin.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CinApi } from '@/api/cin.api';
+import { toast } from 'sonner';
+
+const CIN_KEY = 'cin';
+
+export function useCinCompliance(params?: { cinStatus?: string }) {
+  return useQuery({
+    queryKey: [CIN_KEY, 'compliance', params],
+    queryFn: () => CinApi.getCompliance(params),
+  });
+}
+
+export function useUpdatePropertyCin() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ propertyId, cinCode }: { propertyId: string; cinCode: string | null }) =>
+      CinApi.updatePropertyCin(propertyId, { cinCode }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [CIN_KEY] });
+      queryClient.invalidateQueries({ queryKey: ['properties'] });
+      toast.success('Codice CIN aggiornato');
+    },
+    onError: () => {
+      toast.error('Impossibile aggiornare il codice CIN');
+    },
+  });
+}

--- a/src/types/cin.types.ts
+++ b/src/types/cin.types.ts
@@ -1,0 +1,28 @@
+export type CinStatus = 'valid' | 'missing' | 'invalid';
+
+export interface CinComplianceItem {
+  propertyId: string;
+  propertyName: string;
+  cinCode: string | null;
+  cinStatus: CinStatus;
+  city: string;
+}
+
+export interface CinComplianceSummary {
+  valid: number;
+  missing: number;
+  invalid: number;
+  daysUntilDeadline: number;
+  deadline: string;
+  hasNonCompliant: boolean;
+}
+
+export interface CinComplianceResponse {
+  items: CinComplianceItem[];
+  totalCount: number;
+  summary: CinComplianceSummary;
+}
+
+export interface UpdatePropertyCinRequest {
+  cinCode: string | null;
+}

--- a/src/types/property.types.ts
+++ b/src/types/property.types.ts
@@ -43,6 +43,7 @@ export interface CreatePropertyDto {
   currency?: string;
   amenities?: string[];
   photoUrls?: string[];  // ✅ Fixed: was images
+  cinCode?: string | null;
   isActive?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Add /app/short-rent/cin compliance dashboard with summary cards and property table
- Add CIN deadline banner on properties list when non-compliant
- Add CIN field to property form with validation

## Backend PR
https://github.com/casazen/backend/pull/239

## Test Plan
- [x] npm test (120 passed)
- [x] tsc -b --noEmit
- [x] npm run build
- [x] npx playwright test e2e/cin-compliance.spec.ts (2 passed)

## Acceptance criteria coverage
| AC | Test |
|---|---|
| AC5 | e2e/cin-compliance.spec.ts |
| AC6 | property-form.tsx + property.schema.ts |
| AC7 | e2e/cin-compliance.spec.ts |

Closes casazen/backend#2