### PR TITLE
fix(prod): admin CIN hardening and pricing preview fallback (#188 #235)

### DIFF
--- a/src/features/admin/admin-cin-page.tsx
+++ b/src/features/admin/admin-cin-page.tsx
@@ -4,7 +4,7 @@ import { CinComplianceTable } from './components/cin-compliance-table';
 import { useCinCompliance } from '@/queries/use-admin';
 
 export function AdminCinPage() {
-  const { data, isLoading } = useCinCompliance();
+  const { data, isLoading, isError } = useCinCompliance();
 
   return (
     <div className="space-y-6">
@@ -14,7 +14,13 @@ export function AdminCinPage() {
       />
       <Card>
         <CardContent className="pt-6">
-          <CinComplianceTable items={data ?? []} isLoading={isLoading} />
+          {isError ? (
+            <p className="py-8 text-center text-destructive">
+              Impossibile caricare i dati CIN. Riprova più tardi.
+            </p>
+          ) : (
+            <CinComplianceTable items={data ?? []} isLoading={isLoading} />
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/features/admin/components/cin-status-badge.tsx
+++ b/src/features/admin/components/cin-status-badge.tsx
@@ -14,6 +14,6 @@ const STATUS_MAP: Record<
 };
 
 export function CinStatusBadge({ status }: CinStatusBadgeProps) {
-  const { label, variant } = STATUS_MAP[status];
-  return <Badge variant={variant}>{label}</Badge>;
+  const mapped = STATUS_MAP[status] ?? STATUS_MAP.missing;
+  return <Badge variant={mapped.variant}>{mapped.label}</Badge>;
 }

--- a/src/queries/use-pricing-adapter.ts
+++ b/src/queries/use-pricing-adapter.ts
@@ -112,7 +112,10 @@ export function useTriggerPricingSync(propertyId: string) {
 export function usePricingPreview(propertyId: string) {
   return useQuery({
     queryKey: [PRICING_KEY, 'preview', propertyId],
-    queryFn: () => pricingAdapterApi.getPreview(propertyId),
+    queryFn: async () => {
+      const preview = await pricingAdapterApi.getPreview(propertyId);
+      return preview ?? { prices: [] };
+    },
     enabled: !!propertyId,
   });
 }


### PR DESCRIPTION
## Summary
- Harden admin CIN page: fallback badge for unknown status, error state on API failure (#188)
- Treat missing pricing preview as empty list instead of query failure (#235)

Note: pricing 404 handling, profile roles, property form prefill, CIN edit dialog, and admin user display fixes are already on develop via 8a903d7.

## Test plan
- [x] `npm run test -- --run src/queries/__tests__/use-pricing-adapter.test.ts`
- [ ] Navigate to /app/admin/cin as Admin — page renders without exception
- [ ] Navigate to property pricing page with no config — shows setup UI, not spinner

Closes #188, #235