### PR TITLE
fix(admin): nav.seo i18n label for SEO sidebar (#266)

### DIFF
--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -353,7 +353,7 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     path: '/app/admin/seo',
     context: 'admin',
     requiredPermissions: ['admin.seo.read'],
-    navLabel: 'SEO Compliance',
+    navKey: 'nav.seo',
     navGroup: 'amministrazione',
     navPlacement: 'primary',
     navOrder: 5,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -15,6 +15,7 @@
     "leases": "Leases",
     "users": "Users",
     "jobs": "Jobs",
+    "seo": "SEO Compliance",
     "more": "More",
     "group": {
       "operazioni": "Operations",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -15,6 +15,7 @@
     "leases": "Contratti",
     "users": "Utenti",
     "jobs": "Job",
+    "seo": "SEO Compliance",
     "more": "Altro",
     "group": {
       "operazioni": "Operazioni",


### PR DESCRIPTION
## Summary

- `navKey: nav.seo` for admin SEO route (was hardcoded `navLabel`)
- IT/EN i18n strings for sidebar label

Related: casazen/backend#266

## Test plan

- [ ] Admin sidebar shows "SEO Compliance" when `admin.seo.read` permission present
