### PR TITLE
fix(admin): CIN compliance pagination and status filter (#184)

### DIFF
--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -15,13 +15,25 @@ export interface CinComplianceQuery {
   cinStatus?: 'valid' | 'missing' | 'invalid';
 }
 
+export interface CinCompliancePagedResult {
+  items: CinComplianceItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
 export const AdminApi = {
   getStats: (): Promise<AdminStats> =>
     ApiClient.get<AdminStats>('/admin/stats'),
 
-  getCinCompliance: (params?: CinComplianceQuery): Promise<CinComplianceItem[]> =>
+  getCinCompliance: (params?: CinComplianceQuery): Promise<CinCompliancePagedResult> =>
     ApiClient.get<BackendPagedResult<CinComplianceItem>>('/admin/cin-compliance', params).then(
-      (res) => res.items ?? [],
+      (res) => ({
+        items: res.items ?? [],
+        totalCount: res.totalCount ?? 0,
+        page: res.page ?? 1,
+        pageSize: res.pageSize ?? 20,
+      }),
     ),
 
   getJobs: (): Promise<JobStatus[]> =>

--- a/src/features/admin/admin-cin-page.tsx
+++ b/src/features/admin/admin-cin-page.tsx
@@ -1,10 +1,25 @@
+import { useState } from 'react';
 import { PageHeader } from '@/components/layout/page-header';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { CinComplianceTable } from './components/cin-compliance-table';
 import { useCinCompliance } from '@/queries/use-admin';
 
+const PAGE_SIZE = 20;
+
+type CinStatusFilter = '' | 'valid' | 'missing' | 'invalid';
+
 export function AdminCinPage() {
-  const { data, isLoading, isError } = useCinCompliance();
+  const [page, setPage] = useState(1);
+  const [cinStatus, setCinStatus] = useState<CinStatusFilter>('');
+
+  const { data, isLoading, isError } = useCinCompliance(
+    page,
+    PAGE_SIZE,
+    cinStatus || undefined,
+  );
+
+  const totalPages = data ? Math.ceil(data.totalCount / PAGE_SIZE) : 1;
 
   return (
     <div className="space-y-6">
@@ -12,6 +27,29 @@ export function AdminCinPage() {
         title="Conformità CIN"
         description="Verifica dei codici identificativi nazionali (D.L. 145/2023)"
       />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Filtri</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <select
+            className="rounded-md border px-3 py-2 text-sm"
+            value={cinStatus}
+            onChange={(e) => {
+              setCinStatus(e.target.value as CinStatusFilter);
+              setPage(1);
+            }}
+            data-testid="cin-status-filter"
+          >
+            <option value="">Tutti gli stati</option>
+            <option value="valid">Valido</option>
+            <option value="missing">Mancante</option>
+            <option value="invalid">Non valido</option>
+          </select>
+        </CardContent>
+      </Card>
+
       <Card>
         <CardContent className="pt-6">
           {isError ? (
@@ -19,7 +57,34 @@ export function AdminCinPage() {
               Impossibile caricare i dati CIN. Riprova più tardi.
             </p>
           ) : (
-            <CinComplianceTable items={data ?? []} isLoading={isLoading} />
+            <>
+              <CinComplianceTable items={data?.items ?? []} isLoading={isLoading} />
+              {data && data.totalCount > PAGE_SIZE && (
+                <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
+                  <span>
+                    Pagina {page} di {totalPages} ({data.totalCount} proprietà)
+                  </span>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page <= 1}
+                      onClick={() => setPage((p) => p - 1)}
+                    >
+                      Precedente
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page >= totalPages}
+                      onClick={() => setPage((p) => p + 1)}
+                    >
+                      Successiva
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </CardContent>
       </Card>

--- a/src/queries/use-admin.ts
+++ b/src/queries/use-admin.ts
@@ -10,10 +10,19 @@ export function useAdminStats() {
   });
 }
 
-export function useCinCompliance() {
+export function useCinCompliance(
+  page = 1,
+  pageSize = 20,
+  cinStatus?: 'valid' | 'missing' | 'invalid',
+) {
   return useQuery({
-    queryKey: [ADMIN_KEY, 'cin-compliance'],
-    queryFn: () => AdminApi.getCinCompliance(),
+    queryKey: [ADMIN_KEY, 'cin-compliance', page, pageSize, cinStatus ?? 'all'],
+    queryFn: () =>
+      AdminApi.getCinCompliance({
+        page,
+        pageSize,
+        ...(cinStatus ? { cinStatus } : {}),
+      }),
   });
 }
 


### PR DESCRIPTION
## Summary
- `AdminApi.getCinCompliance` now forwards `page`, `pageSize`, and `cinStatus` query params and returns full paged result
- `useCinCompliance(page, pageSize, cinStatus?)` hook passes params to the API
- Admin CIN page adds status filter dropdown and pagination when `totalCount > pageSize`

Closes #184.

## Test plan
- [ ] Open Admin → Conformità CIN with >20 properties: pagination controls appear
- [ ] Filter by stato (valid/missing/invalid): table refetches with selected `cinStatus`
- [ ] Network tab shows `/admin/cin-compliance?page=1&pageSize=20&cinStatus=...`
