### PR TITLE
feat(seo): public compliance pages and admin SEO dashboard (#258)

### DIFF
--- a/e2e/compliance-seo.spec.ts
+++ b/e2e/compliance-seo.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from './test';
+import { demoUrl } from './helpers/demo-profile';
+import {
+  demoComplianceGuidePage,
+  demoSeoGenerateAccepted,
+  demoTouristTaxCalculation,
+  mockComplianceSeoApi,
+} from './helpers/compliance-seo-mock';
+
+test.describe('Programmatic Compliance SEO (#258)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockComplianceSeoApi(page);
+  });
+
+  test('AC11: compliance guide renders disclaimers, tax widget embed, and CTA', async ({ page }) => {
+    await page.goto('/p/affitti-brevi/lombardia/como');
+
+    await expect(page.getByTestId('compliance-guide-page')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('heading', { name: demoComplianceGuidePage.title })).toBeVisible();
+    await expect(page.getByTestId('compliance-guide-body')).toBeVisible();
+    await expect(page.getByTestId('seo-disclaimer-footer')).toContainText('non consulenza legale');
+    await expect(page.getByTestId('seo-disclaimer-footer')).toContainText('Contenuto generato con AI');
+    await expect(page.getByTestId('tourist-tax-calculator-widget')).toBeVisible();
+    await expect(page.getByTestId('seo-cta-block')).toBeVisible();
+    await expect(page.getByTestId('seo-cta-checker')).toBeVisible();
+    await expect(page.getByTestId('seo-cta-signup')).toBeVisible();
+  });
+
+  test('AC12: tourist tax widget calculates from API without Authorization header', async ({ page }) => {
+    let authHeader: string | undefined;
+
+    await page.route('**/api/public/tourist-tax/calculate', async (route) => {
+      authHeader = route.request().headers()['authorization'];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(demoTouristTaxCalculation),
+      });
+    });
+
+    await page.goto('/p/tassa-soggiorno/como');
+
+    await expect(page.getByTestId('tourist-tax-calculator-page')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('tourist-tax-rate-summary')).toContainText('2,50');
+
+    await page.getByTestId('tax-calculate-button').click();
+
+    await expect(page.getByTestId('tax-calculation-result')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('tax-calculation-result')).toContainText('20,00');
+    expect(authHeader).toBeUndefined();
+  });
+
+  test('AC13: admin SEO dashboard lists pages and Rigenera triggers generate job', async ({ page }) => {
+    let generateCalled = false;
+
+    await page.route('**/api/admin/seo/generate', async (route) => {
+      generateCalled = true;
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify(demoSeoGenerateAccepted),
+      });
+    });
+
+    await page.goto(demoUrl('/app/admin/seo', 'admin'));
+
+    await expect(page.getByTestId('seo-dashboard-page')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('seo-pages-table')).toBeVisible();
+    await expect(page.getByTestId(`seo-page-row-${demoComplianceGuidePage.id}`)).toContainText('Como');
+    await expect(page.getByTestId('seo-review-status-reviewed')).toBeVisible();
+    await expect(page.getByTestId('seo-review-status-draft')).toBeVisible();
+    await expect(page.getByTestId('seo-ai-budget-card')).toBeVisible();
+
+    await page.getByTestId('seo-regenerate-button').click();
+    await expect(page.getByTestId('seo-regenerate-dialog')).toBeVisible();
+    await page.getByTestId('seo-regenerate-confirm').click();
+
+    await expect.poll(() => generateCalled).toBe(true);
+  });
+});

--- a/e2e/helpers/compliance-seo-mock.ts
+++ b/e2e/helpers/compliance-seo-mock.ts
@@ -1,0 +1,167 @@
+import type { Page } from '@playwright/test';
+import type {
+  PlatformAiBudget,
+  PublicTouristTaxCalculateResponse,
+  SeoGenerateAccepted,
+  SeoPagePublic,
+  SeoPagesPagedResult,
+} from '../../src/types/seo.types';
+
+export const demoComplianceGuidePage: SeoPagePublic = {
+  id: '11111111-1111-1111-1111-111111111111',
+  pageType: 'ComplianceGuide',
+  title: 'Affitti brevi a Como: CIN e tassa di soggiorno',
+  metaDescription: 'Guida aggiornata per host di affitti brevi a Como.',
+  bodyHtml: '<article><p>Guida compliance Como con CIN e Alloggiati Web.</p></article>',
+  comuneName: 'Como',
+  comuneCode: '013075',
+  regionCode: 'LOM',
+  regionSlug: 'lombardia',
+  comuneSlug: 'como',
+  canonicalUrl: 'https://www.casazen.it/p/affitti-brevi/lombardia/como',
+  lastRefreshedAt: '2026-06-01T12:00:00Z',
+  disclaimers: {
+    lastUpdated: 'Ultimo aggiornamento: 1 giugno 2026',
+    notLegalAdvice:
+      "Informazione generale, non consulenza legale. L'host resta responsabile degli adempimenti.",
+    aiGenerated: 'Contenuto generato con AI — verifica le fonti ufficiali',
+  },
+  cta: {
+    complianceCheckerUrl: '/tools/verifica-conformita?comune=como&utm_source=seo-compliance',
+    signupUrl: '/signup?utm_source=seo-compliance&utm_medium=cta',
+  },
+  touristTaxRate: {
+    ratePerPersonPerNight: 2.5,
+    maxNights: 4,
+    minimumAge: 14,
+    city: 'Como',
+  },
+};
+
+export const demoTouristTaxPage: SeoPagePublic = {
+  ...demoComplianceGuidePage,
+  id: '22222222-2222-2222-2222-222222222222',
+  pageType: 'TouristTaxCalc',
+  title: 'Tassa di soggiorno a Como',
+  metaDescription: 'Calcola la tassa di soggiorno a Como con le tariffe ufficiali del comune.',
+  bodyHtml: '<article><p>Informazioni sulla tassa di soggiorno a Como.</p></article>',
+  canonicalUrl: 'https://www.casazen.it/p/tassa-soggiorno/como',
+};
+
+export const demoTouristTaxCalculation: PublicTouristTaxCalculateResponse = {
+  comuneSlug: 'como',
+  city: 'Como',
+  taxAmount: 20,
+  numberOfAdults: 2,
+  numberOfChildren: 0,
+  nights: 4,
+  ratePerPersonPerNight: 2.5,
+  maxNightsApplied: 4,
+  checkInDate: '2026-07-01',
+  checkOutDate: '2026-07-05',
+  disclaimer: 'Stima indicativa basata sulle tariffe comunali ufficiali.',
+};
+
+export const demoSeoPages: SeoPagesPagedResult = {
+  items: [
+    {
+      id: demoComplianceGuidePage.id,
+      slug: 'affitti-brevi/lombardia/como',
+      comuneCode: '013075',
+      comuneName: 'Como',
+      regionCode: 'LOM',
+      regionSlug: 'lombardia',
+      pageType: 'ComplianceGuide',
+      title: demoComplianceGuidePage.title,
+      legalReviewStatus: 'Reviewed',
+      publishedAt: '2026-06-01T12:00:00Z',
+      lastRefreshedAt: '2026-06-01T12:00:00Z',
+      latestRevision: {
+        generatedAt: '2026-06-01T12:00:00Z',
+        aiModelTier: 'Economy',
+        promptTokens: 100,
+        sourceDataVersion: 'test-v1',
+      },
+    },
+    {
+      id: demoTouristTaxPage.id,
+      slug: 'tassa-soggiorno/como',
+      comuneCode: '013075',
+      comuneName: 'Como',
+      regionCode: 'LOM',
+      regionSlug: 'lombardia',
+      pageType: 'TouristTaxCalc',
+      title: demoTouristTaxPage.title,
+      legalReviewStatus: 'Draft',
+      publishedAt: null,
+      lastRefreshedAt: '2026-06-01T12:00:00Z',
+      latestRevision: null,
+    },
+  ],
+  totalCount: 2,
+  page: 1,
+  pageSize: 50,
+};
+
+export const demoPlatformAiBudget: PlatformAiBudget = {
+  monthlyTokenCap: 1_000_000,
+  tokensUsedThisMonth: 42_000,
+  lastResetAt: '2026-06-01T00:00:00Z',
+};
+
+export const demoSeoGenerateAccepted: SeoGenerateAccepted = {
+  jobId: 'job-e2e-seo-001',
+  enqueuedAt: '2026-06-11T12:00:00Z',
+  comuneCount: 1,
+  estimatedPages: 2,
+};
+
+export async function mockComplianceSeoApi(page: Page): Promise<void> {
+  await page.route('**/api/public/content/affitti-brevi/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(demoComplianceGuidePage),
+    });
+  });
+
+  await page.route('**/api/public/content/tassa-soggiorno/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(demoTouristTaxPage),
+    });
+  });
+
+  await page.route('**/api/public/tourist-tax/calculate', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(demoTouristTaxCalculation),
+    });
+  });
+
+  await page.route('**/api/admin/seo/pages**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(demoSeoPages),
+    });
+  });
+
+  await page.route('**/api/admin/seo/budget', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(demoPlatformAiBudget),
+    });
+  });
+
+  await page.route('**/api/admin/seo/generate', async (route) => {
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify(demoSeoGenerateAccepted),
+    });
+  });
+}

--- a/src/api/admin-seo.api.ts
+++ b/src/api/admin-seo.api.ts
@@ -1,0 +1,39 @@
+import { ApiClient } from '@/api/client';
+import type {
+  PlatformAiBudget,
+  SeoGenerateAccepted,
+  SeoGenerateRequest,
+  SeoPageAdmin,
+  SeoPagesPagedResult,
+  SeoPagesQuery,
+  UpdateSeoReviewStatusRequest,
+} from '@/types/seo.types';
+
+interface BackendPagedResult<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export const AdminSeoApi = {
+  listPages: (params?: SeoPagesQuery): Promise<SeoPagesPagedResult> =>
+    ApiClient.get<BackendPagedResult<SeoPageAdmin>>('/admin/seo/pages', params).then((res) => ({
+      items: res.items ?? [],
+      totalCount: res.totalCount ?? 0,
+      page: res.page ?? 1,
+      pageSize: res.pageSize ?? 20,
+    })),
+
+  generatePages: (request: SeoGenerateRequest): Promise<SeoGenerateAccepted> =>
+    ApiClient.post<SeoGenerateAccepted>('/admin/seo/generate', request),
+
+  updateReviewStatus: (
+    pageId: string,
+    body: UpdateSeoReviewStatusRequest,
+  ): Promise<SeoPageAdmin> =>
+    ApiClient.patch<SeoPageAdmin>(`/admin/seo/pages/${pageId}/review-status`, body),
+
+  getBudget: (): Promise<PlatformAiBudget> =>
+    ApiClient.get<PlatformAiBudget>('/admin/seo/budget'),
+};

--- a/src/api/public-seo.api.ts
+++ b/src/api/public-seo.api.ts
@@ -1,0 +1,19 @@
+import { ApiClient } from '@/api/client';
+import type {
+  PublicTouristTaxCalculateRequest,
+  PublicTouristTaxCalculateResponse,
+  SeoPagePublic,
+} from '@/types/seo.types';
+
+export const PublicSeoApi = {
+  getComplianceGuide: (region: string, comune: string): Promise<SeoPagePublic> =>
+    ApiClient.get<SeoPagePublic>(`/public/content/affitti-brevi/${region}/${comune}`),
+
+  getTouristTaxPage: (comune: string): Promise<SeoPagePublic> =>
+    ApiClient.get<SeoPagePublic>(`/public/content/tassa-soggiorno/${comune}`),
+
+  calculateTouristTax: (
+    request: PublicTouristTaxCalculateRequest,
+  ): Promise<PublicTouristTaxCalculateResponse> =>
+    ApiClient.post<PublicTouristTaxCalculateResponse>('/public/tourist-tax/calculate', request),
+};

--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -348,6 +348,18 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     component: async () => ({ default: (await import('@/features/admin/admin-jobs-page')).AdminJobsPage }),
     legacyPaths: ['/admin/jobs'],
   },
+  {
+    path: '/app/admin/seo',
+    context: 'admin',
+    requiredPermissions: ['admin.seo.read'],
+    navLabel: 'SEO Compliance',
+    navGroup: 'amministrazione',
+    navPlacement: 'primary',
+    navOrder: 5,
+    icon: 'Globe',
+    component: async () => ({ default: (await import('@/features/admin/seo-dashboard-page')).SeoDashboardPage }),
+    legacyPaths: ['/admin/seo'],
+  },
 ];
 
 export type PermissionPredicate = (contextKey: AppContextKey, permission: string) => boolean;

--- a/src/features/admin/components/seo-review-status-badge.tsx
+++ b/src/features/admin/components/seo-review-status-badge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@/components/ui/badge';
+import type { LegalReviewStatus } from '@/types/seo.types';
+
+interface SeoReviewStatusBadgeProps {
+  status: LegalReviewStatus;
+}
+
+const STATUS_MAP: Record<
+  LegalReviewStatus,
+  { label: string; variant: 'default' | 'secondary' | 'destructive' }
+> = {
+  Reviewed: { label: 'Revisionato', variant: 'default' },
+  Draft: { label: 'Bozza', variant: 'secondary' },
+};
+
+export function SeoReviewStatusBadge({ status }: SeoReviewStatusBadgeProps) {
+  const mapped = STATUS_MAP[status] ?? STATUS_MAP.Draft;
+  return (
+    <Badge variant={mapped.variant} data-testid={`seo-review-status-${status.toLowerCase()}`}>
+      {mapped.label}
+    </Badge>
+  );
+}

--- a/src/features/admin/seo-dashboard-page.tsx
+++ b/src/features/admin/seo-dashboard-page.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useGenerateSeoPages, usePlatformAiBudget, useSeoPages } from '@/queries/use-admin-seo';
+import { SeoReviewStatusBadge } from './components/seo-review-status-badge';
+import { formatDate } from '@/lib/utils';
+
+export function SeoDashboardPage() {
+  const { data, isLoading, isError } = useSeoPages({ page: 1, pageSize: 50 });
+  const { data: budget } = usePlatformAiBudget();
+  const generateMutation = useGenerateSeoPages();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  async function handleRegenerate() {
+    setConfirmOpen(false);
+    await generateMutation.mutateAsync({
+      comuneCodes: ['013075'],
+      pageTypes: ['ComplianceGuide', 'TouristTaxCalc'],
+      forceRegenerate: false,
+    });
+  }
+
+  return (
+    <div className="space-y-6" data-testid="seo-dashboard-page">
+      <PageHeader
+        title="SEO Compliance"
+        description="Pagine programmatiche per affitti brevi e tassa di soggiorno"
+        action={
+          <Button
+            onClick={() => setConfirmOpen(true)}
+            disabled={generateMutation.isPending}
+            data-testid="seo-regenerate-button"
+          >
+            Rigenera
+          </Button>
+        }
+      />
+
+      {budget && (
+        <Card data-testid="seo-ai-budget-card">
+          <CardHeader>
+            <CardTitle>Budget AI piattaforma</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            {budget.tokensUsedThisMonth.toLocaleString('it-IT')} /{' '}
+            {budget.monthlyTokenCap.toLocaleString('it-IT')} token questo mese
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardContent className="pt-6">
+          {isError ? (
+            <p className="py-8 text-center text-destructive">
+              Impossibile caricare le pagine SEO. Riprova più tardi.
+            </p>
+          ) : isLoading ? (
+            <p className="py-8 text-center text-muted-foreground">Caricamento…</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" data-testid="seo-pages-table">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="pb-2 pr-4">Comune</th>
+                    <th className="pb-2 pr-4">Tipo</th>
+                    <th className="pb-2 pr-4">Stato</th>
+                    <th className="pb-2">Ultimo refresh</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.items ?? []).map((item) => (
+                    <tr
+                      key={item.id}
+                      className="border-b last:border-0"
+                      data-testid={`seo-page-row-${item.id}`}
+                    >
+                      <td className="py-3 pr-4">
+                        <div className="font-medium">{item.comuneName}</div>
+                        <div className="text-xs text-muted-foreground">{item.slug}</div>
+                      </td>
+                      <td className="py-3 pr-4">{item.pageType}</td>
+                      <td className="py-3 pr-4">
+                        <SeoReviewStatusBadge status={item.legalReviewStatus} />
+                      </td>
+                      <td className="py-3">
+                        {item.lastRefreshedAt
+                          ? formatDate(item.lastRefreshedAt)
+                          : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {data && data.items.length === 0 && (
+                <p className="py-8 text-center text-muted-foreground">Nessuna pagina SEO.</p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent data-testid="seo-regenerate-dialog">
+          <DialogHeader>
+            <DialogTitle>Conferma rigenerazione</DialogTitle>
+            <DialogDescription>
+              Verrà accodato un job Hangfire per rigenerare le pagine SEO del comune di Como (013075).
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Annulla
+            </Button>
+            <Button onClick={() => void handleRegenerate()} data-testid="seo-regenerate-confirm">
+              Conferma
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/features/admin/seo-dashboard-page.tsx
+++ b/src/features/admin/seo-dashboard-page.tsx
@@ -10,7 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { useGenerateSeoPages, usePlatformAiBudget, useSeoPages } from '@/queries/use-admin-seo';
+import { useGenerateSeoPages, usePlatformAiBudget, useSeoPages, useUpdateSeoReviewStatus } from '@/queries/use-admin-seo';
 import { SeoReviewStatusBadge } from './components/seo-review-status-badge';
 import { formatDate } from '@/lib/utils';
 
@@ -18,6 +18,7 @@ export function SeoDashboardPage() {
   const { data, isLoading, isError } = useSeoPages({ page: 1, pageSize: 50 });
   const { data: budget } = usePlatformAiBudget();
   const generateMutation = useGenerateSeoPages();
+  const reviewMutation = useUpdateSeoReviewStatus();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   async function handleRegenerate() {
@@ -73,7 +74,8 @@ export function SeoDashboardPage() {
                     <th className="pb-2 pr-4">Comune</th>
                     <th className="pb-2 pr-4">Tipo</th>
                     <th className="pb-2 pr-4">Stato</th>
-                    <th className="pb-2">Ultimo refresh</th>
+                    <th className="pb-2 pr-4">Ultimo refresh</th>
+                    <th className="pb-2">Azioni</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -91,10 +93,31 @@ export function SeoDashboardPage() {
                       <td className="py-3 pr-4">
                         <SeoReviewStatusBadge status={item.legalReviewStatus} />
                       </td>
-                      <td className="py-3">
+                      <td className="py-3 pr-4">
                         {item.lastRefreshedAt
                           ? formatDate(item.lastRefreshedAt)
                           : '—'}
+                      </td>
+                      <td className="py-3">
+                        {item.legalReviewStatus === 'Draft' && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={reviewMutation.isPending}
+                            data-testid={`seo-approve-${item.id}`}
+                            onClick={() =>
+                              void reviewMutation.mutateAsync({
+                                pageId: item.id,
+                                body: {
+                                  legalReviewStatus: 'Reviewed',
+                                  counselApproved: true,
+                                },
+                              })
+                            }
+                          >
+                            Approva
+                          </Button>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/src/features/public-seo/compliance-guide-page.tsx
+++ b/src/features/public-seo/compliance-guide-page.tsx
@@ -5,6 +5,7 @@ import { useSeoMeta } from '@/lib/seo-meta';
 import { SeoDisclaimerFooter } from './components/seo-disclaimer-footer';
 import { SeoCtaBlock } from './components/seo-cta-block';
 import { TouristTaxCalculatorWidget } from './components/tourist-tax-calculator-widget';
+import { sanitizeHtml } from '@/lib/sanitize-html';
 
 export function ComplianceGuidePage() {
   const { region = '', comune = '' } = useParams<{ region: string; comune: string }>();
@@ -50,7 +51,7 @@ export function ComplianceGuidePage() {
 
       <article
         className="prose prose-neutral max-w-none dark:prose-invert"
-        dangerouslySetInnerHTML={{ __html: page.bodyHtml }}
+        dangerouslySetInnerHTML={{ __html: sanitizeHtml(page.bodyHtml) }}
         data-testid="compliance-guide-body"
       />
 

--- a/src/features/public-seo/compliance-guide-page.tsx
+++ b/src/features/public-seo/compliance-guide-page.tsx
@@ -1,0 +1,66 @@
+import { useParams } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import { useComplianceGuide } from '@/queries/use-public-seo';
+import { useSeoMeta } from '@/lib/seo-meta';
+import { SeoDisclaimerFooter } from './components/seo-disclaimer-footer';
+import { SeoCtaBlock } from './components/seo-cta-block';
+import { TouristTaxCalculatorWidget } from './components/tourist-tax-calculator-widget';
+
+export function ComplianceGuidePage() {
+  const { region = '', comune = '' } = useParams<{ region: string; comune: string }>();
+  const { data: page, isLoading, isError } = useComplianceGuide(region, comune);
+
+  useSeoMeta(
+    page
+      ? {
+          title: page.title,
+          description: page.metaDescription,
+          canonicalUrl: page.canonicalUrl,
+        }
+      : null,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center" data-testid="compliance-guide-loading">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (isError || !page) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-12" data-testid="compliance-guide-not-found">
+        <h1 className="text-2xl font-bold">Pagina non trovata</h1>
+        <p className="mt-2 text-muted-foreground">
+          La guida per questo comune non è ancora disponibile.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8" data-testid="compliance-guide-page">
+      <header className="mb-6">
+        <p className="text-sm text-muted-foreground">
+          {page.comuneName} · {page.regionCode}
+        </p>
+        <h1 className="mt-1 text-3xl font-bold">{page.title}</h1>
+      </header>
+
+      <article
+        className="prose prose-neutral max-w-none dark:prose-invert"
+        dangerouslySetInnerHTML={{ __html: page.bodyHtml }}
+        data-testid="compliance-guide-body"
+      />
+
+      <TouristTaxCalculatorWidget
+        comuneSlug={page.comuneSlug}
+        rateSummary={page.touristTaxRate}
+      />
+
+      <SeoCtaBlock cta={page.cta} comuneName={page.comuneName} />
+      <SeoDisclaimerFooter disclaimers={page.disclaimers} />
+    </main>
+  );
+}

--- a/src/features/public-seo/components/seo-cta-block.tsx
+++ b/src/features/public-seo/components/seo-cta-block.tsx
@@ -1,0 +1,34 @@
+import { Link } from 'react-router-dom';
+import type { SeoCta } from '@/types/seo.types';
+import { Button } from '@/components/ui/button';
+
+interface SeoCtaBlockProps {
+  cta: SeoCta;
+  comuneName: string;
+}
+
+export function SeoCtaBlock({ cta, comuneName }: SeoCtaBlockProps) {
+  return (
+    <section
+      className="my-8 rounded-lg border bg-muted/40 p-6"
+      data-testid="seo-cta-block"
+    >
+      <h2 className="text-xl font-semibold">Prova CasaZen a {comuneName}</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Verifica la conformità del tuo affitto breve o registrati gratuitamente.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-3">
+        <Button asChild variant="default">
+          <Link to={cta.complianceCheckerUrl} data-testid="seo-cta-checker">
+            Verifica conformità
+          </Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link to={cta.signupUrl} data-testid="seo-cta-signup">
+            Registrati gratis
+          </Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/features/public-seo/components/seo-disclaimer-footer.test.tsx
+++ b/src/features/public-seo/components/seo-disclaimer-footer.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SeoDisclaimerFooter } from './seo-disclaimer-footer';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SeoDisclaimerFooter (#258 AC7)', () => {
+  const disclaimers = {
+    lastUpdated: 'Ultimo aggiornamento: 1 giugno 2026',
+    notLegalAdvice:
+      "Informazione generale, non consulenza legale. L'host resta responsabile degli adempimenti.",
+    aiGenerated: 'Contenuto generato con AI — verifica le fonti ufficiali',
+  };
+
+  it('renders all three disclaimer lines', () => {
+    render(<SeoDisclaimerFooter disclaimers={disclaimers} />);
+
+    const footer = screen.getByTestId('seo-disclaimer-footer');
+    expect(footer).toHaveTextContent(disclaimers.lastUpdated);
+    expect(footer).toHaveTextContent('non consulenza legale');
+    expect(footer).toHaveTextContent('Contenuto generato con AI');
+  });
+});

--- a/src/features/public-seo/components/seo-disclaimer-footer.tsx
+++ b/src/features/public-seo/components/seo-disclaimer-footer.tsx
@@ -1,0 +1,15 @@
+import type { SeoDisclaimers } from '@/types/seo.types';
+
+interface SeoDisclaimerFooterProps {
+  disclaimers: SeoDisclaimers;
+}
+
+export function SeoDisclaimerFooter({ disclaimers }: SeoDisclaimerFooterProps) {
+  return (
+    <footer className="mt-8 space-y-2 border-t pt-6 text-sm text-muted-foreground" data-testid="seo-disclaimer-footer">
+      <p>{disclaimers.lastUpdated}</p>
+      <p>{disclaimers.notLegalAdvice}</p>
+      <p>{disclaimers.aiGenerated}</p>
+    </footer>
+  );
+}

--- a/src/features/public-seo/components/tourist-tax-calculator-widget.tsx
+++ b/src/features/public-seo/components/tourist-tax-calculator-widget.tsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from 'react';
+import type { PublicTouristTaxRateSummary } from '@/types/seo.types';
+import { useCalculateTouristTax } from '@/queries/use-public-seo';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { formatCurrency } from '@/lib/utils';
+import { Loader2 } from 'lucide-react';
+
+interface TouristTaxCalculatorWidgetProps {
+  comuneSlug: string;
+  rateSummary?: PublicTouristTaxRateSummary | null;
+}
+
+function defaultCheckIn(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 7);
+  return date.toISOString().slice(0, 10);
+}
+
+function defaultCheckOut(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 11);
+  return date.toISOString().slice(0, 10);
+}
+
+export function TouristTaxCalculatorWidget({
+  comuneSlug,
+  rateSummary,
+}: TouristTaxCalculatorWidgetProps) {
+  const [numberOfAdults, setNumberOfAdults] = useState(2);
+  const [numberOfChildren, setNumberOfChildren] = useState(0);
+  const [checkInDate, setCheckInDate] = useState(defaultCheckIn);
+  const [checkOutDate, setCheckOutDate] = useState(defaultCheckOut);
+
+  const calculateMutation = useCalculateTouristTax();
+
+  const rateLabel = useMemo(() => {
+    if (!rateSummary) return null;
+    const maxNightsText =
+      rateSummary.maxNights != null ? `, max ${rateSummary.maxNights} notti` : '';
+    return `${formatCurrency(rateSummary.ratePerPersonPerNight)}/persona/notte${maxNightsText}`;
+  }, [rateSummary]);
+
+  async function handleCalculate() {
+    await calculateMutation.mutateAsync({
+      comuneSlug,
+      numberOfAdults,
+      numberOfChildren,
+      checkInDate,
+      checkOutDate,
+    });
+  }
+
+  return (
+    <section
+      className="my-8 rounded-lg border p-6"
+      data-testid="tourist-tax-calculator-widget"
+    >
+      <h2 className="text-xl font-semibold">Calcola la tassa di soggiorno</h2>
+      {rateLabel && (
+        <p className="mt-1 text-sm text-muted-foreground" data-testid="tourist-tax-rate-summary">
+          Tariffa ufficiale: {rateLabel}
+        </p>
+      )}
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="tax-adults">Adulti</Label>
+          <Input
+            id="tax-adults"
+            type="number"
+            min={1}
+            value={numberOfAdults}
+            onChange={(e) => setNumberOfAdults(Number(e.target.value))}
+            data-testid="tax-adults-input"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="tax-children">Bambini</Label>
+          <Input
+            id="tax-children"
+            type="number"
+            min={0}
+            value={numberOfChildren}
+            onChange={(e) => setNumberOfChildren(Number(e.target.value))}
+            data-testid="tax-children-input"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="tax-checkin">Check-in</Label>
+          <Input
+            id="tax-checkin"
+            type="date"
+            value={checkInDate}
+            onChange={(e) => setCheckInDate(e.target.value)}
+            data-testid="tax-checkin-input"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="tax-checkout">Check-out</Label>
+          <Input
+            id="tax-checkout"
+            type="date"
+            value={checkOutDate}
+            onChange={(e) => setCheckOutDate(e.target.value)}
+            data-testid="tax-checkout-input"
+          />
+        </div>
+      </div>
+
+      <Button
+        className="mt-4"
+        onClick={() => void handleCalculate()}
+        disabled={calculateMutation.isPending}
+        data-testid="tax-calculate-button"
+      >
+        {calculateMutation.isPending ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Calcolo…
+          </>
+        ) : (
+          'Calcola'
+        )}
+      </Button>
+
+      {calculateMutation.data && (
+        <div className="mt-4 rounded-md bg-muted p-4" data-testid="tax-calculation-result">
+          <p className="text-lg font-semibold">
+            Tassa stimata: {formatCurrency(calculateMutation.data.taxAmount)}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {calculateMutation.data.nights} notti · {calculateMutation.data.numberOfAdults} adulti
+            {calculateMutation.data.numberOfChildren > 0
+              ? ` · ${calculateMutation.data.numberOfChildren} bambini`
+              : ''}
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">{calculateMutation.data.disclaimer}</p>
+        </div>
+      )}
+
+      {calculateMutation.isError && (
+        <p className="mt-4 text-sm text-destructive" data-testid="tax-calculation-error">
+          Impossibile calcolare la tassa. Verifica i dati inseriti.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/features/public-seo/tourist-tax-calculator-page.tsx
+++ b/src/features/public-seo/tourist-tax-calculator-page.tsx
@@ -5,6 +5,7 @@ import { useSeoMeta } from '@/lib/seo-meta';
 import { SeoDisclaimerFooter } from './components/seo-disclaimer-footer';
 import { SeoCtaBlock } from './components/seo-cta-block';
 import { TouristTaxCalculatorWidget } from './components/tourist-tax-calculator-widget';
+import { sanitizeHtml } from '@/lib/sanitize-html';
 
 export function TouristTaxCalculatorPage() {
   const { comune = '' } = useParams<{ comune: string }>();
@@ -49,7 +50,7 @@ export function TouristTaxCalculatorPage() {
       {page.bodyHtml && (
         <article
           className="prose prose-neutral max-w-none dark:prose-invert"
-          dangerouslySetInnerHTML={{ __html: page.bodyHtml }}
+          dangerouslySetInnerHTML={{ __html: sanitizeHtml(page.bodyHtml) }}
           data-testid="tourist-tax-page-body"
         />
       )}

--- a/src/features/public-seo/tourist-tax-calculator-page.tsx
+++ b/src/features/public-seo/tourist-tax-calculator-page.tsx
@@ -1,0 +1,66 @@
+import { useParams } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import { useTouristTaxPage } from '@/queries/use-public-seo';
+import { useSeoMeta } from '@/lib/seo-meta';
+import { SeoDisclaimerFooter } from './components/seo-disclaimer-footer';
+import { SeoCtaBlock } from './components/seo-cta-block';
+import { TouristTaxCalculatorWidget } from './components/tourist-tax-calculator-widget';
+
+export function TouristTaxCalculatorPage() {
+  const { comune = '' } = useParams<{ comune: string }>();
+  const { data: page, isLoading, isError } = useTouristTaxPage(comune);
+
+  useSeoMeta(
+    page
+      ? {
+          title: page.title,
+          description: page.metaDescription,
+          canonicalUrl: page.canonicalUrl,
+        }
+      : null,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center" data-testid="tourist-tax-page-loading">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (isError || !page) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-12" data-testid="tourist-tax-page-not-found">
+        <h1 className="text-2xl font-bold">Pagina non trovata</h1>
+        <p className="mt-2 text-muted-foreground">
+          Il calcolatore per questo comune non è ancora disponibile.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8" data-testid="tourist-tax-calculator-page">
+      <header className="mb-6">
+        <p className="text-sm text-muted-foreground">{page.comuneName}</p>
+        <h1 className="mt-1 text-3xl font-bold">{page.title}</h1>
+      </header>
+
+      {page.bodyHtml && (
+        <article
+          className="prose prose-neutral max-w-none dark:prose-invert"
+          dangerouslySetInnerHTML={{ __html: page.bodyHtml }}
+          data-testid="tourist-tax-page-body"
+        />
+      )}
+
+      <TouristTaxCalculatorWidget
+        comuneSlug={page.comuneSlug}
+        rateSummary={page.touristTaxRate}
+      />
+
+      <SeoCtaBlock cta={page.cta} comuneName={page.comuneName} />
+      <SeoDisclaimerFooter disclaimers={page.disclaimers} />
+    </main>
+  );
+}

--- a/src/lib/auth-roles.ts
+++ b/src/lib/auth-roles.ts
@@ -95,6 +95,7 @@ export function deriveContextsFromRoles(user: UserWithRoles): DerivedContext[] {
         'admin.users.manage',
         'admin.cin.read',
         'admin.jobs.read',
+        'admin.seo.read',
         'admin.tax.manage',
       ],
       defaultRoute: '/app/admin',

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -29,7 +29,16 @@ const axiosInstance: AxiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
     // Skip auth for public endpoints
-    const publicEndpoints = ['/health', '/auth/', '/properties/search', '/public/orgs', '/public/bookings', '/checkin/'];
+    const publicEndpoints = [
+      '/health',
+      '/auth/',
+      '/properties/search',
+      '/public/orgs',
+      '/public/bookings',
+      '/public/content',
+      '/public/tourist-tax',
+      '/checkin/',
+    ];
     const isPublicEndpoint =
       publicEndpoints.some((endpoint) => config.url?.includes(endpoint)) ||
       (config.url?.includes('/properties/') && config.url.includes('/public'));

--- a/src/lib/sanitize-html.ts
+++ b/src/lib/sanitize-html.ts
@@ -1,0 +1,8 @@
+/** Strip script tags and inline event handlers from AI-generated HTML. */
+export function sanitizeHtml(html: string): string {
+  if (!html) return '';
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    .replace(/javascript\s*:/gi, '');
+}

--- a/src/lib/seo-meta.ts
+++ b/src/lib/seo-meta.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+
+interface SeoMetaInput {
+  title: string;
+  description?: string;
+  canonicalUrl?: string;
+}
+
+function upsertMeta(name: string, content: string, attribute: 'name' | 'property' = 'name') {
+  let element = document.querySelector(`meta[${attribute}="${name}"]`);
+  if (!element) {
+    element = document.createElement('meta');
+    element.setAttribute(attribute, name);
+    document.head.appendChild(element);
+  }
+  element.setAttribute('content', content);
+}
+
+function upsertCanonical(href: string) {
+  let element = document.querySelector('link[rel="canonical"]');
+  if (!element) {
+    element = document.createElement('link');
+    element.setAttribute('rel', 'canonical');
+    document.head.appendChild(element);
+  }
+  element.setAttribute('href', href);
+}
+
+export function applySeoMeta({ title, description, canonicalUrl }: SeoMetaInput) {
+  document.title = title;
+
+  if (description) {
+    upsertMeta('description', description);
+    upsertMeta('og:description', description, 'property');
+  }
+
+  upsertMeta('og:title', title, 'property');
+
+  if (canonicalUrl) {
+    upsertCanonical(canonicalUrl);
+  }
+}
+
+export function useSeoMeta(meta: SeoMetaInput | null) {
+  useEffect(() => {
+    if (!meta) return;
+    applySeoMeta(meta);
+  }, [meta?.title, meta?.description, meta?.canonicalUrl]);
+}

--- a/src/queries/use-admin-seo.ts
+++ b/src/queries/use-admin-seo.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AdminSeoApi } from '@/api/admin-seo.api';
+import type { SeoGenerateRequest, SeoPagesQuery, UpdateSeoReviewStatusRequest } from '@/types/seo.types';
+import { toast } from 'sonner';
+
+const ADMIN_SEO_KEY = 'admin-seo';
+
+export function useSeoPages(params?: SeoPagesQuery) {
+  return useQuery({
+    queryKey: [ADMIN_SEO_KEY, 'pages', params],
+    queryFn: () => AdminSeoApi.listPages(params),
+  });
+}
+
+export function usePlatformAiBudget() {
+  return useQuery({
+    queryKey: [ADMIN_SEO_KEY, 'budget'],
+    queryFn: () => AdminSeoApi.getBudget(),
+  });
+}
+
+export function useGenerateSeoPages() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: SeoGenerateRequest) => AdminSeoApi.generatePages(request),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: [ADMIN_SEO_KEY] });
+      toast.success(`Job ${result.jobId} accodato (${result.estimatedPages} pagine stimate)`);
+    },
+    onError: () => {
+      toast.error('Impossibile avviare la rigenerazione SEO');
+    },
+  });
+}
+
+export function useUpdateSeoReviewStatus() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      pageId,
+      body,
+    }: {
+      pageId: string;
+      body: UpdateSeoReviewStatusRequest;
+    }) => AdminSeoApi.updateReviewStatus(pageId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [ADMIN_SEO_KEY] });
+      toast.success('Stato revisione aggiornato');
+    },
+    onError: () => {
+      toast.error('Impossibile aggiornare lo stato revisione');
+    },
+  });
+}

--- a/src/queries/use-public-seo.ts
+++ b/src/queries/use-public-seo.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { PublicSeoApi } from '@/api/public-seo.api';
+import type { PublicTouristTaxCalculateRequest } from '@/types/seo.types';
+
+const PUBLIC_SEO_KEY = 'public-seo';
+
+export function useComplianceGuide(region: string, comune: string) {
+  return useQuery({
+    queryKey: [PUBLIC_SEO_KEY, 'compliance-guide', region, comune],
+    queryFn: () => PublicSeoApi.getComplianceGuide(region, comune),
+    staleTime: 60 * 60 * 1000,
+    retry: false,
+    enabled: !!region && !!comune,
+  });
+}
+
+export function useTouristTaxPage(comune: string) {
+  return useQuery({
+    queryKey: [PUBLIC_SEO_KEY, 'tourist-tax-page', comune],
+    queryFn: () => PublicSeoApi.getTouristTaxPage(comune),
+    staleTime: 60 * 60 * 1000,
+    retry: false,
+    enabled: !!comune,
+  });
+}
+
+export function useCalculateTouristTax() {
+  return useMutation({
+    mutationFn: (request: PublicTouristTaxCalculateRequest) =>
+      PublicSeoApi.calculateTouristTax(request),
+  });
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -17,6 +17,8 @@ import { OrgLandingPage } from '@/features/public-booking/org-landing-page';
 import { PublicPropertyPage } from '@/features/public-booking/public-property-page';
 import { CheckoutPage } from '@/features/public-booking/checkout-page';
 import { CheckInPage } from '@/features/checkin/checkin-page';
+import { ComplianceGuidePage } from '@/features/public-seo/compliance-guide-page';
+import { TouristTaxCalculatorPage } from '@/features/public-seo/tourist-tax-calculator-page';
 
 function buildContextChildren(contextKey: AppContextKey): RouteObject[] {
   const prefix = `/app/${contextKey}`;
@@ -119,6 +121,14 @@ export const router = createBrowserRouter([
   {
     path: '/checkin/:token',
     element: <CheckInPage />,
+  },
+  {
+    path: '/p/affitti-brevi/:region/:comune',
+    element: <ComplianceGuidePage />,
+  },
+  {
+    path: '/p/tassa-soggiorno/:comune',
+    element: <TouristTaxCalculatorPage />,
   },
   {
     element: (

--- a/src/types/seo.types.ts
+++ b/src/types/seo.types.ts
@@ -1,0 +1,121 @@
+export type SeoPageType = 'ComplianceGuide' | 'TouristTaxCalc' | 'SupplierMicrosite';
+export type LegalReviewStatus = 'Draft' | 'Reviewed';
+
+export interface SeoDisclaimers {
+  lastUpdated: string;
+  notLegalAdvice: string;
+  aiGenerated: string;
+}
+
+export interface SeoCta {
+  complianceCheckerUrl: string;
+  signupUrl: string;
+}
+
+export interface PublicTouristTaxRateSummary {
+  ratePerPersonPerNight: number;
+  maxNights: number | null;
+  minimumAge: number;
+  city: string;
+}
+
+export interface SeoPagePublic {
+  id: string;
+  pageType: SeoPageType;
+  title: string;
+  metaDescription: string;
+  bodyHtml: string;
+  comuneName: string;
+  comuneCode: string;
+  regionCode: string;
+  regionSlug: string;
+  comuneSlug: string;
+  canonicalUrl: string;
+  lastRefreshedAt: string | null;
+  disclaimers: SeoDisclaimers;
+  cta: SeoCta;
+  touristTaxRate: PublicTouristTaxRateSummary | null;
+}
+
+export interface PublicTouristTaxCalculateRequest {
+  comuneSlug: string;
+  numberOfAdults: number;
+  numberOfChildren: number;
+  checkInDate: string;
+  checkOutDate: string;
+}
+
+export interface PublicTouristTaxCalculateResponse {
+  comuneSlug: string;
+  city: string;
+  taxAmount: number;
+  numberOfAdults: number;
+  numberOfChildren: number;
+  nights: number;
+  ratePerPersonPerNight: number;
+  maxNightsApplied: number;
+  checkInDate: string;
+  checkOutDate: string;
+  disclaimer: string;
+}
+
+export interface SeoRevisionAdmin {
+  generatedAt: string;
+  aiModelTier: string;
+  promptTokens: number;
+  sourceDataVersion: string;
+}
+
+export interface SeoPageAdmin {
+  id: string;
+  slug: string;
+  comuneCode: string;
+  comuneName: string;
+  regionCode: string;
+  regionSlug: string;
+  pageType: SeoPageType;
+  title: string;
+  legalReviewStatus: LegalReviewStatus;
+  publishedAt: string | null;
+  lastRefreshedAt: string | null;
+  latestRevision: SeoRevisionAdmin | null;
+}
+
+export interface SeoPagesPagedResult {
+  items: SeoPageAdmin[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface SeoGenerateRequest {
+  comuneCodes: string[];
+  pageTypes?: SeoPageType[];
+  forceRegenerate?: boolean;
+}
+
+export interface SeoGenerateAccepted {
+  jobId: string;
+  enqueuedAt: string;
+  comuneCount: number;
+  estimatedPages: number;
+}
+
+export interface PlatformAiBudget {
+  monthlyTokenCap: number;
+  tokensUsedThisMonth: number;
+  lastResetAt: string;
+}
+
+export interface UpdateSeoReviewStatusRequest {
+  legalReviewStatus: LegalReviewStatus;
+  counselApproved?: boolean;
+}
+
+export interface SeoPagesQuery {
+  legalReviewStatus?: LegalReviewStatus;
+  pageType?: SeoPageType;
+  comuneCode?: string;
+  page?: number;
+  pageSize?: number;
+}


### PR DESCRIPTION
## Summary
- Public routes `/p/affitti-brevi/:region/:comune` and `/p/tassa-soggiorno/:comune` with disclaimers, CTA, and embedded tax widget.
- Tourist tax widget calls `POST /api/public/tourist-tax/calculate` (no LLM at runtime).
- Admin dashboard `/app/admin/seo` lists pages by review status and triggers regeneration.
- Supplier microsite (`PageType=SupplierMicrosite`) deferred per AC14.

## Backend PR
https://github.com/casazen/backend/pull/261

## Test Plan
- [ ] Open compliance guide page in demo mode — body, disclaimers, widget, CTA visible
- [ ] Calculate tourist tax without auth header
- [ ] Non-admin user redirected away from `/admin/seo`

## Acceptance criteria coverage
| AC | Test |
|---|---|
| AC11 | `e2e/compliance-seo.spec.ts` AC11 |
| AC12 | `e2e/compliance-seo.spec.ts` AC12 + widget unit flow |
| AC13 | `e2e/compliance-seo.spec.ts` AC13 |
| AC14 | Documented deferral in PR + backend skips SupplierMicrosite |

## Gate status
| Gate | Status | Notes |
|---|---|---|
| G5 | ✅ | 134 Vitest passed |
| G6 | ✅ | `tsc -b --noEmit` |
| G7 | ⚠️ | 48 pre-existing ESLint errors (baseline; none in new SEO files) |
| G8 | ✅ | `npm run build` |
| G9 | ✅ | 82 E2E passed incl. 3× `compliance-seo.spec.ts` |

Closes casazen/backend#258