### PR TITLE
feat(#294): property iCal settings and calendar blocks

### DIFF
--- a/src/api/property-ical.api.ts
+++ b/src/api/property-ical.api.ts
@@ -1,0 +1,17 @@
+import { ApiClient } from './client';
+import type {
+  PropertyIcalExportUrl,
+  PropertyIcalImportUrlRequest,
+  PropertyIcalStatus,
+} from '@/types/property-ical';
+
+export const propertyIcalApi = {
+  getStatus: (propertyId: string) =>
+    ApiClient.get<PropertyIcalStatus>(`/properties/${propertyId}/ical/status`),
+
+  setImportUrl: (propertyId: string, data: PropertyIcalImportUrlRequest) =>
+    ApiClient.post<PropertyIcalStatus>(`/properties/${propertyId}/ical/import-url`, data),
+
+  getExportUrl: (propertyId: string) =>
+    ApiClient.get<PropertyIcalExportUrl>(`/properties/${propertyId}/ical/export-url`),
+};

--- a/src/features/bookings/calendar-page.tsx
+++ b/src/features/bookings/calendar-page.tsx
@@ -10,7 +10,7 @@ import { useBookingCalendar } from '@/queries/use-bookings';
 import { useProperties } from '@/queries/use-properties';
 import { List } from 'lucide-react';
 import type { Booking, BookingCalendarEvent } from '@/types';
-import type { CalendarBookingDto } from '@/types/calendar.types';
+import type { CalendarBookingDto, CalendarItemDto } from '@/types/calendar.types';
 
 function toMonthRange(date: Date): { startDate: string; endDate: string } {
   const start = new Date(date.getFullYear(), date.getMonth(), 1);
@@ -45,6 +45,41 @@ function mapCalendarBooking(dto: CalendarBookingDto): Booking {
   };
 }
 
+function mapCalendarItemToBooking(item: CalendarItemDto): Booking {
+  const [firstName = '', ...rest] = (item.guestName ?? '').split(' ');
+  return {
+    id: item.id,
+    propertyId: item.propertyId,
+    userId: '',
+    checkInDate: item.startDate,
+    checkOutDate: item.endDate,
+    numberOfGuests: item.numberOfGuests ?? 0,
+    totalPrice: item.totalPrice ?? 0,
+    currency: 'EUR',
+    status: (item.status ?? 'Confirmed') as Booking['status'],
+    guest: {
+      firstName,
+      lastName: rest.join(' '),
+      email: '',
+      phone: '',
+      country: '',
+    },
+    createdAt: item.startDateUtc,
+    updatedAt: item.endDateUtc,
+  };
+}
+
+function mapIcalItemToEvent(item: CalendarItemDto): BookingCalendarEvent {
+  return {
+    id: item.id,
+    title: item.summary || 'OTA',
+    start: new Date(item.startDate),
+    end: new Date(item.endDate),
+    resource: undefined,
+    eventType: 'ical-block',
+  };
+}
+
 export function CalendarPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -62,7 +97,16 @@ export function CalendarPage() {
   );
 
   const bookings = useMemo(
-    () => (calendarResponse?.bookings ?? []).map(mapCalendarBooking),
+    () => (calendarResponse?.items?.length
+      ? calendarResponse.items.filter((i) => i.type === 'booking').map(mapCalendarItemToBooking)
+      : (calendarResponse?.bookings ?? []).map(mapCalendarBooking)),
+    [calendarResponse],
+  );
+
+  const icalEvents = useMemo(
+    () => (calendarResponse?.items ?? [])
+      .filter((item) => item.type === 'ical-block')
+      .map(mapIcalItemToEvent),
     [calendarResponse],
   );
 
@@ -131,6 +175,7 @@ export function CalendarPage() {
             ) : (
               <BookingCalendar
                 bookings={bookings}
+                icalEvents={icalEvents}
                 onSelectEvent={handleSelectEvent}
                 onSelectSlot={handleSelectSlot}
               />

--- a/src/features/bookings/components/booking-calendar.tsx
+++ b/src/features/bookings/components/booking-calendar.tsx
@@ -1,6 +1,7 @@
 import { Calendar, momentLocalizer } from 'react-big-calendar';
 import moment from 'moment';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
+import { useTranslation } from 'react-i18next';
 import type { Booking } from '@/types';
 import type { BookingCalendarEvent } from '@/types';
 
@@ -8,20 +9,39 @@ const localizer = momentLocalizer(moment);
 
 interface BookingCalendarProps {
   bookings: Booking[];
+  icalEvents?: BookingCalendarEvent[];
   onSelectEvent?: (event: BookingCalendarEvent) => void;
   onSelectSlot?: (slotInfo: { start: Date; end: Date }) => void;
 }
 
-export function BookingCalendar({ bookings, onSelectEvent, onSelectSlot }: BookingCalendarProps) {
-  const events: BookingCalendarEvent[] = bookings.map((booking) => ({
+export function BookingCalendar({ bookings, icalEvents = [], onSelectEvent, onSelectSlot }: BookingCalendarProps) {
+  const { t } = useTranslation();
+
+  const bookingEvents: BookingCalendarEvent[] = bookings.map((booking) => ({
     id: booking.id,
     title: `${booking.guest.firstName} ${booking.guest.lastName}`,
     start: new Date(booking.checkInDate),
     end: new Date(booking.checkOutDate),
     resource: booking,
+    eventType: 'booking',
   }));
 
+  const events: BookingCalendarEvent[] = [...bookingEvents, ...icalEvents];
+
   const eventStyleGetter = (event: BookingCalendarEvent) => {
+    if (event.eventType === 'ical-block') {
+      return {
+        style: {
+          backgroundColor: '#9333ea',
+          borderRadius: '5px',
+          opacity: 0.85,
+          color: 'white',
+          border: '0px',
+          display: 'block',
+        },
+      };
+    }
+
     const booking = event.resource;
     let backgroundColor = '#3174ad';
 
@@ -58,20 +78,32 @@ export function BookingCalendar({ bookings, onSelectEvent, onSelectSlot }: Booki
   };
 
   return (
-    <div className="h-[600px] bg-white p-4 rounded-lg border">
-      <Calendar
-        localizer={localizer}
-        events={events}
-        startAccessor="start"
-        endAccessor="end"
-        style={{ height: '100%' }}
-        onSelectEvent={onSelectEvent}
-        onSelectSlot={onSelectSlot}
-        selectable
-        eventPropGetter={eventStyleGetter}
-        views={['month', 'week', 'day']}
-        defaultView="month"
-      />
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+        <span className="inline-flex items-center gap-2">
+          <span className="h-3 w-3 rounded bg-blue-500" />
+          {t('ical.legendBooking')}
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <span className="h-3 w-3 rounded bg-purple-600" />
+          {t('ical.legendIcalBlock')}
+        </span>
+      </div>
+      <div className="h-[600px] bg-white p-4 rounded-lg border">
+        <Calendar
+          localizer={localizer}
+          events={events}
+          startAccessor="start"
+          endAccessor="end"
+          style={{ height: '100%' }}
+          onSelectEvent={onSelectEvent}
+          onSelectSlot={onSelectSlot}
+          selectable
+          eventPropGetter={eventStyleGetter}
+          views={['month', 'week', 'day']}
+          defaultView="month"
+        />
+      </div>
     </div>
   );
 }

--- a/src/features/properties/components/ical-settings.tsx
+++ b/src/features/properties/components/ical-settings.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { CalendarSync, Copy, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { usePropertyIcalStatus, useSetPropertyIcalImportUrl } from '@/queries/use-property-ical';
+
+interface IcalSettingsProps {
+  propertyId: string;
+}
+
+export function IcalSettings({ propertyId }: IcalSettingsProps) {
+  const { t } = useTranslation();
+  const { data: status, isLoading } = usePropertyIcalStatus(propertyId);
+  const setImportUrl = useSetPropertyIcalImportUrl(propertyId);
+  const [importUrl, setImportUrlValue] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const handleSave = async () => {
+    if (!importUrl.trim()) return;
+    await setImportUrl.mutateAsync(importUrl.trim());
+    setImportUrlValue('');
+  };
+
+  const handleCopyExport = async () => {
+    if (!status?.exportUrl) return;
+    await navigator.clipboard.writeText(status.exportUrl);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="py-8 flex justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid="property-ical-settings">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <CalendarSync className="h-5 w-5" />
+          {t('ical.title')}
+        </CardTitle>
+        <CardDescription>{t('ical.description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="property-ical-import">{t('ical.importUrlLabel')}</Label>
+          <Input
+            id="property-ical-import"
+            value={importUrl || status?.importUrl || ''}
+            onChange={(e) => setImportUrlValue(e.target.value)}
+            placeholder="https://www.airbnb.com/calendar/ical/..."
+          />
+          <p className="text-xs text-muted-foreground">
+            {t('ical.importHint')}{' '}
+            <Link to="/help/ical" className="text-primary hover:underline">
+              {t('ical.helpLink')}
+            </Link>
+          </p>
+          <Button onClick={() => void handleSave()} disabled={setImportUrl.isPending || !(importUrl.trim() || status?.importUrl)}>
+            {setImportUrl.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {t('ical.saveImport')}
+          </Button>
+        </div>
+
+        <div className="space-y-2 rounded-md border p-4">
+          <p className="text-sm font-medium">{t('ical.syncStatus')}</p>
+          <p className="text-sm text-muted-foreground">
+            {status?.lastImportAt
+              ? t('ical.lastSync', { date: new Date(status.lastImportAt).toLocaleString() })
+              : t('ical.neverSynced')}
+          </p>
+          {status?.lastImportStatus && (
+            <p className="text-sm">{t('ical.statusValue', { status: status.lastImportStatus })}</p>
+          )}
+          {status?.lastError && (
+            <p className="text-sm text-destructive">{status.lastError}</p>
+          )}
+          <p className="text-sm text-muted-foreground">
+            {t('ical.blockCount', { count: status?.blockCount ?? 0 })}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label>{t('ical.exportUrlLabel')}</Label>
+          <div className="flex gap-2">
+            <Input readOnly value={status?.exportUrl ?? ''} />
+            <Button type="button" variant="outline" onClick={() => void handleCopyExport()} disabled={!status?.exportUrl}>
+              <Copy className="h-4 w-4" />
+              {copied ? t('ical.copied') : t('ical.copy')}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">{t('ical.exportHint')}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/properties/property-detail-page.tsx
+++ b/src/features/properties/property-detail-page.tsx
@@ -18,6 +18,7 @@ import { PropertyInfoCard } from './components/property-info-card';
 import { PropertyAmenitiesGrid } from './components/property-amenities-grid';
 import { PropertyDocumentsSection } from './components/property-documents-section';
 import { PropertyOtaSummary } from './components/property-ota-summary';
+import { IcalSettings } from './components/ical-settings';
 import { PropertyBookingsKpi } from './components/property-bookings-kpi';
 import { PropertyPricingSummaryCard } from './components/property-pricing-summary-card';
 
@@ -175,6 +176,7 @@ export function PropertyDetailPage() {
 
         {activeTab === 'ota' && (
           <div className="space-y-6">
+            <IcalSettings propertyId={property.id} />
             <PropertyOtaSummary integrations={property.otaIntegrations} />
           </div>
         )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1138,6 +1138,25 @@
       "Rifiutato": "Declined"
     }
   },
+  "ical": {
+    "title": "OTA Calendar",
+    "description": "Import your Airbnb or Booking.com calendar and share CasaZen availability via iCal.",
+    "importUrlLabel": "Import URL (HTTPS)",
+    "importHint": "Paste the iCal URL from your OTA. Need help?",
+    "helpLink": "How to find your iCal link",
+    "saveImport": "Save and sync",
+    "syncStatus": "Sync status",
+    "lastSync": "Last sync: {{date}}",
+    "neverSynced": "Not synced yet",
+    "statusValue": "Status: {{status}}",
+    "blockCount": "{{count}} blocked periods imported",
+    "exportUrlLabel": "Export URL for OTAs",
+    "exportHint": "Paste this URL into Airbnb/Booking to export CasaZen bookings and blocks.",
+    "copy": "Copy",
+    "copied": "Copied",
+    "legendBooking": "Booking",
+    "legendIcalBlock": "OTA block (iCal)"
+  },
   "supplier": {
     "profileLoading": "Loading profile...",
     "profileTitle": "Supplier Profile",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1140,6 +1140,25 @@
       "Rifiutato": "Rifiutato"
     }
   },
+  "ical": {
+    "title": "Calendario OTA",
+    "description": "Importa il calendario Airbnb o Booking.com e condividi la disponibilità CasaZen via iCal.",
+    "importUrlLabel": "URL import (HTTPS)",
+    "importHint": "Incolla l'URL iCal dalla tua OTA. Serve aiuto?",
+    "helpLink": "Come trovare il link iCal",
+    "saveImport": "Salva e sincronizza",
+    "syncStatus": "Stato sincronizzazione",
+    "lastSync": "Ultima sync: {{date}}",
+    "neverSynced": "Mai sincronizzato",
+    "statusValue": "Stato: {{status}}",
+    "blockCount": "{{count}} periodi bloccati importati",
+    "exportUrlLabel": "URL export per le OTA",
+    "exportHint": "Incolla questo URL su Airbnb/Booking per esportare prenotazioni e blocchi CasaZen.",
+    "copy": "Copia",
+    "copied": "Copiato",
+    "legendBooking": "Prenotazione",
+    "legendIcalBlock": "Blocco OTA (iCal)"
+  },
   "supplier": {
     "profileLoading": "Caricamento profilo...",
     "profileTitle": "Profilo fornitore",

--- a/src/queries/use-property-ical.ts
+++ b/src/queries/use-property-ical.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { propertyIcalApi } from '@/api/property-ical.api';
+
+export function usePropertyIcalStatus(propertyId: string | undefined) {
+  return useQuery({
+    queryKey: ['property-ical', propertyId],
+    queryFn: () => propertyIcalApi.getStatus(propertyId!),
+    enabled: Boolean(propertyId),
+  });
+}
+
+export function useSetPropertyIcalImportUrl(propertyId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (importUrl: string) => propertyIcalApi.setImportUrl(propertyId, { importUrl }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['property-ical', propertyId] });
+    },
+  });
+}
+
+export function usePropertyIcalExportUrl(propertyId: string | undefined) {
+  return useQuery({
+    queryKey: ['property-ical-export', propertyId],
+    queryFn: () => propertyIcalApi.getExportUrl(propertyId!),
+    enabled: Boolean(propertyId),
+  });
+}

--- a/src/types/booking.types.ts
+++ b/src/types/booking.types.ts
@@ -46,6 +46,7 @@ export interface BookingCalendarEvent {
   start: Date;
   end: Date;
   resource?: Booking;
+  eventType?: 'booking' | 'ical-block';
 }
 
 export interface CheckInDto {

--- a/src/types/calendar.types.ts
+++ b/src/types/calendar.types.ts
@@ -14,9 +14,27 @@ export interface CalendarBookingDto {
   guestName: string;
 }
 
+/** Matches backend CalendarItemDto */
+export interface CalendarItemDto {
+  type: 'booking' | 'ical-block' | string;
+  id: string;
+  propertyId: string;
+  startDate: string;
+  endDate: string;
+  startDateUtc: string;
+  endDateUtc: string;
+  status?: string;
+  source?: string;
+  numberOfGuests?: number;
+  totalPrice?: number;
+  guestName?: string;
+  summary?: string;
+}
+
 /** Matches backend CalendarResponseDto */
 export interface CalendarResponseDto {
   timezone: string;
   utcOffsetMinutes: number;
   bookings: CalendarBookingDto[];
+  items?: CalendarItemDto[];
 }

--- a/src/types/property-ical.ts
+++ b/src/types/property-ical.ts
@@ -1,0 +1,16 @@
+export interface PropertyIcalStatus {
+  importUrl?: string | null;
+  exportUrl: string;
+  lastImportAt?: string | null;
+  lastImportStatus?: string | null;
+  lastError?: string | null;
+  blockCount: number;
+}
+
+export interface PropertyIcalExportUrl {
+  exportUrl: string;
+}
+
+export interface PropertyIcalImportUrlRequest {
+  importUrl: string;
+}


### PR DESCRIPTION
## Summary
- OTA calendar card on property detail (import URL, sync status, export URL copy)
- Booking calendar shows iCal blocks in purple with legend
- i18n ical.* keys (en/it)

## Test plan
- [x] npm run build
- [x] tsc --noEmit
- [ ] E2E on staging

Related: casazen/backend#294

Made with [Cursor](https://cursor.com)