### PR TITLE
feat(nav): unify navigation IA and layout across all breakpoints (#259)

### DIFF
--- a/e2e/mobile-navigation.spec.ts
+++ b/e2e/mobile-navigation.spec.ts
@@ -34,20 +34,22 @@ test.describe('Mobile navigation (#252)', () => {
     await page.goto(demoUrl('/app/short-rent', 'short-stay'), { waitUntil: 'domcontentloaded' });
 
     await page.getByRole('button', { name: 'Open navigation menu' }).click();
-    await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByText('Finanza')).toBeVisible();
+    const drawer = page.getByRole('dialog');
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByText(/Finanza|Finance/i)).toBeVisible();
 
-    await page.getByRole('link', { name: 'Incassi' }).click();
+    await drawer.getByRole('link', { name: /Incassi|Payments/i }).click();
     await expect(page).toHaveURL(/\/app\/short-rent\/payments/);
-    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(drawer).not.toBeVisible();
   });
 
   test('drawer shows disambiguated payment labels', async ({ page }) => {
     await page.goto(demoUrl('/app/short-rent', 'short-stay'), { waitUntil: 'domcontentloaded' });
 
     await page.getByRole('button', { name: 'Open navigation menu' }).click();
-    await expect(page.getByRole('link', { name: 'Incassi' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Stripe Connect' })).toBeVisible();
+    const drawer = page.getByRole('dialog');
+    await expect(drawer.getByRole('link', { name: /Incassi|Payments/i })).toBeVisible();
+    await expect(drawer.getByRole('link', { name: /Stripe Connect/i })).toBeVisible();
   });
 
   test('no horizontal overflow on dashboard', async ({ page }) => {
@@ -73,7 +75,9 @@ test.describe('Mobile navigation (#252)', () => {
     await mockLeasesApiEmpty(page);
     await page.goto(demoUrl('/app/short-rent', 'dual'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('tab', { name: 'Affitti brevi' })).toBeVisible();
-    await expect(page.getByRole('tab', { name: 'Affitti lungo termine' })).toBeVisible();
+    await page.getByRole('button', { name: 'Open navigation menu' }).click();
+    const drawer = page.getByRole('dialog');
+    await expect(drawer.getByRole('tab', { name: 'Affitti brevi' })).toBeVisible();
+    await expect(drawer.getByRole('tab', { name: 'Affitti lungo termine' })).toBeVisible();
   });
 });

--- a/e2e/nav-layout-unification.spec.ts
+++ b/e2e/nav-layout-unification.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from './test';
+import { demoUrl } from './helpers/demo-profile';
+
+test.describe('Navigation layout unification (#259)', () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
+  test('desktop sidebar shows grouped sections', async ({ page }) => {
+    await page.goto(demoUrl('/app/short-rent', 'short-stay'), { waitUntil: 'domcontentloaded' });
+
+    const sidebar = page.getByRole('complementary', { name: 'Main navigation' });
+    await expect(sidebar.getByText(/Operazioni|Operations/i)).toBeVisible();
+    await expect(sidebar.getByText(/Finanza|Finance/i)).toBeVisible();
+  });
+
+  test('calendar route highlights Calendario not Prenotazioni in sidebar', async ({ page }) => {
+    await page.goto(demoUrl('/app/short-rent/bookings/calendar', 'short-stay'), {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const sidebar = page.getByRole('complementary', { name: 'Main navigation' });
+    const calendarLink = sidebar.getByRole('link', { name: /Calendario|Calendar/i });
+    const bookingsLink = sidebar.getByRole('link', { name: /Prenotazioni|Bookings/i });
+
+    await expect(calendarLink).toHaveAttribute('aria-current', 'page');
+    await expect(bookingsLink).not.toHaveAttribute('aria-current', 'page');
+  });
+
+  test('revenue page uses app shell with sidebar', async ({ page }) => {
+    await page.goto(demoUrl('/app/short-rent/payments/revenue', 'short-stay'), {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(page.getByRole('complementary', { name: 'Main navigation' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Analisi ricavi|Revenue Analytics/i })).toBeVisible();
+  });
+
+  test('CIN page uses app shell with sidebar', async ({ page }) => {
+    await page.goto(demoUrl('/app/short-rent/cin', 'short-stay'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByRole('complementary', { name: 'Main navigation' })).toBeVisible();
+    await expect(page.getByTestId('cin-compliance-page')).toBeVisible();
+  });
+});
+
+test.describe('Navigation layout unification — mobile (#259)', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('workspace switcher is not in header on dual-role mobile', async ({ page }) => {
+    await page.goto(demoUrl('/app/short-rent', 'dual'), { waitUntil: 'domcontentloaded' });
+
+    const header = page.locator('header');
+    await expect(header.getByRole('tablist', { name: 'Workspace context' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Open navigation menu' }).click();
+    await expect(page.getByRole('dialog').getByRole('tablist', { name: 'Workspace context' })).toBeVisible();
+  });
+});

--- a/src/components/layout/admin-app-shell.tsx
+++ b/src/components/layout/admin-app-shell.tsx
@@ -3,22 +3,18 @@ import { AdminSidebar } from './admin-sidebar';
 import { Header } from './header';
 import { BottomNav } from './bottom-nav';
 import { MobileNavDrawer } from './mobile-nav-drawer';
-import { WorkspaceSwitcher } from './workspace-switcher';
-import { useWorkspace } from '@/hooks/use-workspace';
 
 interface AdminAppShellProps {
   children?: React.ReactNode;
 }
 
 export function AdminAppShell({ children }: AdminAppShellProps) {
-  const { contexts } = useWorkspace();
-
   return (
     <div className="flex h-screen overflow-hidden">
       <AdminSidebar />
       <MobileNavDrawer contextKey="admin" />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <Header slotStart={contexts.length > 1 ? <WorkspaceSwitcher /> : undefined} />
+        <Header />
         <main className="flex-1 overflow-y-auto p-4 pb-[calc(var(--bottom-nav-height)+env(safe-area-inset-bottom))] md:pb-6 md:p-6">
           {children ?? <Outlet />}
         </main>

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -1,64 +1,12 @@
-import { NavLink } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
-import { cn } from '@/lib/utils';
-import { Home } from 'lucide-react';
-import { getVisibleNavEntries } from '@/config/route-manifest';
-import { getNavIcon } from '@/lib/nav-icons';
-import { getNavLabel } from '@/lib/nav-labels';
-import { useWorkspace } from '@/hooks/use-workspace';
+import { ContextSidebar } from './context-sidebar';
 
 export function AdminSidebar() {
-  const { t } = useTranslation();
-  const { hasPermission } = useWorkspace();
-  const navItems = getVisibleNavEntries('admin', hasPermission).map((entry) => ({
-    to: entry.path,
-    icon: getNavIcon(entry.icon),
-    label: getNavLabel(entry, t),
-    end: entry.path === '/app/admin',
-  }));
-
   return (
-    <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
-      <div className="flex h-16 items-center border-b px-6">
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-destructive text-destructive-foreground shadow-sm">
-            <Home className="h-4 w-4" />
-          </div>
-          <div className="flex flex-col leading-none">
-            <span className="text-base font-bold tracking-tight">CASAZEN</span>
-            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">
-              Admin Panel
-            </span>
-          </div>
-        </div>
-      </div>
-      <nav className="flex-1 space-y-0.5 p-3">
-        {navItems.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            end={item.end}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-primary text-primary-foreground shadow-sm'
-                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-              )
-            }
-          >
-            <>
-              <item.icon className="h-4 w-4 shrink-0" />
-              {item.label}
-            </>
-          </NavLink>
-        ))}
-      </nav>
-      <div className="border-t p-3">
-        <p className="text-[10px] text-muted-foreground text-center tracking-wide">
-          v1.0.0 · Admin
-        </p>
-      </div>
-    </aside>
+    <ContextSidebar
+      contextKey="admin"
+      subtitle="Admin Panel"
+      iconClassName="bg-destructive text-destructive-foreground"
+      footerLabel="v1.0.0 · Admin"
+    />
   );
 }

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -2,24 +2,20 @@ import { Sidebar } from './sidebar';
 import { Header } from './header';
 import { BottomNav } from './bottom-nav';
 import { MobileNavDrawer } from './mobile-nav-drawer';
-import { WorkspaceSwitcher } from './workspace-switcher';
 import { DemoBanner } from '@/components/shared/demo-banner';
-import { useWorkspace } from '@/hooks/use-workspace';
 
 interface AppShellProps {
   children: React.ReactNode;
 }
 
 export function AppShell({ children }: AppShellProps) {
-  const { contexts } = useWorkspace();
-
   return (
     <div className="flex h-screen overflow-hidden">
       <Sidebar />
       <MobileNavDrawer contextKey="short-rent" />
       <div className="flex flex-1 flex-col overflow-hidden">
         <DemoBanner />
-        <Header slotStart={contexts.length > 1 ? <WorkspaceSwitcher /> : undefined} />
+        <Header />
         <main className="flex-1 overflow-y-auto p-4 pb-[calc(var(--bottom-nav-height)+env(safe-area-inset-bottom))] md:pb-6 md:p-6">
           {children}
         </main>

--- a/src/components/layout/context-sidebar.tsx
+++ b/src/components/layout/context-sidebar.tsx
@@ -1,0 +1,64 @@
+import type { LucideIcon } from 'lucide-react';
+import { Home } from 'lucide-react';
+import {
+  getDesktopNavByGroup,
+  getVisibleNavEntries,
+  type AppContextKey,
+} from '@/config/route-manifest';
+import { useWorkspace } from '@/hooks/use-workspace';
+import { GroupedNavLinks } from './grouped-nav-links';
+import { WorkspaceSwitcher } from './workspace-switcher';
+
+interface ContextSidebarProps {
+  contextKey: AppContextKey;
+  subtitle: string;
+  icon?: LucideIcon;
+  iconClassName?: string;
+  footerLabel?: string;
+}
+
+export function ContextSidebar({
+  contextKey,
+  subtitle,
+  icon: Icon = Home,
+  iconClassName = 'bg-primary text-primary-foreground',
+  footerLabel = 'v1.0.0 · casazen.io',
+}: ContextSidebarProps) {
+  const { contexts, hasPermission } = useWorkspace();
+  const permissionCheck = (ctx: AppContextKey, permission: string) =>
+    hasPermission(ctx, permission);
+
+  const allEntries = getVisibleNavEntries(contextKey, permissionCheck);
+  const grouped = getDesktopNavByGroup(contextKey, permissionCheck);
+
+  return (
+    <aside role="complementary" aria-label="Main navigation" className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
+      <div className="border-b px-4 py-4 space-y-3">
+        <div className="flex items-center gap-2.5 px-2">
+          <div
+            className={`flex h-8 w-8 items-center justify-center rounded-lg shadow-sm ${iconClassName}`}
+          >
+            <Icon className="h-4 w-4" />
+          </div>
+          <div className="flex flex-col leading-none">
+            <span className="text-base font-bold tracking-tight">CASAZEN</span>
+            <span className="text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+              {subtitle}
+            </span>
+          </div>
+        </div>
+        {contexts.length > 1 && <WorkspaceSwitcher layout="sidebar" />}
+      </div>
+      <nav className="flex-1 overflow-y-auto p-3">
+        <GroupedNavLinks
+          grouped={grouped}
+          allEntries={allEntries}
+          variant="sidebar"
+        />
+      </nav>
+      <div className="border-t p-3">
+        <p className="text-center text-[10px] tracking-wide text-muted-foreground">{footerLabel}</p>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/layout/grouped-nav-links.tsx
+++ b/src/components/layout/grouped-nav-links.tsx
@@ -1,0 +1,81 @@
+import { Link, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { getNavIcon } from '@/lib/nav-icons';
+import { getNavGroupLabel, getNavLabel } from '@/lib/nav-labels';
+import { isNavEntryActive } from '@/lib/nav-active';
+import {
+  NAV_GROUP_ORDER,
+  type NavGroup,
+  type RouteManifestEntry,
+} from '@/config/route-manifest';
+
+type NavVariant = 'sidebar' | 'drawer';
+
+interface GroupedNavLinksProps {
+  grouped: Map<NavGroup, RouteManifestEntry[]>;
+  allEntries: RouteManifestEntry[];
+  variant?: NavVariant;
+  onNavigate?: () => void;
+}
+
+const linkStyles: Record<NavVariant, { active: string; inactive: string; row: string }> = {
+  sidebar: {
+    row: 'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+    active: 'bg-primary text-primary-foreground shadow-sm',
+    inactive: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+  },
+  drawer: {
+    row: 'flex min-h-11 items-center gap-3 px-4 py-3 text-sm font-medium transition-colors',
+    active: 'bg-primary/10 text-primary',
+    inactive: 'text-foreground hover:bg-accent',
+  },
+};
+
+export function GroupedNavLinks({
+  grouped,
+  allEntries,
+  variant = 'sidebar',
+  onNavigate,
+}: GroupedNavLinksProps) {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const styles = linkStyles[variant];
+  const visibleGroups = NAV_GROUP_ORDER.filter((group) => grouped.has(group));
+
+  return (
+    <>
+      {visibleGroups.map((group) => {
+        const entries = grouped.get(group) ?? [];
+        return (
+          <div key={group} className={variant === 'sidebar' ? 'mb-4' : 'mb-4'}>
+            <p
+              className={cn(
+                'text-xs font-semibold uppercase tracking-wide text-muted-foreground',
+                variant === 'sidebar' ? 'px-3 py-2' : 'px-4 py-2',
+              )}
+            >
+              {getNavGroupLabel(group, t)}
+            </p>
+            {entries.map((entry) => {
+              const Icon = getNavIcon(entry.icon);
+              const active = isNavEntryActive(location.pathname, entry, allEntries);
+              return (
+                <Link
+                  key={entry.path}
+                  to={entry.path}
+                  onClick={onNavigate}
+                  aria-current={active ? 'page' : undefined}
+                  className={cn(styles.row, active ? styles.active : styles.inactive)}
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  {getNavLabel(entry, t)}
+                </Link>
+              );
+            })}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/layout/long-term-app-shell.tsx
+++ b/src/components/layout/long-term-app-shell.tsx
@@ -3,24 +3,20 @@ import { LongTermSidebar } from './long-term-sidebar';
 import { Header } from './header';
 import { BottomNav } from './bottom-nav';
 import { MobileNavDrawer } from './mobile-nav-drawer';
-import { WorkspaceSwitcher } from './workspace-switcher';
 import { DemoBanner } from '@/components/shared/demo-banner';
-import { useWorkspace } from '@/hooks/use-workspace';
 
 interface LongTermAppShellProps {
   children?: React.ReactNode;
 }
 
 export function LongTermAppShell({ children }: LongTermAppShellProps) {
-  const { contexts } = useWorkspace();
-
   return (
     <div className="flex h-screen overflow-hidden">
       <LongTermSidebar />
       <MobileNavDrawer contextKey="long-rent" />
       <div className="flex flex-1 flex-col overflow-hidden">
         <DemoBanner />
-        <Header slotStart={contexts.length > 1 ? <WorkspaceSwitcher /> : undefined} />
+        <Header />
         <main className="flex-1 overflow-y-auto p-4 pb-[calc(var(--bottom-nav-height)+env(safe-area-inset-bottom))] md:pb-6 md:p-6">
           {children ?? <Outlet />}
         </main>

--- a/src/components/layout/long-term-sidebar.tsx
+++ b/src/components/layout/long-term-sidebar.tsx
@@ -1,62 +1,10 @@
-import { NavLink } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
-import { cn } from '@/lib/utils';
-import { Home } from 'lucide-react';
-import { getVisibleNavEntries } from '@/config/route-manifest';
-import { getNavIcon } from '@/lib/nav-icons';
-import { getNavLabel } from '@/lib/nav-labels';
-import { useWorkspace } from '@/hooks/use-workspace';
+import { ContextSidebar } from './context-sidebar';
 
 export function LongTermSidebar() {
-  const { t } = useTranslation();
-  const { hasPermission } = useWorkspace();
-  const navItems = getVisibleNavEntries('long-rent', hasPermission).map((entry) => ({
-    to: entry.path,
-    icon: getNavIcon(entry.icon),
-    label: getNavLabel(entry, t),
-    end: entry.path === '/app/long-rent/leases',
-  }));
-
   return (
-    <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
-      <div className="flex h-16 items-center border-b px-6">
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <Home className="h-4 w-4" />
-          </div>
-          <div className="flex flex-col leading-none">
-            <span className="text-base font-bold tracking-tight">CASAZEN</span>
-            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">
-              Long-Term Rental
-            </span>
-          </div>
-        </div>
-      </div>
-      <nav className="flex-1 space-y-0.5 p-3">
-        {navItems.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            end={item.end}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-primary text-primary-foreground shadow-sm'
-                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-              )
-            }
-          >
-            <>
-              <item.icon className="h-4 w-4 shrink-0" />
-              {item.label}
-            </>
-          </NavLink>
-        ))}
-      </nav>
-      <div className="border-t p-3">
-        <p className="text-[10px] text-muted-foreground text-center tracking-wide">v1.0.0 · casazen.io</p>
-      </div>
-    </aside>
+    <ContextSidebar
+      contextKey="long-rent"
+      subtitle="Long-Term Rental"
+    />
   );
 }

--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -1,16 +1,13 @@
-import { NavLink } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import { Home } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { getNavIcon } from '@/lib/nav-icons';
-import { getNavGroupLabel, getNavLabel } from '@/lib/nav-labels';
 import {
-  NAV_GROUP_ORDER,
   getDrawerNavByGroup,
+  getVisibleNavEntries,
   type AppContextKey,
 } from '@/config/route-manifest';
 import { useWorkspace } from '@/hooks/use-workspace';
 import { useUiStore } from '@/store/ui-store';
+import { GroupedNavLinks } from './grouped-nav-links';
+import { WorkspaceSwitcher } from './workspace-switcher';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 
 const CONTEXT_TITLES: Record<AppContextKey, string> = {
@@ -24,16 +21,15 @@ interface MobileNavDrawerProps {
 }
 
 export function MobileNavDrawer({ contextKey }: MobileNavDrawerProps) {
-  const { t } = useTranslation();
-  const { hasPermission } = useWorkspace();
+  const { contexts, hasPermission } = useWorkspace();
   const sidebarOpen = useUiStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUiStore((state) => state.setSidebarOpen);
 
   const permissionCheck = (ctx: AppContextKey, permission: string) =>
     hasPermission(ctx, permission);
 
+  const allEntries = getVisibleNavEntries(contextKey, permissionCheck);
   const grouped = getDrawerNavByGroup(contextKey, permissionCheck);
-  const visibleGroups = NAV_GROUP_ORDER.filter((group) => grouped.has(group));
 
   return (
     <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
@@ -46,39 +42,18 @@ export function MobileNavDrawer({ contextKey }: MobileNavDrawerProps) {
             <SheetTitle>{CONTEXT_TITLES[contextKey]}</SheetTitle>
           </div>
         </SheetHeader>
+        {contexts.length > 1 && (
+          <div className="border-b py-3">
+            <WorkspaceSwitcher layout="drawer" />
+          </div>
+        )}
         <nav className="flex-1 overflow-y-auto py-2">
-          {visibleGroups.map((group) => {
-            const entries = grouped.get(group) ?? [];
-            return (
-              <div key={group} className="mb-4">
-                <p className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  {getNavGroupLabel(group, t)}
-                </p>
-                {entries.map((entry) => {
-                  const Icon = getNavIcon(entry.icon);
-                  return (
-                    <NavLink
-                      key={entry.path}
-                      to={entry.path}
-                      end={entry.path === `/app/${contextKey === 'admin' ? 'admin' : contextKey}`}
-                      onClick={() => setSidebarOpen(false)}
-                      className={({ isActive }) =>
-                        cn(
-                          'flex min-h-11 items-center gap-3 px-4 py-3 text-sm font-medium transition-colors',
-                          isActive
-                            ? 'bg-primary/10 text-primary'
-                            : 'text-foreground hover:bg-accent',
-                        )
-                      }
-                    >
-                      <Icon className="h-4 w-4 shrink-0" />
-                      {getNavLabel(entry, t)}
-                    </NavLink>
-                  );
-                })}
-              </div>
-            );
-          })}
+          <GroupedNavLinks
+            grouped={grouped}
+            allEntries={allEntries}
+            variant="drawer"
+            onNavigate={() => setSidebarOpen(false)}
+          />
         </nav>
       </SheetContent>
     </Sheet>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,60 +1,10 @@
-import { NavLink } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
-import { cn } from '@/lib/utils';
-import { Home } from 'lucide-react';
-import { getVisibleNavEntries } from '@/config/route-manifest';
-import { getNavIcon } from '@/lib/nav-icons';
-import { getNavLabel } from '@/lib/nav-labels';
-import { useWorkspace } from '@/hooks/use-workspace';
+import { ContextSidebar } from './context-sidebar';
 
 export function Sidebar() {
-  const { t } = useTranslation();
-  const { hasPermission } = useWorkspace();
-  const navItems = getVisibleNavEntries('short-rent', hasPermission).map((entry) => ({
-    to: entry.path,
-    label: getNavLabel(entry, t),
-    icon: getNavIcon(entry.icon),
-    end: entry.path === '/app/short-rent',
-  }));
-
   return (
-    <aside className="hidden md:flex h-screen w-64 flex-col border-r bg-card">
-      <div className="flex h-16 items-center border-b px-6">
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <Home className="h-4 w-4" />
-          </div>
-          <div className="flex flex-col leading-none">
-            <span className="text-base font-bold tracking-tight">CASAZEN</span>
-            <span className="text-[10px] text-muted-foreground font-medium tracking-widest uppercase">Property Manager</span>
-          </div>
-        </div>
-      </div>
-      <nav className="flex-1 space-y-0.5 p-3">
-        {navItems.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            end={item.end}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-primary text-primary-foreground shadow-sm'
-                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-              )
-            }
-          >
-            <>
-              <item.icon className="h-4 w-4 shrink-0" />
-              {item.label}
-            </>
-          </NavLink>
-        ))}
-      </nav>
-      <div className="border-t p-3">
-        <p className="text-[10px] text-muted-foreground text-center tracking-wide">v1.0.0 · casazen.io</p>
-      </div>
-    </aside>
+    <ContextSidebar
+      contextKey="short-rent"
+      subtitle="Property Manager"
+    />
   );
 }

--- a/src/components/layout/workspace-switcher.tsx
+++ b/src/components/layout/workspace-switcher.tsx
@@ -2,7 +2,14 @@ import { useCallback, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { useWorkspace } from '@/hooks/use-workspace';
 
-export function WorkspaceSwitcher() {
+type WorkspaceSwitcherLayout = 'sidebar' | 'drawer';
+
+interface WorkspaceSwitcherProps {
+  layout?: WorkspaceSwitcherLayout;
+  className?: string;
+}
+
+export function WorkspaceSwitcher({ layout = 'sidebar', className }: WorkspaceSwitcherProps) {
   const { contexts, activeContext, setActiveContext } = useWorkspace();
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
@@ -32,35 +39,54 @@ export function WorkspaceSwitcher() {
     return null;
   }
 
+  const isDrawer = layout === 'drawer';
+
   return (
-    <div
-      role="tablist"
-      aria-label="Workspace context"
-      className="ml-2 flex rounded-lg border bg-muted p-0.5"
-      onKeyDown={handleKeyDown}
-    >
-      {contexts.map((context, index) => {
-        const isSelected = activeContext === context.contextKey;
-        return (
-          <button
-            key={context.contextKey}
-            ref={(element) => {
-              tabRefs.current[index] = element;
-            }}
-            type="button"
-            role="tab"
-            aria-selected={isSelected}
-            tabIndex={isSelected ? 0 : -1}
-            className={cn(
-              'min-h-11 min-w-11 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
-              isSelected ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
-            )}
-            onClick={() => setActiveContext(context.contextKey)}
-          >
-            {context.displayName}
-          </button>
-        );
-      })}
+    <div className={cn('min-w-0', className)}>
+      <p
+        className={cn(
+          'mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground',
+          isDrawer ? 'px-4' : 'px-2',
+        )}
+      >
+        Workspace
+      </p>
+      <div
+        role="tablist"
+        aria-label="Workspace context"
+        className={cn(
+          'flex gap-0.5 rounded-lg border bg-muted p-0.5',
+          isDrawer ? 'mx-4' : 'mx-2',
+          isDrawer && 'flex-col sm:flex-row',
+        )}
+        onKeyDown={handleKeyDown}
+      >
+        {contexts.map((context, index) => {
+          const isSelected = activeContext === context.contextKey;
+          return (
+            <button
+              key={context.contextKey}
+              ref={(element) => {
+                tabRefs.current[index] = element;
+              }}
+              type="button"
+              role="tab"
+              aria-selected={isSelected}
+              tabIndex={isSelected ? 0 : -1}
+              className={cn(
+                'min-h-10 flex-1 rounded-md px-2 py-1.5 text-xs font-medium transition-colors',
+                'truncate text-center',
+                isSelected
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              onClick={() => setActiveContext(context.contextKey)}
+            >
+              {context.displayName}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -421,6 +421,21 @@ export function getSecondaryNavByGroup(
   return grouped;
 }
 
+/** Desktop sidebar: all visible nav entries grouped (primary + secondary). */
+export function getDesktopNavByGroup(
+  contextKey: AppContextKey,
+  hasPermission?: PermissionPredicate,
+): Map<NavGroup, RouteManifestEntry[]> {
+  const grouped = new Map<NavGroup, RouteManifestEntry[]>();
+  for (const entry of getVisibleNavEntries(contextKey, hasPermission)) {
+    if (!entry.navGroup) continue;
+    const list = grouped.get(entry.navGroup) ?? [];
+    list.push(entry);
+    grouped.set(entry.navGroup, list);
+  }
+  return grouped;
+}
+
 /** Drawer entries: secondary routes, or all visible routes when no secondary (long-rent, admin). */
 export function getDrawerNavByGroup(
   contextKey: AppContextKey,

--- a/src/features/cin/cin-compliance-page.tsx
+++ b/src/features/cin/cin-compliance-page.tsx
@@ -1,3 +1,4 @@
+import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { Card, CardContent } from '@/components/ui/card';
 import { CinComplianceTable } from './components/cin-compliance-table';
@@ -9,31 +10,33 @@ export function CinCompliancePage() {
   const { data, isLoading } = useCinCompliance();
 
   return (
-    <div className="space-y-6" data-testid="cin-compliance-page">
-      <PageHeader
-        title="Conformità CIN"
-        description="Gestione codici identificativi nazionali — D.L. 145/2023"
-      />
+    <AppShell>
+      <div className="space-y-6" data-testid="cin-compliance-page">
+        <PageHeader
+          title="Conformità CIN"
+          description="Gestione codici identificativi nazionali — D.L. 145/2023"
+        />
 
-      {data?.summary && <CinDeadlineBanner summary={data.summary} />}
-      {data?.summary && <CinSummaryCards summary={data.summary} />}
+        {data?.summary && <CinDeadlineBanner summary={data.summary} />}
+        {data?.summary && <CinSummaryCards summary={data.summary} />}
 
-      <Card>
-        <CardContent className="pt-6">
-          <p className="text-sm text-muted-foreground mb-4">
-            Richiedi il CIN sul portale{' '}
-            <a
-              href="https://bdsr.ministeroturismo.it"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary underline"
-            >
-              BDSR — Ministero del Turismo
-            </a>
-          </p>
-          <CinComplianceTable items={data?.items ?? []} isLoading={isLoading} />
-        </CardContent>
-      </Card>
-    </div>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="mb-4 text-sm text-muted-foreground">
+              Richiedi il CIN sul portale{' '}
+              <a
+                href="https://bdsr.ministeroturismo.it"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline"
+              >
+                BDSR — Ministero del Turismo
+              </a>
+            </p>
+            <CinComplianceTable items={data?.items ?? []} isLoading={isLoading} />
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
   );
 }

--- a/src/features/payments/revenue-page.tsx
+++ b/src/features/payments/revenue-page.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { AppShell } from '@/components/layout/app-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -11,6 +13,7 @@ import { useRevenue } from '@/queries/use-payments';
 import { ArrowLeft } from 'lucide-react';
 
 export function RevenuePage() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
@@ -23,27 +26,29 @@ export function RevenuePage() {
   });
 
   return (
-    <div className="space-y-6">
+    <AppShell>
+      <div className="space-y-6">
         <PageHeader
-          title="Revenue Analytics"
-          description="Track and analyze your revenue performance"
+          title={t('revenue.pageTitle', { defaultValue: 'Analisi ricavi' })}
+          description={t('revenue.pageDescription', {
+            defaultValue: 'Monitora e analizza l’andamento dei ricavi',
+          })}
           action={
             <Button variant="outline" onClick={() => navigate('/app/short-rent/payments')}>
               <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Payments
+              {t('revenue.backToPayments', { defaultValue: 'Torna agli incassi' })}
             </Button>
           }
         />
 
-        {/* Filters */}
         <Card>
           <CardHeader>
-            <CardTitle>Filters</CardTitle>
+            <CardTitle>{t('revenue.filters', { defaultValue: 'Filtri' })}</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
               <div className="space-y-2">
-                <Label htmlFor="startDate">Start Date</Label>
+                <Label htmlFor="startDate">{t('revenue.startDate', { defaultValue: 'Data inizio' })}</Label>
                 <Input
                   id="startDate"
                   type="date"
@@ -53,7 +58,7 @@ export function RevenuePage() {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="endDate">End Date</Label>
+                <Label htmlFor="endDate">{t('revenue.endDate', { defaultValue: 'Data fine' })}</Label>
                 <Input
                   id="endDate"
                   type="date"
@@ -63,17 +68,17 @@ export function RevenuePage() {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="groupBy">Group By</Label>
+                <Label htmlFor="groupBy">{t('revenue.groupBy', { defaultValue: 'Raggruppa per' })}</Label>
                 <select
                   id="groupBy"
                   value={groupBy}
-                  onChange={(e) => setGroupBy(e.target.value as any)}
+                  onChange={(e) => setGroupBy(e.target.value as typeof groupBy)}
                   className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
-                  <option value="day">Day</option>
-                  <option value="week">Week</option>
-                  <option value="month">Month</option>
-                  <option value="year">Year</option>
+                  <option value="day">{t('revenue.period.day', { defaultValue: 'Giorno' })}</option>
+                  <option value="week">{t('revenue.period.week', { defaultValue: 'Settimana' })}</option>
+                  <option value="month">{t('revenue.period.month', { defaultValue: 'Mese' })}</option>
+                  <option value="year">{t('revenue.period.year', { defaultValue: 'Anno' })}</option>
                 </select>
               </div>
 
@@ -86,25 +91,27 @@ export function RevenuePage() {
                     setGroupBy('month');
                   }}
                 >
-                  Reset Filters
+                  {t('revenue.resetFilters', { defaultValue: 'Reimposta filtri' })}
                 </Button>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        {/* Dashboard */}
         {isLoading ? (
-          <LoadingScreen message="Loading analytics..." />
+          <LoadingScreen message={t('revenue.loading', { defaultValue: 'Caricamento analisi...' })} />
         ) : analytics ? (
           <RevenueDashboard analytics={analytics} />
         ) : (
           <Card>
             <CardContent className="py-12 text-center">
-              <p className="text-muted-foreground">No revenue data available</p>
+              <p className="text-muted-foreground">
+                {t('revenue.empty', { defaultValue: 'Nessun dato ricavi disponibile' })}
+              </p>
             </CardContent>
           </Card>
         )}
-    </div>
+      </div>
+    </AppShell>
   );
 }

--- a/src/hooks/use-mobile-nav.ts
+++ b/src/hooks/use-mobile-nav.ts
@@ -3,28 +3,14 @@ import { useLocation } from 'react-router-dom';
 import {
   getPrimaryNavEntries,
   getSecondaryNavEntries,
+  getVisibleNavEntries,
   type AppContextKey,
-  type RouteManifestEntry,
 } from '@/config/route-manifest';
+import { isNavEntryActive } from '@/lib/nav-active';
 import { useWorkspace } from '@/hooks/use-workspace';
 import { useUiStore } from '@/store/ui-store';
 
 export type MobileNavTabId = string | 'more';
-
-function isBookingsActive(pathname: string): boolean {
-  return (
-    pathname.startsWith('/app/short-rent/bookings') &&
-    !pathname.startsWith('/app/short-rent/bookings/calendar')
-  );
-}
-
-function isRouteActive(pathname: string, entry: RouteManifestEntry): boolean {
-  const exact = entry.path === '/app/short-rent' || entry.path === '/app/admin';
-  if (exact) {
-    return pathname === entry.path;
-  }
-  return pathname === entry.path || pathname.startsWith(`${entry.path}/`);
-}
 
 export function useMobileNav(contextKey: AppContextKey) {
   const location = useLocation();
@@ -35,6 +21,7 @@ export function useMobileNav(contextKey: AppContextKey) {
   const permissionCheck = (ctx: AppContextKey, permission: string) =>
     hasPermission(ctx, permission);
 
+  const allEntries = getVisibleNavEntries(contextKey, permissionCheck);
   const primaryEntries = getPrimaryNavEntries(contextKey, permissionCheck);
   const secondaryEntries = getSecondaryNavEntries(contextKey, permissionCheck);
   const hasSecondary = secondaryEntries.length > 0;
@@ -46,23 +33,17 @@ export function useMobileNav(contextKey: AppContextKey) {
   const resolveActiveTab = (): MobileNavTabId => {
     const pathname = location.pathname;
 
-    if (contextKey === 'short-rent') {
-      if (pathname === '/app/short-rent') return '/app/short-rent';
-      if (isBookingsActive(pathname)) return '/app/short-rent/bookings';
-      if (pathname.startsWith('/app/short-rent/properties')) return '/app/short-rent/properties';
-
-      const secondaryMatch = secondaryEntries.some((entry) => isRouteActive(pathname, entry));
-      if (secondaryMatch || sidebarOpen) return 'more';
-      return primaryEntries[0]?.path ?? 'more';
+    const activePrimary = primaryEntries.find((entry) =>
+      isNavEntryActive(pathname, entry, allEntries),
+    );
+    if (activePrimary) {
+      return activePrimary.path;
     }
 
-    for (const entry of primaryEntries) {
-      if (isRouteActive(pathname, entry)) {
-        return entry.path;
-      }
-    }
-
-    if (hasSecondary && (sidebarOpen || secondaryEntries.some((e) => isRouteActive(pathname, e)))) {
+    const onSecondary = secondaryEntries.some((entry) =>
+      isNavEntryActive(pathname, entry, allEntries),
+    );
+    if (onSecondary || sidebarOpen) {
       return 'more';
     }
 

--- a/src/lib/__tests__/nav-active.test.ts
+++ b/src/lib/__tests__/nav-active.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import type { RouteManifestEntry } from '@/config/route-manifest';
+import { isNavEntryActive } from '@/lib/nav-active';
+
+const bookings: RouteManifestEntry = {
+  path: '/app/short-rent/bookings',
+  context: 'short-rent',
+  requiredPermissions: ['booking.read'],
+  navKey: 'nav.bookings',
+  component: async () => ({ default: () => null }),
+};
+
+const calendar: RouteManifestEntry = {
+  path: '/app/short-rent/bookings/calendar',
+  context: 'short-rent',
+  requiredPermissions: ['booking.read'],
+  navKey: 'nav.calendar',
+  component: async () => ({ default: () => null }),
+};
+
+const navEntries = [bookings, calendar];
+
+describe('isNavEntryActive', () => {
+  it('activates only calendar on calendar route (not parent bookings)', () => {
+    const pathname = '/app/short-rent/bookings/calendar';
+    expect(isNavEntryActive(pathname, calendar, navEntries)).toBe(true);
+    expect(isNavEntryActive(pathname, bookings, navEntries)).toBe(false);
+  });
+
+  it('activates bookings on bookings list route', () => {
+    const pathname = '/app/short-rent/bookings';
+    expect(isNavEntryActive(pathname, bookings, navEntries)).toBe(true);
+    expect(isNavEntryActive(pathname, calendar, navEntries)).toBe(false);
+  });
+
+  it('activates bookings on booking detail route', () => {
+    const pathname = '/app/short-rent/bookings/abc-123';
+    expect(isNavEntryActive(pathname, bookings, navEntries)).toBe(true);
+    expect(isNavEntryActive(pathname, calendar, navEntries)).toBe(false);
+  });
+});

--- a/src/lib/nav-active.ts
+++ b/src/lib/nav-active.ts
@@ -1,0 +1,38 @@
+import type { RouteManifestEntry } from '@/config/route-manifest';
+
+const EXACT_MATCH_PATHS = new Set([
+  '/app/short-rent',
+  '/app/admin',
+  '/app/long-rent/leases',
+]);
+
+/**
+ * Returns true when `entry` should appear selected for `pathname`.
+ * Prevents parent routes (e.g. Prenotazioni) from staying active when a more
+ * specific sibling nav route matches (e.g. Calendario under /bookings/calendar).
+ */
+export function isNavEntryActive(
+  pathname: string,
+  entry: RouteManifestEntry,
+  navEntries: RouteManifestEntry[],
+): boolean {
+  if (EXACT_MATCH_PATHS.has(entry.path)) {
+    return pathname === entry.path;
+  }
+
+  if (pathname === entry.path) {
+    return true;
+  }
+
+  if (!pathname.startsWith(`${entry.path}/`)) {
+    return false;
+  }
+
+  return !navEntries.some(
+    (other) =>
+      other.path !== entry.path &&
+      other.path.length > entry.path.length &&
+      other.path.startsWith(`${entry.path}/`) &&
+      (pathname === other.path || pathname.startsWith(`${other.path}/`)),
+  );
+}


### PR DESCRIPTION
## Summary
- Grouped desktop sidebars (short-rent, long-rent, admin) share the same IA as the mobile drawer via \ContextSidebar\ + \GroupedNavLinks\
- Workspace switcher removed from header; placed in sidebar (desktop) and drawer (mobile)
- Revenue and CIN pages wrapped in \AppShell\ for consistent chrome
- Fixed Calendario/Prenotazioni active-state bug with \isNavEntryActive\ (React Router v7 has no custom NavLink.isActive)

## Test plan
- [x] \
pm test\ — 133 passed
- [x] \
pm run build\ — OK
- [x] \
pm run test:e2e -- nav-layout-unification\ — 5/5 passed
- [ ] CI green on PR

Closes casazen/backend#259 (frontend-only)

Made with [Cursor](https://cursor.com)