### PR TITLE
feat: add iCal help tooltip and internal doc page for supplier section

### DIFF
--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -459,6 +459,12 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     component: async () => ({ default: (await import('@/features/supplier/supplier-calendar-sync-page')).SupplierCalendarSyncPage }),
   },
   {
+    path: '/app/supplier/help/ical',
+    context: 'supplier',
+    requiredPermissions: [],
+    component: async () => ({ default: (await import('@/features/supplier/ical-help-page')).IcalHelpPage }),
+  },
+  {
     path: '/app/supplier/profile',
     context: 'supplier',
     requiredPermissions: [],

--- a/src/features/supplier/components/ical-help-tooltip.tsx
+++ b/src/features/supplier/components/ical-help-tooltip.tsx
@@ -1,0 +1,75 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { HelpCircle, ArrowRight, X } from 'lucide-react';
+
+export function IcalHelpTooltip() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      setOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [open, handleClickOutside]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative inline-flex items-center">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="inline-flex items-center justify-center rounded-full p-0.5 text-muted-foreground hover:text-primary hover:bg-primary/10 transition-colors"
+        aria-label={t('supplier.help.icalTooltipLabel')}
+      >
+        <HelpCircle className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 w-72 rounded-lg border bg-white p-4 shadow-lg">
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="absolute top-2 right-2 rounded-sm p-0.5 text-muted-foreground hover:text-foreground"
+            aria-label="Chiudi"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+
+          <p className="pr-5 text-sm text-muted-foreground">
+            {t('supplier.help.icalTooltipText')}
+          </p>
+
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              navigate('/app/supplier/help/ical');
+            }}
+            className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+          >
+            {t('supplier.help.icalTooltipCta')}
+            <ArrowRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/supplier/ical-help-page.tsx
+++ b/src/features/supplier/ical-help-page.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { PageHeader } from '@/components/layout/page-header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, Globe, Building2, CalendarDays, Apple, Mail } from 'lucide-react';
+
+interface PlatformGuide {
+  icon: React.ComponentType<{ className?: string }>;
+  titleKey: string;
+  stepsKey: string;
+}
+
+const PLATFORM_GUIDES: PlatformGuide[] = [
+  { icon: Building2, titleKey: 'supplier.help.airbnbTitle', stepsKey: 'supplier.help.airbnbSteps' },
+  { icon: Globe, titleKey: 'supplier.help.bookingTitle', stepsKey: 'supplier.help.bookingSteps' },
+  { icon: Building2, titleKey: 'supplier.help.vrboTitle', stepsKey: 'supplier.help.vrboSteps' },
+  { icon: CalendarDays, titleKey: 'supplier.help.googleCalendarTitle', stepsKey: 'supplier.help.googleCalendarSteps' },
+  { icon: Apple, titleKey: 'supplier.help.appleCalendarTitle', stepsKey: 'supplier.help.appleCalendarSteps' },
+  { icon: Mail, titleKey: 'supplier.help.outlookTitle', stepsKey: 'supplier.help.outlookSteps' },
+];
+
+export function IcalHelpPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  return (
+    <div className="max-w-3xl mx-auto" data-testid="ical-help-page">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="mb-4 -ml-2 text-muted-foreground"
+        onClick={() => navigate('/app/supplier/calendar')}
+      >
+        <ArrowLeft className="mr-1.5 h-4 w-4" />
+        {t('supplier.help.backToSync')}
+      </Button>
+
+      <PageHeader
+        title={t('supplier.help.icalPageTitle')}
+        description={t('supplier.help.icalPageDescription')}
+      />
+
+      <p className="mt-4 mb-6 text-sm text-muted-foreground">
+        {t('supplier.help.icalIntro')}
+      </p>
+
+      <div className="space-y-4">
+        {PLATFORM_GUIDES.map((guide) => {
+          const Icon = guide.icon;
+          return (
+            <Card key={guide.titleKey}>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Icon className="h-5 w-5 text-primary" />
+                  {t(guide.titleKey)}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ol className="list-decimal space-y-1.5 pl-5 text-sm text-muted-foreground">
+                  {(t(guide.stepsKey, { returnObjects: true }) as string[]).map((step, i) => (
+                    <li key={i}>{step}</li>
+                  ))}
+                </ol>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      <Card className="mt-6 border-blue-200 bg-blue-50">
+        <CardContent className="py-4">
+          <p className="text-sm text-blue-800">{t('supplier.help.syncFrequencyNote')}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/supplier/supplier-activation-page.tsx
+++ b/src/features/supplier/supplier-activation-page.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/queries/use-supplier';
 import type { SupplierProfile } from '@/types/supplier';
 import { Calendar, Smartphone, CheckCircle2, ArrowRight, Link2, Loader2 } from 'lucide-react';
+import { IcalHelpTooltip } from './components/ical-help-tooltip';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 
 const CATEGORY_OPTIONS = ['Pulizie', 'Manutenzione', 'Giardinaggio', 'Eventi', 'Noleggio', 'Escursioni'];
@@ -218,6 +219,10 @@ function Step2Calendar({ profile }: { profile: SupplierProfile }) {
             <DialogDescription>{t('supplier.icalFeedUrlDescription')}</DialogDescription>
           </DialogHeader>
           <div className="space-y-4 mt-2">
+            <div className="flex items-center gap-1.5">
+              <Label className="text-sm font-medium">{t('supplier.icalFeedUrlLabel')}</Label>
+              <IcalHelpTooltip />
+            </div>
             <Input
               value={icalUrl}
               onChange={(e) => setIcalUrl(e.target.value)}

--- a/src/features/supplier/supplier-calendar-sync-page.tsx
+++ b/src/features/supplier/supplier-calendar-sync-page.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { useCalendarSyncStatus, useSetIcalFeed } from '@/queries/use-supplier';
 import { Calendar, Link2, Smartphone, CheckCircle2, AlertTriangle, Loader2 } from 'lucide-react';
+import { IcalHelpTooltip } from './components/ical-help-tooltip';
 
 export function SupplierCalendarSyncPage() {
   const { t } = useTranslation();
@@ -131,7 +132,10 @@ export function SupplierCalendarSyncPage() {
 
           <div className="space-y-4 mt-2">
             <div>
-              <Label htmlFor="ical-url">{t('supplier.icalFeedUrlLabel')}</Label>
+              <div className="flex items-center gap-1.5">
+                <Label htmlFor="ical-url">{t('supplier.icalFeedUrlLabel')}</Label>
+                <IcalHelpTooltip />
+              </div>
               <Input
                 id="ical-url"
                 className="mt-2"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1232,7 +1232,66 @@
     "maxPhotosError": "Maximum {{max}} photos allowed",
     "photoCount": "{{current}}/{{max}} photos",
     "photoGallery": "Photo gallery",
-    "noPhotos": "No photos uploaded"
+    "noPhotos": "No photos uploaded",
+    "help": {
+      "icalPageTitle": "How to connect your calendar via iCal",
+      "icalPageDescription": "Step-by-step instructions to export the iCal URL from the most popular platforms. Copy the link and paste it in the calendar sync page.",
+      "icalIntro": "Each platform calls it differently: \"Export calendar\", \"Sync calendars\", \"Secret iCal address\". Find yours below and paste the URL in the connection dialog.",
+      "icalTooltipText": "Don't know where to find your iCal link? See how to export it from Airbnb, Booking, Google Calendar and other platforms.",
+      "icalTooltipCta": "See how to do it",
+      "icalTooltipLabel": "iCal help",
+      "backToSync": "Back to calendar sync",
+      "airbnbTitle": "Airbnb",
+      "airbnbSteps": [
+        "Go to Menu → Listings and select your listing",
+        "Click Availability → Calendar sync",
+        "Click Export calendar",
+        "Copy the URL under \"Calendar URL (iCal)\"",
+        "Paste it in the CasaZen iCal dialog"
+      ],
+      "bookingTitle": "Booking.com",
+      "bookingSteps": [
+        "Log in to the Extranet",
+        "Go to Rates & Availability → Calendar",
+        "Click Export",
+        "Copy the iCal URL shown in the popup",
+        "Paste it in the CasaZen iCal dialog"
+      ],
+      "vrboTitle": "VRBO",
+      "vrboSteps": [
+        "Go to Dashboard → select your property",
+        "Click Calendar → Import/Export",
+        "Click Export → copy the iCal URL",
+        "Paste it in the CasaZen iCal dialog"
+      ],
+      "googleCalendarTitle": "Google Calendar",
+      "googleCalendarSteps": [
+        "On a computer: open Google Calendar",
+        "Click the gear icon → Settings",
+        "On the left, click the calendar name",
+        "Scroll to \"Integrate calendar\"",
+        "Copy the \"Secret iCal address\" URL",
+        "Paste it in the CasaZen iCal dialog"
+      ],
+      "appleCalendarTitle": "Apple Calendar",
+      "appleCalendarSteps": [
+        "Open Calendar on your Mac",
+        "Right-click a calendar in the sidebar",
+        "Click Share → Public Calendar",
+        "Copy the link shown",
+        "Paste it in the CasaZen iCal dialog"
+      ],
+      "outlookTitle": "Outlook",
+      "outlookSteps": [
+        "Open Outlook on the web (outlook.office.com)",
+        "Go to Calendar → Settings (gear icon)",
+        "Click Shared calendars → Publish calendar",
+        "Select the calendar and permission level",
+        "Copy the ICS URL",
+        "Paste it in the CasaZen iCal dialog"
+      ],
+      "syncFrequencyNote": "CasaZen syncs iCal feeds every 15 minutes. Changes made on the external calendar will appear within 15 minutes."
+    }
   },
   "settings": {
     "planTitle": "Your plan",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1232,7 +1232,66 @@
     "maxPhotosError": "Massimo {{max}} foto consentite",
     "photoCount": "{{current}}/{{max}} foto",
     "photoGallery": "Galleria foto",
-    "noPhotos": "Nessuna foto caricata"
+    "noPhotos": "Nessuna foto caricata",
+    "help": {
+      "icalPageTitle": "Come collegare il calendario via iCal",
+      "icalPageDescription": "Istruzioni passo passo per esportare l'URL iCal dalle piattaforme più diffuse. Copia il link e incollalo nella pagina di sincronizzazione.",
+      "icalIntro": "Ogni piattaforma lo chiama in modo diverso: \"Esporta calendario\", \"Sincronizza calendari\", \"Indirizzo segreto iCal\". Trova il tuo qui sotto e incolla l'URL nel dialog di collegamento.",
+      "icalTooltipText": "Non sai dove trovare il link iCal? Scopri come esportarlo da Airbnb, Booking, Google Calendar e altre piattaforme.",
+      "icalTooltipCta": "Scopri come fare",
+      "icalTooltipLabel": "Aiuto iCal",
+      "backToSync": "Torna alla sincronizzazione calendario",
+      "airbnbTitle": "Airbnb",
+      "airbnbSteps": [
+        "Vai su Menu → Annunci e seleziona il tuo annuncio",
+        "Clicca su Disponibilità → Sincronizzazione calendari",
+        "Clicca su Esporta calendario",
+        "Copia l'URL sotto \"URL calendario (iCal)\"",
+        "Incollalo nel dialog iCal di CasaZen"
+      ],
+      "bookingTitle": "Booking.com",
+      "bookingSteps": [
+        "Accedi all'Extranet",
+        "Vai su Tariffe e Disponibilità → Calendario",
+        "Clicca su Esporta",
+        "Copia l'URL iCal mostrato nel popup",
+        "Incollalo nel dialog iCal di CasaZen"
+      ],
+      "vrboTitle": "VRBO",
+      "vrboSteps": [
+        "Vai su Dashboard → seleziona la tua proprietà",
+        "Clicca su Calendario → Importa/Esporta",
+        "Clicca su Esporta → copia l'URL iCal",
+        "Incollalo nel dialog iCal di CasaZen"
+      ],
+      "googleCalendarTitle": "Google Calendar",
+      "googleCalendarSteps": [
+        "Da computer: apri Google Calendar",
+        "Clicca sull'icona ingranaggio → Impostazioni",
+        "A sinistra, clicca sul nome del calendario",
+        "Scorri fino a \"Integra calendario\"",
+        "Copia l'URL \"Indirizzo segreto iCal\"",
+        "Incollalo nel dialog iCal di CasaZen"
+      ],
+      "appleCalendarTitle": "Apple Calendar",
+      "appleCalendarSteps": [
+        "Apri Calendario sul tuo Mac",
+        "Clic destro su un calendario nella barra laterale",
+        "Clicca su Condividi → Calendario pubblico",
+        "Copia il link mostrato",
+        "Incollalo nel dialog iCal di CasaZen"
+      ],
+      "outlookTitle": "Outlook",
+      "outlookSteps": [
+        "Apri Outlook sul web (outlook.office.com)",
+        "Vai su Calendario → Impostazioni (ingranaggio)",
+        "Clicca su Calendari condivisi → Pubblica calendario",
+        "Seleziona il calendario e il livello di permesso",
+        "Copia l'URL ICS",
+        "Incollalo nel dialog iCal di CasaZen"
+      ],
+      "syncFrequencyNote": "CasaZen sincronizza i feed iCal ogni 15 minuti. Le modifiche sul calendario esterno saranno visibili entro 15 minuti."
+    }
   },
   "settings": {
     "planTitle": "Il tuo piano",


### PR DESCRIPTION
## Summary

Adds a clickable help tooltip next to the iCal URL input field in the supplier console, linking to an internal documentation page that explains how to export iCal URLs from Airbnb, Booking.com, VRBO, Google Calendar, Apple Calendar, and Outlook.

- New `IcalHelpTooltip` component: inline icon that opens a popover with help text and a CTA link
- New `IcalHelpPage`: static documentation page at `/app/supplier/help/ical` with platform-specific instructions in Italian
- Tooltip added to both the calendar sync page dialog and the activation wizard step 2
- All text uses i18n keys (`supplier.help.*`) in both `it.json` and `en.json`

## Test Plan

- [ ] Navigate to `/app/supplier/calendar` → click "Incolla link iCal" → verify help icon is visible next to the label
- [ ] Click the help icon → verify tooltip opens with text and "Scopri come fare" link
- [ ] Click "Scopri come fare" → verify redirect to `/app/supplier/help/ical`
- [ ] Verify the doc page shows all 6 platforms with step-by-step instructions
- [ ] Verify "Torna alla sincronizzazione calendario" back link works
- [ ] Repeat steps on activation wizard (`/app/supplier/activation` → step 2)
- [ ] `npm run build` passes
- [ ] `npm test` passes (151 tests)
- [ ] `npx tsc -b --noEmit` passes

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)