### PR TITLE
fix: move iCal help page to top-level /help/ical route

### DIFF
--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -459,12 +459,6 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     component: async () => ({ default: (await import('@/features/supplier/supplier-calendar-sync-page')).SupplierCalendarSyncPage }),
   },
   {
-    path: '/app/supplier/help/ical',
-    context: 'supplier',
-    requiredPermissions: [],
-    component: async () => ({ default: (await import('@/features/supplier/ical-help-page')).IcalHelpPage }),
-  },
-  {
     path: '/app/supplier/profile',
     context: 'supplier',
     requiredPermissions: [],

--- a/src/features/supplier/components/ical-help-tooltip.tsx
+++ b/src/features/supplier/components/ical-help-tooltip.tsx
@@ -61,7 +61,7 @@ export function IcalHelpTooltip() {
             type="button"
             onClick={() => {
               setOpen(false);
-              navigate('/app/supplier/help/ical');
+              navigate('/help/ical');
             }}
             className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
           >

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,6 +23,7 @@ import { SupplierCheckInPage } from '@/pages/supplier-check-in';
 import { SupplierShowcasePage } from '@/pages/supplier-showcase';
 import { ComplianceGuidePage } from '@/features/public-seo/compliance-guide-page';
 import { TouristTaxCalculatorPage } from '@/features/public-seo/tourist-tax-calculator-page';
+import { IcalHelpPage } from '@/features/supplier/ical-help-page';
 
 function buildContextChildren(contextKey: AppContextKey): RouteObject[] {
   const prefix = `/app/${contextKey}`;
@@ -159,6 +160,10 @@ export const router = createBrowserRouter([
   {
     path: '/supplier/*',
     element: <Navigate to="/app/supplier/inbox" replace />,
+  },
+  {
+    path: '/help/ical',
+    element: <IcalHelpPage />,
   },
   {
     element: (


### PR DESCRIPTION
Standardise help docs under `/help` prefix for future help pages.