### PR TITLE
feat(supplier): supplier console web wave 1 (#291 / #292)

### DIFF
--- a/e2e/golden-journey-web.spec.ts
+++ b/e2e/golden-journey-web.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './test';
-import { demoUrl } from './helpers/demo-profile';
+import { demoUrl, setDemoProfile } from './helpers/demo-profile';
 import { mockPlansCatalog } from './helpers/org-api-mock';
+import { mockSupplierConsoleApi } from './helpers/supplier-console-mock';
 import {
   DEMO_ORG_SLUG,
   mockBrandedBookingApi,
@@ -8,10 +9,9 @@ import {
 } from './helpers/branded-booking-mock';
 
 /**
- * Golden Journey web — Fase 0 batch (#301).
- * Single sequential demo run for steps 1–4; steps 5–12 remain Fase 1.
+ * Golden Journey web — Fase 0 batch (#301) + Fase 1 Wave 1 supplier (#292).
  */
-test.describe('Golden Journey web (#301)', () => {
+test.describe('Golden Journey web (#301 / #292)', () => {
   test.beforeEach(async ({ page }) => {
     await mockPlansCatalog(page);
     await mockBrandedBookingApi(page);
@@ -20,17 +20,42 @@ test.describe('Golden Journey web (#301)', () => {
     });
   });
 
-  test('GJ steps 1–4 sequential (demo mode)', async ({ page }) => {
+  test('GJ steps 1–2: supplier activation (demo mode)', async ({ page }) => {
+    await setDemoProfile(page, 'supplier');
+    await mockSupplierConsoleApi(page);
+
+    await page.goto(demoUrl('/supplier/activation', 'supplier'));
+    await expect(page.getByTestId('supplier-activation-page')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: /Attivazione profilo fornitore/i })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Pulizie' }).click();
+    await page.getByLabel('Codici comune (separati da virgola)').fill('H501');
+    await page.getByLabel('Descrizione').fill('Servizi di pulizia professionali per affitti brevi.');
+    await page.getByLabel(/Accetto i termini di servizio/i).click();
+    await page.getByRole('button', { name: 'Attiva profilo' }).click();
+
+    await expect(page).toHaveURL(/\/supplier\/inbox/, { timeout: 15_000 });
+    await expect(page.getByTestId('supplier-inbox-page')).toBeVisible();
+  });
+
+  test('GJ supplier inbox mobile viewport F1 smoke (#292)', async ({ page }) => {
+    await setDemoProfile(page, 'supplier');
+    await mockSupplierConsoleApi(page, { active: true });
+    await page.setViewportSize({ width: 375, height: 812 });
+
+    await page.goto(demoUrl('/supplier/inbox', 'supplier'));
+    await expect(page.getByTestId('supplier-shell')).toBeVisible();
+    await expect(page.getByTestId('supplier-inbox-page')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Inbox' })).toBeVisible();
+  });
+
+  test('GJ steps 3–4 sequential (demo mode)', async ({ page }) => {
     const api500: string[] = [];
     page.on('response', (res) => {
       if (res.url().includes('/api/') && res.status() >= 500) {
         api500.push(`${res.status()} ${res.url()}`);
       }
     });
-
-    // Step 1–2: supplier path — auth gate (no admin in demo)
-    await page.goto(demoUrl('/admin/users', 'short-stay'));
-    await expect(page).not.toHaveURL(/\/admin\/users/, { timeout: 10_000 });
 
     // Step 3: host onboarding → short-rent
     await page.goto(demoUrl('/onboarding', 'onboarding'));

--- a/e2e/helpers/demo-profile.ts
+++ b/e2e/helpers/demo-profile.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-export type DemoProfile = 'short-stay' | 'long-term' | 'dual' | 'admin' | 'triple' | 'onboarding';
+export type DemoProfile = 'short-stay' | 'long-term' | 'dual' | 'admin' | 'triple' | 'onboarding' | 'supplier';
 
 export function demoUrl(path: string, profile: DemoProfile): string {
   const separator = path.includes('?') ? '&' : '?';

--- a/e2e/helpers/supplier-console-mock.ts
+++ b/e2e/helpers/supplier-console-mock.ts
@@ -1,0 +1,100 @@
+import type { Page } from '@playwright/test';
+
+interface SupplierProfile {
+  orgId: string;
+  status: string;
+  legalName: string;
+  phone: string;
+  email: string;
+  categories: string[];
+  comuni: string[];
+  bio?: string | null;
+  photoUrls: string[];
+  tosAcceptedAt?: string | null;
+}
+
+interface ActivationStatus {
+  status: string;
+  steps: Array<{ id: string; label: string; status: string; blocker?: string | null }>;
+}
+
+const demoSupplierProfile: SupplierProfile = {
+  orgId: '22222222-2222-2222-2222-222222222202',
+  status: 'Pending',
+  legalName: 'Pulizie Demo Srl',
+  phone: '+39 06 1234567',
+  email: 'supplier@demo.casazen.com',
+  categories: [],
+  comuni: [],
+  bio: null,
+  photoUrls: [],
+  tosAcceptedAt: null,
+};
+
+const demoActivationPending: ActivationStatus = {
+  status: 'Pending',
+  steps: [
+    { id: 'identity', label: 'Identità e contatti', status: 'completed' },
+    { id: 'categories', label: 'Categorie di servizio', status: 'pending', blocker: 'Scegli almeno una categoria' },
+    { id: 'comuni', label: 'Comuni di operatività', status: 'pending', blocker: 'Seleziona almeno un comune' },
+    { id: 'profile', label: 'Profilo professionale', status: 'pending', blocker: 'Aggiungi una descrizione professionale' },
+    { id: 'tos', label: 'Termini di servizio', status: 'pending', blocker: 'Accetta i termini di servizio' },
+  ],
+};
+
+const demoActivationActive: ActivationStatus = {
+  status: 'Active',
+  steps: demoActivationPending.steps.map((step) => ({ ...step, status: 'completed', blocker: null })),
+};
+
+export async function mockSupplierConsoleApi(page: Page, options?: { active?: boolean }): Promise<void> {
+  const active = options?.active ?? false;
+  const profile: SupplierProfile = active
+    ? { ...demoSupplierProfile, status: 'Active', categories: ['Pulizie'], comuni: ['H501'], bio: 'Servizi demo', tosAcceptedAt: new Date().toISOString() }
+    : demoSupplierProfile;
+  const activation = active ? demoActivationActive : demoActivationPending;
+
+  await page.route('**/api/supplier/**', async (route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+
+    if (url.includes('/profile/activation') && method === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(activation) });
+      return;
+    }
+
+    if (url.includes('/profile/activation/complete') && method === 'POST') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'Active' }) });
+      return;
+    }
+
+    if (url.includes('/profile') && method === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(profile) });
+      return;
+    }
+
+    if (url.includes('/profile') && method === 'PUT') {
+      const body = route.request().postDataJSON() as Partial<SupplierProfile>;
+      const merged = {
+        ...profile,
+        ...body,
+        categories: body.categories ?? profile.categories,
+        comuni: body.comuni ?? profile.comuni,
+      };
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(merged) });
+      return;
+    }
+
+    if (url.includes('/inbox')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [], total: 0 }) });
+      return;
+    }
+
+    if (url.includes('/availability') && method === 'PUT') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ updated: 1 }) });
+      return;
+    }
+
+    await route.continue();
+  });
+}

--- a/src/config/demo.config.ts
+++ b/src/config/demo.config.ts
@@ -10,7 +10,7 @@
 export const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true';
 
 export type DemoProfile = 'short-stay' | 'long-term' | 'dual' | 'onboarding';
-export type ExtendedDemoProfile = DemoProfile | 'admin' | 'triple';
+export type ExtendedDemoProfile = DemoProfile | 'admin' | 'triple' | 'supplier';
 
 const ROLES_CLAIM = 'https://casazen.app/roles';
 
@@ -32,6 +32,9 @@ const demoProfiles: Record<ExtendedDemoProfile, { roles: string[] }> = {
   },
   triple: {
     roles: ['PropertyOwner', 'LongTermLandlord', 'Admin'],
+  },
+  supplier: {
+    roles: ['Supplier'],
   },
 };
 

--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -326,6 +326,18 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     legacyPaths: ['/admin/users'],
   },
   {
+    path: '/app/admin/suppliers/invite',
+    context: 'admin',
+    requiredPermissions: ['admin.users.manage'],
+    navLabel: 'Invita fornitore',
+    navGroup: 'amministrazione',
+    navPlacement: 'secondary',
+    navOrder: 6,
+    icon: 'UserPlus',
+    component: async () => ({ default: (await import('@/features/admin/admin-supplier-invite-page')).AdminSupplierInvitePage }),
+    legacyPaths: ['/admin/suppliers/invite'],
+  },
+  {
     path: '/app/admin/cin',
     context: 'admin',
     requiredPermissions: ['admin.cin.read'],

--- a/src/features/admin/admin-supplier-invite-page.tsx
+++ b/src/features/admin/admin-supplier-invite-page.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { PageHeader } from '@/components/layout/page-header';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useInviteSupplier } from '@/queries/use-supplier';
+
+export function AdminSupplierInvitePage() {
+  const invite = useInviteSupplier();
+  const [email, setEmail] = useState('');
+  const [comuneCode, setComuneCode] = useState('');
+  const [message, setMessage] = useState('');
+
+  const submit = async () => {
+    try {
+      const result = await invite.mutateAsync({
+        email,
+        comuneCode,
+        categories: ['Pulizie'],
+        message: message || undefined,
+      });
+      toast.success(`Invito inviato — scade ${new Date(result.expiresAt).toLocaleDateString('it-IT')}`);
+      setEmail('');
+      setComuneCode('');
+      setMessage('');
+    } catch {
+      toast.error('Impossibile inviare l\'invito');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Invita fornitore" description="Invia un invito pilota per comune" />
+      <Card>
+        <CardHeader>
+          <CardTitle>Nuovo invito</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="comune">Codice comune</Label>
+            <Input id="comune" value={comuneCode} onChange={(e) => setComuneCode(e.target.value)} placeholder="H501" />
+          </div>
+          <div>
+            <Label htmlFor="message">Messaggio (opzionale)</Label>
+            <Input id="message" value={message} onChange={(e) => setMessage(e.target.value)} />
+          </div>
+          <Button onClick={() => void submit()} disabled={invite.isPending || !email || !comuneCode}>
+            Invia invito
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/supplier/supplier-activation-page.tsx
+++ b/src/features/supplier/supplier-activation-page.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { PageHeader } from '@/components/layout/page-header';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import {
+  useCompleteSupplierActivation,
+  useSupplierActivation,
+  useSupplierProfile,
+  useUpdateSupplierProfile,
+} from '@/queries/use-supplier';
+import type { ActivationStatus, SupplierProfile } from '@/types/supplier';
+
+const CATEGORY_OPTIONS = ['Pulizie', 'Manutenzione', 'Biancheria', 'Giardinaggio'];
+
+interface SupplierActivationFormProps {
+  profile: SupplierProfile;
+  activation: ActivationStatus;
+}
+
+function SupplierActivationForm({ profile, activation }: SupplierActivationFormProps) {
+  const navigate = useNavigate();
+  const updateProfile = useUpdateSupplierProfile();
+  const completeActivation = useCompleteSupplierActivation();
+
+  const [categories, setCategories] = useState<string[]>(profile.categories ?? []);
+  const [comuni, setComuni] = useState((profile.comuni ?? []).join(', '));
+  const [bio, setBio] = useState(profile.bio ?? '');
+  const [tosAccepted, setTosAccepted] = useState(Boolean(profile.tosAcceptedAt));
+
+  const toggleCategory = (category: string) => {
+    setCategories((prev) =>
+      prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category],
+    );
+  };
+
+  const saveProfileFields = async () => {
+    await updateProfile.mutateAsync({
+      categories,
+      comuni: comuni
+        .split(',')
+        .map((c) => c.trim())
+        .filter(Boolean),
+      bio,
+    });
+    toast.success('Progresso salvato');
+  };
+
+  const handleComplete = async () => {
+    try {
+      await saveProfileFields();
+      await completeActivation.mutateAsync(tosAccepted);
+      toast.success('Profilo fornitore attivato');
+      navigate('/supplier/inbox', { replace: true });
+    } catch {
+      toast.error('Completa tutti i passaggi prima di attivare il profilo');
+    }
+  };
+
+  return (
+    <div className="space-y-6" data-testid="supplier-activation-page">
+      <PageHeader
+        title="Attivazione profilo fornitore"
+        description="Completa i 5 passaggi per comparire nel marketplace host"
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Stato attivazione</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {(activation.steps ?? []).map((step) => (
+            <div key={step.id} className="flex items-start justify-between gap-3 rounded-md border p-3">
+              <div>
+                <p className="font-medium">{step.label}</p>
+                {step.blocker ? <p className="text-sm text-muted-foreground">{step.blocker}</p> : null}
+              </div>
+              <span className="text-xs uppercase text-muted-foreground">{step.status}</span>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Categorie di servizio</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          {CATEGORY_OPTIONS.map((category) => (
+            <Button
+              key={category}
+              type="button"
+              variant={categories.includes(category) ? 'default' : 'outline'}
+              onClick={() => toggleCategory(category)}
+            >
+              {category}
+            </Button>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Comuni di operatività</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Label htmlFor="comuni">Codici comune (separati da virgola)</Label>
+          <Input
+            id="comuni"
+            value={comuni}
+            onChange={(e) => setComuni(e.target.value)}
+            placeholder="H501, F205"
+            className="mt-2"
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Profilo professionale</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Label htmlFor="bio">Descrizione</Label>
+          <textarea
+            id="bio"
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            className="mt-2 min-h-24 w-full rounded-md border px-3 py-2 text-sm"
+            placeholder="Descrivi i tuoi servizi..."
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="flex items-start gap-3 pt-6">
+          <Checkbox
+            id="tos"
+            checked={tosAccepted}
+            onCheckedChange={(checked) => setTosAccepted(checked === true)}
+          />
+          <Label htmlFor="tos" className="leading-relaxed">
+            Accetto i termini di servizio fornitore CasaZen
+          </Label>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap gap-3">
+        <Button type="button" variant="outline" onClick={() => void saveProfileFields()} disabled={updateProfile.isPending}>
+          Salva progresso
+        </Button>
+        <Button type="button" onClick={() => void handleComplete()} disabled={completeActivation.isPending}>
+          Attiva profilo
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function SupplierActivationPage() {
+  const { data: activation, isLoading: activationLoading } = useSupplierActivation();
+  const { data: profile, isLoading: profileLoading } = useSupplierProfile();
+
+  if (activationLoading || profileLoading || !profile || !activation) {
+    return <LoadingScreen message="Caricamento attivazione..." />;
+  }
+
+  if (activation.status === 'Active') {
+    return <Navigate to="/supplier/inbox" replace />;
+  }
+
+  return <SupplierActivationForm key={profile.orgId} profile={profile} activation={activation} />;
+}

--- a/src/features/supplier/supplier-availability-page.tsx
+++ b/src/features/supplier/supplier-availability-page.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { PageHeader } from '@/components/layout/page-header';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { useUpdateSupplierAvailability } from '@/queries/use-supplier';
+
+function formatDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function SupplierAvailabilityPage() {
+  const updateAvailability = useUpdateSupplierAvailability();
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+
+  const days = Array.from({ length: 14 }, (_, index) => {
+    const date = new Date();
+    date.setDate(date.getDate() + index);
+    return date;
+  });
+
+  const toggleDay = (key: string) => {
+    setSelected((prev) => ({ ...prev, [key]: !(prev[key] ?? true) }));
+  };
+
+  const save = async () => {
+    const dates = Object.entries(selected).map(([date, available]) => ({ date, available }));
+    if (dates.length === 0) {
+      toast.message('Seleziona almeno un giorno');
+      return;
+    }
+    await updateAvailability.mutateAsync(dates);
+    toast.success('Disponibilità aggiornata');
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Disponibilità" description="Tocca un giorno per segnare indisponibilità" />
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {days.map((day) => {
+          const key = formatDateKey(day);
+          const available = selected[key] ?? true;
+          return (
+            <Card key={key}>
+              <CardContent className="p-3">
+                <button
+                  type="button"
+                  className="w-full text-left"
+                  onClick={() => toggleDay(key)}
+                  data-testid={`availability-${key}`}
+                >
+                  <p className="text-sm font-medium">{day.toLocaleDateString('it-IT', { weekday: 'short', day: 'numeric', month: 'short' })}</p>
+                  <p className="text-xs text-muted-foreground">{available ? 'Disponibile' : 'Non disponibile'}</p>
+                </button>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+      <Button onClick={() => void save()} disabled={updateAvailability.isPending}>
+        Salva disponibilità
+      </Button>
+    </div>
+  );
+}

--- a/src/features/supplier/supplier-inbox-page.tsx
+++ b/src/features/supplier/supplier-inbox-page.tsx
@@ -1,0 +1,22 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent } from '@/components/ui/card';
+import { useSupplierInbox } from '@/queries/use-supplier';
+
+export function SupplierInboxPage() {
+  const { data, isLoading } = useSupplierInbox();
+
+  return (
+    <div className="space-y-6" data-testid="supplier-inbox-page">
+      <PageHeader
+        title="Inbox incarichi"
+        description="Richieste di servizio dai host (disponibile dalla wave 2 marketplace)"
+      />
+
+      <Card>
+        <CardContent className="py-8 text-center text-muted-foreground">
+          {isLoading ? 'Caricamento...' : data?.total === 0 ? 'Nessun incarico aperto' : `${data?.total} incarichi`}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/supplier/supplier-profile-page.tsx
+++ b/src/features/supplier/supplier-profile-page.tsx
@@ -1,0 +1,31 @@
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import { useSupplierProfile } from '@/queries/use-supplier';
+
+export function SupplierProfilePage() {
+  const { data: profile, isLoading } = useSupplierProfile();
+
+  if (isLoading || !profile) {
+    return <LoadingScreen message="Caricamento profilo..." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Profilo fornitore" description="Dati visibili ai host nel picker" />
+      <Card>
+        <CardHeader>
+          <CardTitle>{profile.legalName}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>Stato: {profile.status}</p>
+          <p>Email: {profile.email}</p>
+          <p>Telefono: {profile.phone}</p>
+          <p>Categorie: {(profile.categories ?? []).join(', ') || '—'}</p>
+          <p>Comuni: {(profile.comuni ?? []).join(', ') || '—'}</p>
+          {profile.bio ? <p className="pt-2">{profile.bio}</p> : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/supplier/supplier-shell.tsx
+++ b/src/features/supplier/supplier-shell.tsx
@@ -1,0 +1,42 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+
+const navItems = [
+  { to: '/supplier/inbox', label: 'Inbox' },
+  { to: '/supplier/profile', label: 'Profilo' },
+  { to: '/supplier/availability', label: 'Disponibilità' },
+];
+
+export function SupplierShell() {
+  return (
+    <div className="min-h-screen bg-background" data-testid="supplier-shell">
+      <header className="border-b bg-card px-4 py-3">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">CasaZen</p>
+            <h1 className="text-lg font-semibold">Console fornitore</h1>
+          </div>
+          <nav className="flex flex-wrap gap-2">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  cn(
+                    'rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                    isActive ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted',
+                  )
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl px-4 py-6">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/src/lib/auth-roles.ts
+++ b/src/lib/auth-roles.ts
@@ -3,6 +3,7 @@ export const ROLES_CLAIM = 'https://casazen.app/roles';
 export const ROLE_PROPERTY_OWNER = 'PropertyOwner';
 export const ROLE_LONG_TERM_LANDLORD = 'LongTermLandlord';
 export const ROLE_ADMIN = 'Admin';
+export const ROLE_SUPPLIER = 'Supplier';
 
 export type UserWithRoles = Record<string, unknown> | null | undefined;
 

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -38,6 +38,7 @@ axiosInstance.interceptors.request.use(
       '/public/content',
       '/public/tourist-tax',
       '/checkin/',
+      '/suppliers/register',
     ];
     const isPublicEndpoint =
       publicEndpoints.some((endpoint) => config.url?.includes(endpoint)) ||

--- a/src/queries/use-supplier.ts
+++ b/src/queries/use-supplier.ts
@@ -1,0 +1,64 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  completeSupplierActivation,
+  fetchSupplierActivation,
+  fetchSupplierInbox,
+  fetchSupplierProfile,
+  inviteSupplier,
+  updateSupplierAvailability,
+  updateSupplierProfile,
+} from '@/services/supplier-api';
+import type { UpdateAvailabilityEntry } from '@/types/supplier';
+
+export function useSupplierActivation() {
+  return useQuery({
+    queryKey: ['supplier', 'activation'],
+    queryFn: fetchSupplierActivation,
+  });
+}
+
+export function useSupplierProfile() {
+  return useQuery({
+    queryKey: ['supplier', 'profile'],
+    queryFn: fetchSupplierProfile,
+  });
+}
+
+export function useSupplierInbox(status = 'open', page = 1) {
+  return useQuery({
+    queryKey: ['supplier', 'inbox', status, page],
+    queryFn: () => fetchSupplierInbox(status, page),
+  });
+}
+
+export function useCompleteSupplierActivation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (tosAccepted: boolean) => completeSupplierActivation(tosAccepted),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['supplier'] });
+    },
+  });
+}
+
+export function useUpdateSupplierProfile() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateSupplierProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['supplier'] });
+    },
+  });
+}
+
+export function useUpdateSupplierAvailability() {
+  return useMutation({
+    mutationFn: (dates: UpdateAvailabilityEntry[]) => updateSupplierAvailability(dates),
+  });
+}
+
+export function useInviteSupplier() {
+  return useMutation({
+    mutationFn: inviteSupplier,
+  });
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,6 +20,11 @@ import { GuestBookingsPage } from '@/features/public-booking/guest-bookings-page
 import { CheckInPage } from '@/features/checkin/checkin-page';
 import { ComplianceGuidePage } from '@/features/public-seo/compliance-guide-page';
 import { TouristTaxCalculatorPage } from '@/features/public-seo/tourist-tax-calculator-page';
+import { SupplierShell } from '@/features/supplier/supplier-shell';
+import { SupplierActivationPage } from '@/features/supplier/supplier-activation-page';
+import { SupplierInboxPage } from '@/features/supplier/supplier-inbox-page';
+import { SupplierProfilePage } from '@/features/supplier/supplier-profile-page';
+import { SupplierAvailabilityPage } from '@/features/supplier/supplier-availability-page';
 
 function buildContextChildren(contextKey: AppContextKey): RouteObject[] {
   const prefix = `/app/${contextKey}`;
@@ -131,6 +136,21 @@ export const router = createBrowserRouter([
   {
     path: '/p/tassa-soggiorno/:comune',
     element: <TouristTaxCalculatorPage />,
+  },
+  {
+    path: '/supplier',
+    element: (
+      <ProtectedRoute role="Supplier">
+        <SupplierShell />
+      </ProtectedRoute>
+    ),
+    children: [
+      { index: true, element: <Navigate to="/supplier/inbox" replace /> },
+      { path: 'activation', element: <SupplierActivationPage /> },
+      { path: 'inbox', element: <SupplierInboxPage /> },
+      { path: 'profile', element: <SupplierProfilePage /> },
+      { path: 'availability', element: <SupplierAvailabilityPage /> },
+    ],
   },
   {
     element: (

--- a/src/services/supplier-api.ts
+++ b/src/services/supplier-api.ts
@@ -1,0 +1,57 @@
+import axios from '@/lib/axios';
+import type {
+  ActivationStatus,
+  SupplierInboxResponse,
+  SupplierProfile,
+  UpdateAvailabilityEntry,
+} from '@/types/supplier';
+
+export async function fetchSupplierActivation(): Promise<ActivationStatus> {
+  const { data } = await axios.get<ActivationStatus>('/supplier/profile/activation');
+  return data;
+}
+
+export async function completeSupplierActivation(tosAccepted: boolean): Promise<{ status: string }> {
+  const { data } = await axios.post<{ status: string }>('/supplier/profile/activation/complete', {
+    tosAccepted,
+  });
+  return data;
+}
+
+export async function fetchSupplierProfile(): Promise<SupplierProfile> {
+  const { data } = await axios.get<SupplierProfile>('/supplier/profile');
+  return data;
+}
+
+export async function updateSupplierProfile(
+  payload: Partial<Pick<SupplierProfile, 'legalName' | 'vatNumber' | 'phone' | 'bio'>> & {
+    categories?: string[];
+    comuni?: string[];
+    photoUrls?: string[];
+  },
+): Promise<SupplierProfile> {
+  const { data } = await axios.put<SupplierProfile>('/supplier/profile', payload);
+  return data;
+}
+
+export async function fetchSupplierInbox(status = 'open', page = 1, pageSize = 20): Promise<SupplierInboxResponse> {
+  const { data } = await axios.get<SupplierInboxResponse>('/supplier/inbox', {
+    params: { status, page, pageSize },
+  });
+  return data;
+}
+
+export async function updateSupplierAvailability(dates: UpdateAvailabilityEntry[]): Promise<{ updated: number }> {
+  const { data } = await axios.put<{ updated: number }>('/supplier/availability', { dates });
+  return data;
+}
+
+export async function inviteSupplier(payload: {
+  email: string;
+  comuneCode: string;
+  categories?: string[];
+  message?: string;
+}): Promise<{ inviteId: string; expiresAt: string }> {
+  const { data } = await axios.post<{ inviteId: string; expiresAt: string }>('/admin/suppliers/invite', payload);
+  return data;
+}

--- a/src/types/supplier.ts
+++ b/src/types/supplier.ts
@@ -1,0 +1,35 @@
+export interface SupplierProfile {
+  orgId: string;
+  status: string;
+  legalName: string;
+  vatNumber?: string | null;
+  phone: string;
+  email: string;
+  categories: string[];
+  comuni: string[];
+  bio?: string | null;
+  photoUrls: string[];
+  tosAcceptedAt?: string | null;
+}
+
+export interface ActivationStep {
+  id: string;
+  label: string;
+  status: string;
+  blocker?: string | null;
+}
+
+export interface ActivationStatus {
+  status: string;
+  steps: ActivationStep[];
+}
+
+export interface SupplierInboxResponse {
+  items: unknown[];
+  total: number;
+}
+
+export interface UpdateAvailabilityEntry {
+  date: string;
+  available: boolean;
+}


### PR DESCRIPTION
## Summary

- `/supplier/*` route group with `ProtectedRoute role="Supplier"` and `SupplierShell`
- Activation wizard (5 steps, Italian), inbox/profile/availability pages
- Admin invite page at `/app/admin/suppliers/invite`
- GJ E2E steps 1–2 + mobile F1 inbox smoke with demo mocks

## Backend PR

https://github.com/casazen/backend/pull/312

## Acceptance criteria coverage

| AC | Test |
|---|---|
| AC10 SupplierShell routes | `golden-journey-web.spec.ts` inbox smoke |
| AC11 activation wizard | `GJ steps 1–2: supplier activation` |
| AC12 inbox mobile | `GJ supplier inbox mobile viewport F1 smoke` |
| AC13 availability UI | manual / Wave 2 E2E extension |

## Gate status

| Gate | Status |
|---|---|
| G5 npm test | ✅ 176 passed |
| G6 tsc | ✅ |
| G7 lint | ⚠️ pre-existing repo errors; no new supplier lint errors |
| G8 build | ✅ |
| G9 E2E | ✅ 4 passed (3 fixme) |

## Test plan

- [ ] `npm run test:e2e -- golden-journey-web`
- [ ] Demo: `?demoProfile=supplier` → `/supplier/activation` → complete → inbox
- [ ] Admin: `?demoProfile=admin` → `/app/admin/suppliers/invite`

Closes casazen/backend#292
