### PR TITLE
fix(onboarding): send required legal consents on first signup

### DIFF
--- a/src/api/legal.api.ts
+++ b/src/api/legal.api.ts
@@ -1,0 +1,10 @@
+import { ApiClient } from '@/api/client';
+import type { LegalDocumentMeta, SubprocessorsDocument } from '@/types/onboarding.types';
+
+export const LegalApi = {
+  getTos: (): Promise<LegalDocumentMeta> => ApiClient.get<LegalDocumentMeta>('/legal/tos'),
+  getPrivacy: (): Promise<LegalDocumentMeta> => ApiClient.get<LegalDocumentMeta>('/legal/privacy'),
+  getDpa: (): Promise<LegalDocumentMeta> => ApiClient.get<LegalDocumentMeta>('/legal/dpa'),
+  getSubprocessors: (): Promise<SubprocessorsDocument> =>
+    ApiClient.get<SubprocessorsDocument>('/legal/subprocessors'),
+};

--- a/src/features/onboarding/components/consents-step.tsx
+++ b/src/features/onboarding/components/consents-step.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { LoadingScreen } from '@/components/shared/loading-screen';
+import { useLegalDocuments } from '@/queries/use-legal';
+import type { OnboardingConsentsPayload } from '@/types/onboarding.types';
+
+interface ConsentsStepProps {
+  onBack: () => void;
+  onContinue: (consents: OnboardingConsentsPayload) => void;
+  isLoading?: boolean;
+}
+
+export function ConsentsStep({ onBack, onContinue, isLoading }: ConsentsStepProps) {
+  const { tos, privacy, dpa, subprocessors, isLoading: docsLoading, isError } = useLegalDocuments();
+  const [tosAccepted, setTosAccepted] = useState(false);
+  const [privacyAccepted, setPrivacyAccepted] = useState(false);
+  const [dpaAccepted, setDpaAccepted] = useState(false);
+  const [subprocessorsAcknowledged, setSubprocessorsAcknowledged] = useState(false);
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
+
+  if (docsLoading) {
+    return <LoadingScreen message="Caricamento documenti legali..." />;
+  }
+
+  if (isError || !tos || !privacy || !dpa || !subprocessors) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-muted-foreground">
+          Impossibile caricare i documenti legali. Riprova tra qualche istante.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const allRequired =
+    tosAccepted && privacyAccepted && dpaAccepted && subprocessorsAcknowledged;
+
+  const handleContinue = () => {
+    if (!allRequired) return;
+    onContinue({
+      tosAccepted: true,
+      tosVersion: tos.version,
+      privacyAccepted: true,
+      privacyVersion: privacy.version,
+      dpaAccepted: true,
+      dpaVersion: dpa.version,
+      subprocessorsAcknowledged: true,
+      subprocessorsVersion: subprocessors.version,
+      marketingOptIn: marketingOptIn || undefined,
+    });
+  };
+
+  return (
+    <div className="space-y-6 text-left" data-testid="onboarding-consents-step">
+      <Card>
+        <CardHeader>
+          <CardTitle>Documenti legali</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <ConsentRow
+            id="tos"
+            checked={tosAccepted}
+            onCheckedChange={setTosAccepted}
+            label={`Accetto i ${tos.title} (v${tos.version})`}
+            summary={tos.summary}
+          />
+          <ConsentRow
+            id="privacy"
+            checked={privacyAccepted}
+            onCheckedChange={setPrivacyAccepted}
+            label={`Accetto l'${privacy.title} (v${privacy.version})`}
+            summary={privacy.summary}
+          />
+          <ConsentRow
+            id="dpa"
+            checked={dpaAccepted}
+            onCheckedChange={setDpaAccepted}
+            label={`Accetto il ${dpa.title} (v${dpa.version})`}
+            summary={dpa.summary}
+          />
+          <div className="rounded-md border p-4 space-y-3">
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="subprocessors"
+                checked={subprocessorsAcknowledged}
+                onCheckedChange={(value) => setSubprocessorsAcknowledged(value === true)}
+              />
+              <Label htmlFor="subprocessors" className="leading-relaxed cursor-pointer">
+                Ho preso visione dell&apos;elenco dei responsabili del trattamento (v
+                {subprocessors.version})
+              </Label>
+            </div>
+            <ul className="ml-8 list-disc text-sm text-muted-foreground space-y-1">
+              {subprocessors.items.map((item) => (
+                <li key={item.name}>
+                  {item.name} — {item.purpose} ({item.region})
+                </li>
+              ))}
+            </ul>
+          </div>
+          <ConsentRow
+            id="marketing"
+            checked={marketingOptIn}
+            onCheckedChange={setMarketingOptIn}
+            label="Desidero ricevere aggiornamenti e novità (opzionale)"
+          />
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap justify-center gap-3">
+        <Button type="button" variant="outline" onClick={onBack} disabled={isLoading}>
+          Indietro
+        </Button>
+        <Button
+          type="button"
+          data-testid="onboarding-consents-continue"
+          disabled={!allRequired || isLoading}
+          onClick={handleContinue}
+        >
+          Continua
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ConsentRow({
+  id,
+  checked,
+  onCheckedChange,
+  label,
+  summary,
+}: {
+  id: string;
+  checked: boolean;
+  onCheckedChange: (value: boolean) => void;
+  label: string;
+  summary?: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-md border p-4">
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(value) => onCheckedChange(value === true)}
+      />
+      <div className="space-y-1">
+        <Label htmlFor={id} className="leading-relaxed cursor-pointer">
+          {label}
+        </Label>
+        {summary ? <p className="text-sm text-muted-foreground">{summary}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/features/onboarding/onboarding-page.tsx
+++ b/src/features/onboarding/onboarding-page.tsx
@@ -4,16 +4,20 @@ import { toast } from 'sonner';
 import { useAuth } from '@/hooks/use-auth';
 import { useCompleteOnboarding, useMe } from '@/queries/use-users';
 import type { PlanTier, RentalType } from '@/types';
+import type { OnboardingConsentsPayload } from '@/types/onboarding.types';
 import { getHomeRouteForRentalType, getHomeRouteForUser, needsOrgSetup, canEditOnboarding } from '@/lib/onboarding';
 import { getUserRoles } from '@/lib/auth-roles';
 import { isDemoMode } from '@/config/demo.config';
 import { applyDemoOnboardingProfile } from '@/lib/demo-onboarding';
 import { RentalTypeCard } from './components/rental-type-card';
+import { ConsentsStep } from './components/consents-step';
 import { PlanSelectionGrid } from '@/components/org/plan-selection-grid';
 import { Button } from '@/components/ui/button';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 
 const RENTAL_TYPES: RentalType[] = ['ShortTerm', 'LongTerm', 'Both'];
+
+type WizardStep = 'role' | 'consents' | 'plan';
 
 export function OnboardingPage() {
   const navigate = useNavigate();
@@ -22,13 +26,15 @@ export function OnboardingPage() {
   const { user, refreshAccessToken } = useAuth();
   const { data: profile, isLoading: profileLoading } = useMe();
   const completeOnboarding = useCompleteOnboarding();
-  const [step, setStep] = useState<1 | 2>(1);
+  const [step, setStep] = useState<WizardStep>('role');
   const [selectedType, setSelectedType] = useState<RentalType | null>(null);
   const [selectedPlan, setSelectedPlan] = useState<PlanTier>('Starter');
+  const [consents, setConsents] = useState<OnboardingConsentsPayload | null>(null);
   const [failedType, setFailedType] = useState<RentalType | null>(null);
 
   const hasRoles = getUserRoles(user).length > 0;
   const isOrgBackfill = hasRoles && needsOrgSetup(profile);
+  const needsConsentsStep = !hasRoles && !isEditMode;
 
   useEffect(() => {
     if (profileLoading || !profile) return;
@@ -38,15 +44,13 @@ export function OnboardingPage() {
     }
 
     if (isOrgBackfill && profile.rentalType) {
-      setStep(2);
+      setStep('plan');
     }
 
-    // Edit mode: skip to plan selection if user has rental type (#277)
     if (isEditMode && profile.rentalType) {
-      setStep(2);
+      setStep('plan');
     }
 
-    // Guard: edit mode requires onboardingCompletedAt timestamp + orgId (#277)
     if (isEditMode && !canEditOnboarding(profile)) {
       navigate('/', { replace: true });
       return;
@@ -68,7 +72,18 @@ export function OnboardingPage() {
         return;
       }
 
-      await completeOnboarding.mutateAsync({ rentalType, planTier, isUpdate: hasRoles });
+      if (needsConsentsStep && !consents) {
+        toast.error('Accetta i documenti legali obbligatori prima di continuare.');
+        setStep('consents');
+        return;
+      }
+
+      await completeOnboarding.mutateAsync({
+        rentalType,
+        planTier,
+        isUpdate: hasRoles,
+        consents: needsConsentsStep ? consents ?? undefined : undefined,
+      });
       await refreshAccessToken();
       window.location.assign(getHomeRouteForRentalType(rentalType));
     } catch {
@@ -80,7 +95,7 @@ export function OnboardingPage() {
 
   const handleRentalSelect = (rentalType: RentalType) => {
     setSelectedType(rentalType);
-    setStep(2);
+    setStep(needsConsentsStep ? 'consents' : 'plan');
   };
 
   const handlePlanConfirm = () => {
@@ -92,28 +107,34 @@ export function OnboardingPage() {
     return <LoadingScreen message="Caricamento..." />;
   }
 
+  const heading =
+    step === 'role'
+      ? isEditMode
+        ? 'Modifica tipo di operatore'
+        : 'Come vuoi usare CasaZen?'
+      : step === 'consents'
+        ? 'Accetta i documenti legali'
+        : 'Scegli il tuo piano';
+
+  const subheading =
+    step === 'role'
+      ? 'Scegli il tipo di operatore per personalizzare la tua esperienza.'
+      : step === 'consents'
+        ? 'Per attivare il tuo account sono richiesti ToS, privacy, DPA e l\'elenco subprocessori.'
+        : isOrgBackfill
+          ? 'Configura la tua organizzazione per iniziare a gestire proprietà e prenotazioni.'
+          : 'Seleziona il piano iniziale per la tua organizzazione. Potrai modificarlo in seguito.';
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-muted/40 px-4 py-12">
       <div className="mx-auto max-w-5xl space-y-10 text-center">
         <div className="space-y-3">
           <p className="text-sm font-semibold uppercase tracking-wide text-primary">CasaZen</p>
-          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            {step === 1
-              ? isEditMode
-                ? 'Modifica tipo di operatore'
-                : 'Come vuoi usare CasaZen?'
-              : 'Scegli il tuo piano'}
-          </h1>
-          <p className="text-muted-foreground">
-            {step === 1
-              ? 'Scegli il tipo di operatore per personalizzare la tua esperienza.'
-              : isOrgBackfill
-                ? 'Configura la tua organizzazione per iniziare a gestire proprietà e prenotazioni.'
-                : 'Seleziona il piano iniziale per la tua organizzazione. Potrai modificarlo in seguito.'}
-          </p>
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{heading}</h1>
+          <p className="text-muted-foreground">{subheading}</p>
         </div>
 
-        {step === 1 ? (
+        {step === 'role' ? (
           <div className="grid gap-6 text-left md:grid-cols-3">
             {RENTAL_TYPES.map((rentalType) => (
               <RentalTypeCard
@@ -125,7 +146,20 @@ export function OnboardingPage() {
               />
             ))}
           </div>
-        ) : (
+        ) : null}
+
+        {step === 'consents' ? (
+          <ConsentsStep
+            onBack={() => setStep('role')}
+            onContinue={(payload) => {
+              setConsents(payload);
+              setStep('plan');
+            }}
+            isLoading={completeOnboarding.isPending}
+          />
+        ) : null}
+
+        {step === 'plan' ? (
           <div className="space-y-6">
             <PlanSelectionGrid
               selectedTier={selectedPlan}
@@ -139,7 +173,7 @@ export function OnboardingPage() {
                   type="button"
                   variant="outline"
                   disabled={completeOnboarding.isPending}
-                  onClick={() => setStep(1)}
+                  onClick={() => setStep(needsConsentsStep ? 'consents' : 'role')}
                 >
                   Indietro
                 </Button>
@@ -158,9 +192,9 @@ export function OnboardingPage() {
               </Button>
             </div>
           </div>
-        )}
+        ) : null}
 
-        {failedType && step === 1 && (
+        {failedType && step === 'role' && (
           <button
             type="button"
             className="text-sm font-medium text-primary underline-offset-4 hover:underline"

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -39,6 +39,7 @@ axiosInstance.interceptors.request.use(
       '/public/tourist-tax',
       '/checkin/',
       '/suppliers/register',
+      '/legal/',
     ];
     const isPublicEndpoint =
       publicEndpoints.some((endpoint) => config.url?.includes(endpoint)) ||

--- a/src/queries/use-legal.ts
+++ b/src/queries/use-legal.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { LegalApi } from '@/api/legal.api';
+
+export function useLegalDocuments() {
+  const tos = useQuery({ queryKey: ['legal', 'tos'], queryFn: () => LegalApi.getTos() });
+  const privacy = useQuery({ queryKey: ['legal', 'privacy'], queryFn: () => LegalApi.getPrivacy() });
+  const dpa = useQuery({ queryKey: ['legal', 'dpa'], queryFn: () => LegalApi.getDpa() });
+  const subprocessors = useQuery({
+    queryKey: ['legal', 'subprocessors'],
+    queryFn: () => LegalApi.getSubprocessors(),
+  });
+
+  const isLoading = tos.isLoading || privacy.isLoading || dpa.isLoading || subprocessors.isLoading;
+  const isError = tos.isError || privacy.isError || dpa.isError || subprocessors.isError;
+
+  return {
+    tos: tos.data,
+    privacy: privacy.data,
+    dpa: dpa.data,
+    subprocessors: subprocessors.data,
+    isLoading,
+    isError,
+  };
+}

--- a/src/queries/use-users.ts
+++ b/src/queries/use-users.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { UsersApi } from '@/api/users.api';
 import { OrgsApi } from '@/api/orgs.api';
 import type { RentalType, UpdateProfileRequest, PlanTier } from '@/types';
+import type { OnboardingConsentsPayload } from '@/types/onboarding.types';
 import { toast } from 'sonner';
 
 const USERS_KEY = 'users';
@@ -127,14 +128,16 @@ export function useCompleteOnboarding() {
       rentalType,
       planTier,
       isUpdate,
+      consents,
     }: {
       rentalType: RentalType;
       planTier?: PlanTier;
       isUpdate?: boolean;
+      consents?: OnboardingConsentsPayload;
     }) =>
       isUpdate
         ? UsersApi.putOnboarding({ rentalType, planTier })
-        : UsersApi.postOnboarding({ rentalType, planTier }),
+        : UsersApi.postOnboarding({ rentalType, planTier, consents }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [ME_KEY] });
       queryClient.invalidateQueries({ queryKey: ENTITLEMENT_QUERY_KEY });

--- a/src/types/onboarding.types.ts
+++ b/src/types/onboarding.types.ts
@@ -1,0 +1,32 @@
+export interface LegalDocumentMeta {
+  version: string;
+  effectiveAt: string;
+  title: string;
+  summary: string;
+  documentUrl?: string | null;
+}
+
+export interface SubprocessorItem {
+  name: string;
+  purpose: string;
+  region: string;
+  website?: string | null;
+}
+
+export interface SubprocessorsDocument {
+  version: string;
+  effectiveAt: string;
+  items: SubprocessorItem[];
+}
+
+export interface OnboardingConsentsPayload {
+  tosAccepted: boolean;
+  tosVersion: string;
+  privacyAccepted: boolean;
+  privacyVersion: string;
+  dpaAccepted: boolean;
+  dpaVersion: string;
+  subprocessorsAcknowledged: boolean;
+  subprocessorsVersion: string;
+  marketingOptIn?: boolean;
+}

--- a/src/types/users.types.ts
+++ b/src/types/users.types.ts
@@ -1,5 +1,6 @@
 import type { Org } from './org.types';
 import type { PlanTier } from './org.types';
+import type { OnboardingConsentsPayload } from './onboarding.types';
 
 export type UserRole =
   | 'Admin'
@@ -48,6 +49,7 @@ export interface ChangeRoleRequest {
 export interface OnboardingRequest {
   rentalType: RentalType;
   planTier?: PlanTier;
+  consents?: OnboardingConsentsPayload;
 }
 
 export interface OnboardingResponse {


### PR DESCRIPTION
## Summary

- Fixes 400 on first-time host registration when consents are missing
- Adds wizard step: ToS, Privacy, DPA, subprocessors from GET /api/legal/*
- Sends consents on POST /api/users/onboarding

## Test plan

- [ ] New Auth0 user: role -> consents -> plan -> completes without 400
- [ ] Org backfill / edit mode still uses PUT without consents
