### PR TITLE
release: v1.1.18 — pricing E2E fix (#105)

### DIFF
--- a/e2e/helpers/api-mock.ts
+++ b/e2e/helpers/api-mock.ts
@@ -17,6 +17,32 @@ import {
 const pricingBase = `**/api/pricing-adapter`;
 
 /**
+ * Overrides POST sync with a delayed response so the UI can show the pending spinner.
+ * Call AFTER mockPricingApiDefaults — Playwright evaluates routes LIFO.
+ */
+export async function mockDelayedPricingSync(
+  page: Page,
+  options: { delayMs?: number; onSync?: () => void } = {},
+): Promise<void> {
+  const delayMs = options.delayMs ?? 800;
+
+  await page.route(`${pricingBase}/sync/${PROPERTY_ID}`, async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+
+    options.onSync?.();
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({ jobId: 'job-e2e-sync-001' }),
+    });
+  });
+}
+
+/**
  * Registers the full set of default API mocks needed for the AI pricing flow.
  * Playwright route handlers are evaluated in LIFO order — later registrations
  * take priority, so individual tests can override a specific route by calling

--- a/e2e/pricing-adapter.spec.ts
+++ b/e2e/pricing-adapter.spec.ts
@@ -12,6 +12,7 @@ import {
   mockPricingApiDefaults,
   mockConfigDisabled,
   mockHistoryAfterSync,
+  mockDelayedPricingSync,
 } from './helpers/api-mock';
 import { demoUrl } from './helpers/demo-profile';
 import { mockCurrentUserWithOrg, mockEntitlement, mockPlansCatalog } from './helpers/org-api-mock';
@@ -90,18 +91,10 @@ test.describe('Pricing Adapter verification (AC16–AC20)', () => {
     });
 
     let syncCalled = false;
-    await page.route(`**/api/pricing-adapter/sync/${PROPERTY_ID}`, async (route) => {
-      if (route.request().method() !== 'POST') {
-        await route.fallback();
-        return;
-      }
-      syncCalled = true;
-      await new Promise((resolve) => setTimeout(resolve, 400));
-      await route.fulfill({
-        status: 202,
-        contentType: 'application/json',
-        body: JSON.stringify({ jobId: 'job-e2e-sync-001' }),
-      });
+    await mockDelayedPricingSync(page, {
+      onSync: () => {
+        syncCalled = true;
+      },
     });
 
     await page.goto(demoUrl(PRICING_URL, 'short-stay'));
@@ -109,11 +102,25 @@ test.describe('Pricing Adapter verification (AC16–AC20)', () => {
     const syncBtn = page.getByTestId('sync-btn');
     await expect(syncBtn).toBeVisible();
 
+    const syncResponse = page.waitForResponse(
+      (res) =>
+        res.request().method() === 'POST' &&
+        res.url().includes(`/api/pricing-adapter/sync/${PROPERTY_ID}`),
+      { timeout: 15_000 },
+    );
     await syncBtn.click();
-
-    await expect(syncBtn).toContainText('Syncing...');
+    await expect(syncBtn).toContainText('Syncing...', { timeout: 10_000 });
+    expect((await syncResponse).status()).toBe(202);
     await expect.poll(() => syncCalled).toBe(true);
     await expect(page.getByText('Pricing sync started — history will update shortly')).toBeVisible();
+    await page
+      .waitForResponse(
+        (res) =>
+          res.request().method() === 'GET' &&
+          res.url().includes(`/api/pricing-adapter/history/${PROPERTY_ID}`),
+        { timeout: 10_000 },
+      )
+      .catch(() => undefined);
     const relevantErrors = consoleErrors.filter(
       (msg) =>
         !msg.includes('No response from server') &&


### PR DESCRIPTION
## Summary
- Merges `develop` → `main` for frontend v1.1.18
- Includes pricing-adapter E2E AC18 stabilization (#105, PR #137)
- Prior release v1.1.17 already on main; this adds the e2e fix commit only

## Smoke (pre-promote)
- [x] develop CI e2e green after #137 merge
- [x] Prod API health 200
- [x] Prod FE `casazen-app.vercel.app` serves `#root`

## Test plan
- [ ] Vercel production deploy green
- [ ] `E2E_PROD_SMOKE=1 npm run test:e2e -- prod-deploy-smoke` (post-merge)
