### PR TITLE
feat(mvp-f0): Golden Journey E2E skeleton steps 1-4 (#301)

### DIFF
--- a/e2e/golden-journey-web.spec.ts
+++ b/e2e/golden-journey-web.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from './test';
+import { demoUrl } from './helpers/demo-profile';
+import { mockPlansCatalog } from './helpers/org-api-mock';
+import {
+  GJ_SLUG,
+  installGoldenJourneyApiMocks,
+} from './helpers/golden-journey-mock';
+
+/**
+ * Golden Journey web harness — Fase 0 skeleton (steps 1–4).
+ * Steps 5–12 are test.fixme until Fase 1 features land (#301).
+ * @see Sessions/specs/spec-golden-journey-e2e.md
+ */
+test.describe('Golden Journey web (#301 / #286)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPlansCatalog(page);
+    await installGoldenJourneyApiMocks(page);
+  });
+
+  test('GJ-1: supplier onboarding entry (admin path stub)', async ({ page }) => {
+    await page.goto(demoUrl('/admin/users', 'short-stay'));
+    // Demo user lacks admin — verify auth gate, no 500
+    await expect(page).not.toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+  });
+
+  test('GJ-2: supplier activation wizard reachable (demo stub)', async ({ page }) => {
+    await page.route('**/api/me/contexts**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          contexts: [{ type: 'supplier', orgId: 'cccccccc-cccc-cccc-cccc-ccccccccccc1', status: 'Pending' }],
+        }),
+      });
+    });
+
+    await page.goto(demoUrl('/app/supplier/onboarding', 'short-stay'));
+    // Page may redirect if route not fully wired — assert no server error surface
+    await expect(page.locator('#root')).toBeVisible();
+    const body = await page.locator('body').innerText();
+    expect(body.toLowerCase()).not.toContain('internal server error');
+  });
+
+  test('GJ-3: host onboarding → short-rent home', async ({ page }) => {
+    await page.goto(demoUrl('/onboarding', 'onboarding'));
+    await expect(page.getByRole('heading', { name: /Come vuoi usare CasaZen/i })).toBeVisible();
+    await page.getByRole('button', { name: 'Scegli' }).first().click();
+    await expect(page.getByTestId('plan-selection-grid')).toBeVisible();
+    await page.getByTestId('onboarding-plan-confirm').click();
+    await expect(page).toHaveURL(/\/app\/short-rent/, { timeout: 15_000 });
+  });
+
+  test('GJ-4: guest public booking page loads without API 500', async ({ page }) => {
+    const api500: string[] = [];
+    page.on('response', (res) => {
+      if (res.url().includes('/api/') && res.status() >= 500) {
+        api500.push(`${res.status()} ${res.url()}`);
+      }
+    });
+
+    await page.goto(demoUrl(`/book/${GJ_SLUG}`, 'short-stay'), { waitUntil: 'networkidle' });
+    await expect(page.locator('#root')).toBeVisible();
+    expect(api500).toEqual([]);
+  });
+
+  test.fixme('GJ-5: calendar shows booking + iCal blocks — Fase 1', async () => {});
+  test.fixme('GJ-6: guest check-in + Alloggiati — Fase 1', async () => {});
+  test.fixme('GJ-7: host service request — Fase 1', async () => {});
+  test.fixme('GJ-8: supplier presa in carico — Fase 1', async () => {});
+  test.fixme('GJ-9: supplier completato — Fase 1', async () => {});
+  test.fixme('GJ-10: host payment — Fase 1', async () => {});
+  test.fixme('GJ-11: checkout wizard — Fase 1', async () => {});
+  test.fixme('GJ-12: cockpit green — Fase 1', async () => {});
+});

--- a/e2e/helpers/golden-journey-mock.ts
+++ b/e2e/helpers/golden-journey-mock.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared mocks for Golden Journey E2E (F0 skeleton — steps 1–4).
+ * Full journey wired in Fase 1 (#301).
+ */
+import type { Page } from '@playwright/test';
+import { mockPropertiesApi } from './properties-api-mock';
+import { buildCreatedProperty } from '../fixtures/properties.fixtures';
+import { mockPublicBookingReadApi } from './public-booking-readmodel-mock';
+
+const GJ_PROPERTY = buildCreatedProperty({
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1',
+  name: 'GJ Villa Test',
+  slug: 'gj-villa-test',
+});
+
+export const GJ_SLUG = GJ_PROPERTY.slug ?? 'gj-villa-test';
+
+export async function installGoldenJourneyApiMocks(page: Page): Promise<void> {
+  const apiErrors: { url: string; status: number }[] = [];
+
+  page.on('response', (res) => {
+    const url = res.url();
+    if (url.includes('/api/') && res.status() >= 500) {
+      apiErrors.push({ url, status: res.status() });
+    }
+  });
+
+  page.on('close', () => {
+    if (apiErrors.length > 0) {
+      console.warn('GJ API 500s detected:', apiErrors);
+    }
+  });
+
+  await mockPropertiesApi(page, [GJ_PROPERTY]);
+  await mockPublicBookingReadApi(page);
+
+  await page.route('**/api/suppliers/**', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'Active', services: ['cleaning'] }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route('**/api/bookings**', async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1',
+          status: 'Confirmed',
+          propertyId: GJ_PROPERTY.id,
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+}
+
+export function assertNoApi500(page: Page): void {
+  page.on('response', (res) => {
+    if (res.url().includes('/api/') && res.status() >= 500) {
+      throw new Error(`GJ step triggered API ${res.status()}: ${res.url()}`);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Golden Journey E2E skeleton: steps 1-4 runnable in demo mode
- Steps 5-12 marked test.fixme for Fase 1 (#301)

## Backend PR
https://github.com/casazen/backend/pull/307

## Test Plan
- [x] npm run test:e2e -- golden-journey-web (4 passed, 8 fixme)
- [x] npm test (176 passed)
- [x] npm run build
- [ ] npm run lint (pre-existing develop errors unrelated to this PR)

## Acceptance criteria coverage
| AC | Test |
|---|---|
| GJ skeleton steps 1-4 | e2e/golden-journey-web.spec.ts |
| No API 500 on step 4 | GJ-4 test |

Closes casazen/backend#286
