### PR TITLE
fix(i18n): break circular import causing blank page in CI

### DIFF
--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { z } from 'zod';
-import { i18nZodErrorMap } from './zod-error-map';
+import { i18nZodErrorMap, setZodErrorMapI18n } from './zod-error-map';
 import it from './locales/it.json';
 import en from './locales/en.json';
 
@@ -32,6 +32,8 @@ void i18n.use(initReactI18next).init({
   interpolation: { escapeValue: false },
 });
 
+// Break circular dependency: zod-error-map no longer imports i18n directly.
+setZodErrorMapI18n(i18n);
 z.setErrorMap(i18nZodErrorMap);
 
 export default i18n;

--- a/src/i18n/zod-error-map.ts
+++ b/src/i18n/zod-error-map.ts
@@ -1,15 +1,22 @@
 import { z } from 'zod';
-import i18n from './config';
+import type { i18n as I18nInstance } from 'i18next';
 
-/**
- * Custom Zod error map that resolves i18n keys at display time.
- * Schema validation messages use dot-notation keys (e.g. 'property.validation.name.minLength').
- * When the key resolves to something different than the raw string, the translation is used.
- * Otherwise, the raw message is returned as-is (handles non-i18n Zod default messages).
- */
-export const i18nZodErrorMap: z.ZodErrorMap = (issue, ctx) => {
+let _i18n: I18nInstance | null = null;
+
+export function setZodErrorMapI18n(i18n: I18nInstance): void {
+  _i18n = i18n;
+}
+
+function resolveI18nMessage(message: string): string {
+  if (!_i18n) return message;
+  const resolved = _i18n.t(message);
+  return resolved !== message ? resolved : message;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const i18nZodErrorMap: z.ZodErrorMap = (issue: any, ctx: any) => {
   if (issue.message) {
-    const resolved = i18n.t(issue.message);
+    const resolved = resolveI18nMessage(issue.message);
     if (resolved !== issue.message) {
       return { message: resolved };
     }


### PR DESCRIPTION
Breaks the circular dependency between config.ts and zod-error-map.ts that caused a blank page (React doesn't mount at all).