### PR TITLE
fix(api): sync payments/properties clients with backend (#13 #17 #26)

### DIFF
--- a/src/api/__tests__/payments.api.test.ts
+++ b/src/api/__tests__/payments.api.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { paymentsApi } from '../payments.api';
+import { ApiClient } from '../client';
+import type { Payment, RevenueResponse } from '@/types';
+
+vi.mock('../client');
+vi.mock('@/lib/revenue-analytics', () => ({
+  buildRevenueAnalytics: vi.fn(() => ({
+    totalRevenue: 500,
+    totalBookings: 2,
+    averageBookingValue: 250,
+    data: [],
+  })),
+}));
+
+const paymentId = '22222222-2222-2222-2222-222222222222';
+const propertyId = '11111111-1111-1111-1111-111111111111';
+
+const mockPayment: Payment = {
+  id: paymentId,
+  bookingId: '33333333-3333-3333-3333-333333333333',
+  amount: 120,
+  currency: 'EUR',
+  status: 'Completed',
+  method: 'CreditCard',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('paymentsApi contract sync (#17)', () => {
+  it('process calls POST /payments/:id/process with no body', async () => {
+    vi.mocked(ApiClient.post).mockResolvedValueOnce(mockPayment);
+
+    await paymentsApi.process(paymentId);
+
+    expect(ApiClient.post).toHaveBeenCalledWith(`/payments/${paymentId}/process`);
+  });
+
+  it('refund calls POST /payments/:id/refund with amount query param', async () => {
+    vi.mocked(ApiClient.post).mockResolvedValueOnce(mockPayment);
+
+    await paymentsApi.refund(paymentId, 50);
+
+    expect(ApiClient.post).toHaveBeenCalledWith(`/payments/${paymentId}/refund?amount=50`);
+  });
+
+  it('refund omits query param for full refund', async () => {
+    vi.mocked(ApiClient.post).mockResolvedValueOnce(mockPayment);
+
+    await paymentsApi.refund(paymentId);
+
+    expect(ApiClient.post).toHaveBeenCalledWith(`/payments/${paymentId}/refund`);
+  });
+
+  it('getRevenue calls GET /payments/revenue when property and date range are provided', async () => {
+    const revenueResponse: RevenueResponse = {
+      propertyId,
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+      revenue: 900,
+    };
+    vi.mocked(ApiClient.get).mockResolvedValueOnce(revenueResponse);
+
+    const result = await paymentsApi.getRevenue({
+      propertyId,
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+    });
+
+    expect(ApiClient.get).toHaveBeenCalledWith('/payments/revenue', {
+      propertyId,
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+    });
+    expect(result.totalRevenue).toBe(900);
+    expect(result.data[0]?.revenue).toBe(900);
+  });
+});

--- a/src/api/__tests__/properties.api.test.ts
+++ b/src/api/__tests__/properties.api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { propertiesApi } from '../properties.api';
 import { ApiClient } from '../client';
-import type { PublicPropertyDetailDto, PublicPropertyDto } from '@/types';
+import type { Property, PublicPropertyDetailDto, PublicPropertyDto } from '@/types';
 
 vi.mock('../client');
 
@@ -58,5 +58,16 @@ describe('propertiesApi public read-model (#212)', () => {
     expect(ApiClient.get).toHaveBeenCalledWith(`/properties/${mockListItem.id}/public`);
     expect(result.currency).toBe('EUR');
     expect(result).not.toHaveProperty('ownerId');
+  });
+});
+
+describe('propertiesApi update (#26)', () => {
+  it('uses PUT /properties/:id to match backend PropertiesController', async () => {
+    vi.mocked(ApiClient.put).mockResolvedValueOnce({} as Property);
+
+    await propertiesApi.update(mockListItem.id, { name: 'Updated name' });
+
+    expect(ApiClient.put).toHaveBeenCalledWith(`/properties/${mockListItem.id}`, { name: 'Updated name' });
+    expect(ApiClient.patch).not.toHaveBeenCalled();
   });
 });

--- a/src/api/payments.api.ts
+++ b/src/api/payments.api.ts
@@ -3,12 +3,27 @@ import { buildRevenueAnalytics } from '@/lib/revenue-analytics';
 import type {
   Payment,
   CreatePaymentDto,
-  UpdatePaymentDto,
-  ProcessPaymentDto,
-  RefundPaymentDto,
   RevenueParams,
   RevenueAnalytics,
+  RevenueResponse,
 } from '@/types';
+
+function mapRevenueResponseToAnalytics(response: RevenueResponse): RevenueAnalytics {
+  const period = `${response.startDate} — ${response.endDate}`;
+  return {
+    totalRevenue: response.revenue,
+    totalBookings: 0,
+    averageBookingValue: 0,
+    data: [
+      {
+        period,
+        revenue: response.revenue,
+        bookings: 0,
+        averageBookingValue: 0,
+      },
+    ],
+  };
+}
 
 export const paymentsApi = {
   getAll: (params?: Record<string, any>) =>
@@ -19,18 +34,29 @@ export const paymentsApi = {
   create: (data: CreatePaymentDto) =>
     ApiClient.post<Payment>('/payments', data),
 
-  update: (id: string, data: UpdatePaymentDto) =>
-    ApiClient.put<Payment>(`/payments/${id}`, data),
+  process: (id: string) =>
+    ApiClient.post<Payment>(`/payments/${id}/process`),
 
-  delete: (id: string) => ApiClient.delete<void>(`/payments/${id}`),
-
-  process: (id: string, data: ProcessPaymentDto) =>
-    ApiClient.post<Payment>(`/payments/${id}/process`, data),
-
-  refund: (id: string, data?: RefundPaymentDto) =>
-    ApiClient.post<Payment>(`/payments/${id}/refund`, data),
+  refund: (id: string, amount?: number) => {
+    const url =
+      amount !== undefined
+        ? `/payments/${id}/refund?amount=${encodeURIComponent(String(amount))}`
+        : `/payments/${id}/refund`;
+    return ApiClient.post<Payment>(url);
+  },
 
   getRevenue: async (params?: RevenueParams): Promise<RevenueAnalytics> => {
+    const { propertyId, startDate, endDate } = params ?? {};
+
+    if (propertyId && startDate && endDate) {
+      const response = await ApiClient.get<RevenueResponse>('/payments/revenue', {
+        propertyId,
+        startDate,
+        endDate,
+      });
+      return mapRevenueResponseToAnalytics(response);
+    }
+
     const payments = await ApiClient.get<Payment[]>('/payments');
     return buildRevenueAnalytics(payments ?? [], params);
   },

--- a/src/features/payments/revenue-page.tsx
+++ b/src/features/payments/revenue-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AppShell } from '@/components/layout/app-shell';
@@ -10,19 +10,37 @@ import { Input } from '@/components/ui/input';
 import { RevenueDashboard } from './components/revenue-dashboard';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { useRevenue } from '@/queries/use-payments';
+import { useProperties } from '@/queries/use-properties';
 import { ArrowLeft } from 'lucide-react';
+
+function defaultStartDate(): string {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+}
+
+function defaultEndDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 export function RevenuePage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
+  const { data: properties } = useProperties();
+  const [propertyId, setPropertyId] = useState('');
+  const [startDate, setStartDate] = useState(defaultStartDate);
+  const [endDate, setEndDate] = useState(defaultEndDate);
   const [groupBy, setGroupBy] = useState<'day' | 'week' | 'month' | 'year'>('month');
 
+  const selectedPropertyId = useMemo(() => {
+    if (propertyId) return propertyId;
+    return properties?.[0]?.id ?? '';
+  }, [propertyId, properties]);
+
   const { data: analytics, isLoading } = useRevenue({
-    startDate: startDate || undefined,
-    endDate: endDate || undefined,
-    groupBy,
+    propertyId: selectedPropertyId || undefined,
+    startDate,
+    endDate,
+    groupBy: selectedPropertyId ? undefined : groupBy,
   });
 
   return (
@@ -46,7 +64,27 @@ export function RevenuePage() {
             <CardTitle>{t('revenue.filters', { defaultValue: 'Filtri' })}</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-5">
+              <div className="space-y-2">
+                <Label htmlFor="propertyId">{t('revenue.property', { defaultValue: 'Proprietà' })}</Label>
+                <select
+                  id="propertyId"
+                  value={selectedPropertyId}
+                  onChange={(e) => setPropertyId(e.target.value)}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  {(properties ?? []).length === 0 ? (
+                    <option value="">{t('revenue.noProperties', { defaultValue: 'Nessuna proprietà' })}</option>
+                  ) : (
+                    (properties ?? []).map((property) => (
+                      <option key={property.id} value={property.id}>
+                        {property.name}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
+
               <div className="space-y-2">
                 <Label htmlFor="startDate">{t('revenue.startDate', { defaultValue: 'Data inizio' })}</Label>
                 <Input
@@ -86,8 +124,9 @@ export function RevenuePage() {
                 <Button
                   variant="outline"
                   onClick={() => {
-                    setStartDate('');
-                    setEndDate('');
+                    setPropertyId('');
+                    setStartDate(defaultStartDate());
+                    setEndDate(defaultEndDate());
                     setGroupBy('month');
                   }}
                 >

--- a/src/queries/use-payments.ts
+++ b/src/queries/use-payments.ts
@@ -1,12 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { paymentsApi } from '@/api/payments.api';
-import type {
-  CreatePaymentDto,
-  UpdatePaymentDto,
-  ProcessPaymentDto,
-  RefundPaymentDto,
-  RevenueParams,
-} from '@/types';
+import type { CreatePaymentDto, RevenueParams } from '@/types';
 import { toast } from 'sonner';
 
 const PAYMENTS_KEY = 'payments';
@@ -48,47 +42,14 @@ export function useCreatePayment() {
   });
 }
 
-export function useUpdatePayment() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: UpdatePaymentDto }) =>
-      paymentsApi.update(id, data),
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: [PAYMENTS_KEY] });
-      queryClient.invalidateQueries({ queryKey: [PAYMENTS_KEY, variables.id] });
-      toast.success('Payment updated successfully');
-    },
-    onError: () => {
-      toast.error('Failed to update payment');
-    },
-  });
-}
-
-export function useDeletePayment() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (id: string) => paymentsApi.delete(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [PAYMENTS_KEY] });
-      toast.success('Payment deleted successfully');
-    },
-    onError: () => {
-      toast.error('Failed to delete payment');
-    },
-  });
-}
-
 export function useProcessPayment() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: ProcessPaymentDto }) =>
-      paymentsApi.process(id, data),
-    onSuccess: (_, variables) => {
+    mutationFn: (id: string) => paymentsApi.process(id),
+    onSuccess: (_, id) => {
       queryClient.invalidateQueries({ queryKey: [PAYMENTS_KEY] });
-      queryClient.invalidateQueries({ queryKey: [PAYMENTS_KEY, variables.id] });
+      queryClient.invalidateQueries({ queryKey: [PAYMENTS_KEY, id] });
       toast.success('Payment processed successfully');
     },
     onError: () => {
@@ -101,8 +62,8 @@ export function useRefundPayment() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data?: RefundPaymentDto }) =>
-      paymentsApi.refund(id, data),
+    mutationFn: ({ id, amount }: { id: string; amount?: number }) =>
+      paymentsApi.refund(id, amount),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: [PAYMENTS_KEY] });
       queryClient.invalidateQueries({ queryKey: [PAYMENTS_KEY, variables.id] });

--- a/src/types/payment.types.ts
+++ b/src/types/payment.types.ts
@@ -47,9 +47,12 @@ export interface ProcessPaymentDto {
   saveCard?: boolean;
 }
 
-export interface RefundPaymentDto {
-  amount?: number; // If not provided, full refund
-  reason?: string;
+/** Matches GET /payments/revenue backend response. */
+export interface RevenueResponse {
+  propertyId: string;
+  startDate: string;
+  endDate: string;
+  revenue: number;
 }
 
 export interface RevenueParams {


### PR DESCRIPTION
## Summary
- **#26 / #13 (properties)**: Confirmed `propertiesApi.update` uses `PUT /properties/:id` (matches `PropertiesController`); added regression test.
- **#17 (payments)**: Removed non-existent `update`/`delete` routes; `process` sends no body; `refund` passes `amount` as query param; `getRevenue` calls `GET /payments/revenue` when `propertyId` + date range are provided and maps backend `{ revenue }` response to dashboard analytics.
- **Hooks/UI**: Updated `use-payments` mutations and revenue page property/date filters to supply backend-required revenue params.

## Test plan
- [x] `npm test -- --run src/api` (21 tests passed)
- [ ] Manual: process/refund payment actions return 200 (not 404/405)
- [ ] Manual: revenue page loads totals for selected property + date range

Fixes #13, #17, #26