### PR TITLE
release: v1.1.16 — production bug fixes (#188 #235 #236 #237 #238 #219)

### DIFF
--- a/src/features/admin/admin-cin-page.tsx
+++ b/src/features/admin/admin-cin-page.tsx
@@ -4,7 +4,7 @@ import { CinComplianceTable } from './components/cin-compliance-table';
 import { useCinCompliance } from '@/queries/use-admin';
 
 export function AdminCinPage() {
-  const { data, isLoading } = useCinCompliance();
+  const { data, isLoading, isError } = useCinCompliance();
 
   return (
     <div className="space-y-6">
@@ -14,7 +14,13 @@ export function AdminCinPage() {
       />
       <Card>
         <CardContent className="pt-6">
-          <CinComplianceTable items={data ?? []} isLoading={isLoading} />
+          {isError ? (
+            <p className="py-8 text-center text-destructive">
+              Impossibile caricare i dati CIN. Riprova più tardi.
+            </p>
+          ) : (
+            <CinComplianceTable items={data ?? []} isLoading={isLoading} />
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/features/admin/components/cin-status-badge.tsx
+++ b/src/features/admin/components/cin-status-badge.tsx
@@ -14,6 +14,6 @@ const STATUS_MAP: Record<
 };
 
 export function CinStatusBadge({ status }: CinStatusBadgeProps) {
-  const { label, variant } = STATUS_MAP[status];
-  return <Badge variant={variant}>{label}</Badge>;
+  const mapped = STATUS_MAP[status] ?? STATUS_MAP.missing;
+  return <Badge variant={mapped.variant}>{mapped.label}</Badge>;
 }

--- a/src/queries/use-pricing-adapter.ts
+++ b/src/queries/use-pricing-adapter.ts
@@ -112,7 +112,10 @@ export function useTriggerPricingSync(propertyId: string) {
 export function usePricingPreview(propertyId: string) {
   return useQuery({
     queryKey: [PRICING_KEY, 'preview', propertyId],
-    queryFn: () => pricingAdapterApi.getPreview(propertyId),
+    queryFn: async () => {
+      const preview = await pricingAdapterApi.getPreview(propertyId);
+      return preview ?? { prices: [] };
+    },
     enabled: !!propertyId,
   });
 }


### PR DESCRIPTION
## Release v1.1.16 — Production bug fixes

Fixes open production bugs:
- #235: Pricing page handles missing config/preview (no infinite spinner)
- #236: Profile shows correct JWT roles
- #237: Property edit pre-fills country/currency
- #238: CIN entry dialog on property detail
- #188: Admin CIN page hardened (error state + badge fallback)
- #219: Admin user table display fallbacks

## Test plan (staging)
- [x] npm run test:e2e — 77 passed
- [x] E2E_STAGING api-regression-smoke — 2 passed