### PR TITLE
feat(public-site): PublicSiteShell marketing UI (US-023) (#297)

### DIFF
--- a/e2e/branded-booking-site.spec.ts
+++ b/e2e/branded-booking-site.spec.ts
@@ -17,7 +17,7 @@ test.describe('Branded booking site (#215)', () => {
   test('AC4/AC5: branded landing renders org branding and listings without login', async ({ page }) => {
     await page.goto(`/book/${DEMO_ORG_SLUG}`);
 
-    await expect(page.getByTestId('public-booking-shell')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('public-site-shell')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByRole('heading', { level: 1, name: mockPublicOrg.displayName, exact: true })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Trastevere Suite' })).toBeVisible();
     await expect(page.getByText('CIN valido')).toBeVisible();
@@ -88,7 +88,7 @@ test.describe('Branded booking site (#215)', () => {
 
   test('AC8: footer contains Privacy Policy and Terms of Service links', async ({ page }) => {
     await page.goto(`/book/${DEMO_ORG_SLUG}`);
-    await expect(page.getByTestId('public-booking-shell')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('public-site-shell')).toBeVisible({ timeout: 15_000 });
 
     await expect(page.getByRole('link', { name: 'Privacy Policy' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Termini di servizio' })).toBeVisible();
@@ -107,6 +107,6 @@ test.describe('Branded booking site (#215)', () => {
     await page.goto('/app/short-rent/dashboard');
     // In demo mode the protected routes are bypassed, but in non-demo they redirect
     // We verify the page is NOT the public booking shell (no auth chrome on /book)
-    await expect(page.getByTestId('public-booking-shell')).not.toBeAttached();
+    await expect(page.getByTestId('public-site-shell')).not.toBeAttached();
   });
 });

--- a/e2e/golden-journey-web.spec.ts
+++ b/e2e/golden-journey-web.spec.ts
@@ -36,7 +36,7 @@ test.describe('Golden Journey web (#301)', () => {
 
     // Step 4: guest public booking — branded shell
     await page.goto(demoUrl(`/book/${DEMO_ORG_SLUG}`, 'short-stay'), { waitUntil: 'networkidle' });
-    await expect(page.getByTestId('public-booking-shell')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('public-site-shell')).toBeVisible({ timeout: 15_000 });
     await expect(
       page.getByRole('heading', { level: 1, name: mockPublicOrg.displayName, exact: true }),
     ).toBeVisible();

--- a/src/features/public-booking/org-landing-page.tsx
+++ b/src/features/public-booking/org-landing-page.tsx
@@ -1,9 +1,12 @@
+import { lazy, Suspense } from 'react';
 import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useOrgProperties } from '@/queries/use-public-org';
 import { PropertySearchCard } from '@/features/search/components/property-search-card';
 import type { PublicOrgDto, PublicPropertyDto } from '@/types';
 import { Loader2 } from 'lucide-react';
+
+const Hero = lazy(() => import('@/features/public-site/components/Hero').then((m) => ({ default: m.Hero })));
 
 interface PublicBookingContext {
   org: PublicOrgDto;
@@ -20,28 +23,36 @@ export function OrgLandingPage() {
     navigate(`/book/${orgSlug}/property/${property.id}`);
   };
 
-  return (
-    <div className="space-y-8">
-      <section className="space-y-2">
-        <h2 className="text-3xl font-bold">{t('publicBooking.welcomeToOrg', { orgName: org.displayName })}</h2>
-        <p className="text-muted-foreground">
-          {t('publicBooking.welcomeDescription')}
-        </p>
-      </section>
+  const heroImage = org.heroImageUrl ?? properties[0]?.photoUrls?.[0] ?? null;
 
-      {isLoading ? (
-        <div className="flex justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-primary" />
-        </div>
-      ) : properties.length === 0 ? (
-        <p className="text-muted-foreground">{t('publicBooking.noPropertiesPublished')}</p>
-      ) : (
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {properties.map((property) => (
-            <PropertySearchCard key={property.id} property={property} onViewDetails={handleViewDetails} />
-          ))}
-        </div>
-      )}
+  return (
+    <div className="space-y-[var(--cz-public-section-y)]">
+      <Suspense fallback={<div className="h-48 animate-pulse rounded-[var(--cz-public-radius)] bg-black/5" />}>
+        <Hero
+          imageUrl={heroImage}
+          title={org.displayName}
+          tagline={org.tagline}
+          ctaLabel={properties.length > 0 ? t('publicSite.viewProperties') : undefined}
+          onCta={properties.length > 0 ? () => document.getElementById('property-grid')?.scrollIntoView({ behavior: 'smooth' }) : undefined}
+        />
+      </Suspense>
+
+      <section id="property-grid" className="space-y-6">
+        <h2 className="public-display text-2xl font-semibold">{t('publicSite.ourProperties')}</h2>
+        {isLoading ? (
+          <div className="flex justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-[var(--cz-public-primary)]" />
+          </div>
+        ) : properties.length === 0 ? (
+          <p className="text-[var(--cz-public-muted)]">{t('publicBooking.noPropertiesPublished')}</p>
+        ) : (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {properties.map((property) => (
+              <PropertySearchCard key={property.id} property={property} onViewDetails={handleViewDetails} />
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/features/public-booking/public-property-page.tsx
+++ b/src/features/public-booking/public-property-page.tsx
@@ -1,68 +1,33 @@
-import { useMemo, useState } from 'react';
-import { Link, useNavigate, useOutletContext, useParams } from 'react-router-dom';
+import { lazy, Suspense } from 'react';
+import { Link, useOutletContext, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useOrgPublicProperty, usePropertyAvailability } from '@/queries/use-public-org';
 import { PropertyCinBadge } from '@/features/properties/components/property-cin-badge';
 import { AiContentNotice } from '@/components/shared/ai-content-notice';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { formatCurrency } from '@/lib/utils';
 import type { PublicOrgDto } from '@/types';
-import { ArrowLeft, Bed, Bath, Loader2, Users, AlertCircle } from 'lucide-react';
+import { ArrowLeft, Bed, Bath, Loader2, Users } from 'lucide-react';
+
+const Hero = lazy(() => import('@/features/public-site/components/Hero').then((m) => ({ default: m.Hero })));
+const PropertyGallery = lazy(() => import('@/features/public-site/components/PropertyGallery').then((m) => ({ default: m.PropertyGallery })));
+const AmenityGrid = lazy(() => import('@/features/public-site/components/AmenityGrid').then((m) => ({ default: m.AmenityGrid })));
+const BookingWidget = lazy(() => import('@/features/public-site/components/BookingWidget').then((m) => ({ default: m.BookingWidget })));
 
 interface PublicBookingContext {
   org: PublicOrgDto;
-}
-
-function nightsBetween(checkIn: string, checkOut: string): number {
-  if (!checkIn || !checkOut) return 0;
-  const start = new Date(checkIn);
-  const end = new Date(checkOut);
-  const diff = end.getTime() - start.getTime();
-  if (diff <= 0) return 0;
-  return Math.ceil(diff / (1000 * 60 * 60 * 24));
 }
 
 export function PublicPropertyPage() {
   const { t } = useTranslation();
   const { orgSlug, propertyId } = useParams<{ orgSlug: string; propertyId: string }>();
   const { org } = useOutletContext<PublicBookingContext>();
-  const navigate = useNavigate();
   const { data: property, isLoading, isError } = useOrgPublicProperty(orgSlug, propertyId);
   const { data: availability } = usePropertyAvailability(propertyId);
-
-  const [checkIn, setCheckIn] = useState('');
-  const [checkOut, setCheckOut] = useState('');
-
-  const nights = useMemo(() => nightsBetween(checkIn, checkOut), [checkIn, checkOut]);
-  const lodgingTotal = property ? property.nightlyRate * nights : 0;
-  const estimatedTotal = property ? lodgingTotal + property.cleaningFee : 0;
-
-  const isDateBooked = (dateStr: string): boolean => {
-    return availability?.bookedDates.includes(dateStr) ?? false;
-  };
-
-  const checkInBooked = checkIn && isDateBooked(checkIn);
-  const checkOutBooked = checkOut && isDateBooked(checkOut);
-  const dateRangeAvailable = useMemo(() => {
-    if (!checkIn || !checkOut || !availability) return true;
-    const start = new Date(checkIn);
-    const end = new Date(checkOut);
-    let current = new Date(start);
-    while (current < end) {
-      if (availability.bookedDates.includes(current.toISOString().split('T')[0])) {
-        return false;
-      }
-      current.setDate(current.getDate() + 1);
-    }
-    return true;
-  }, [checkIn, checkOut, availability]);
 
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <Loader2 className="h-8 w-8 animate-spin text-[var(--cz-public-primary)]" />
       </div>
     );
   }
@@ -70,15 +35,13 @@ export function PublicPropertyPage() {
   if (isError || !property) {
     return (
       <div className="space-y-4 text-center">
-        <p className="text-muted-foreground">{t('publicBooking.propertyNotFound')}</p>
+        <p className="text-[var(--cz-public-muted)]">{t('publicBooking.propertyNotFound')}</p>
         <Button asChild variant="outline">
           <Link to={`/book/${orgSlug}`}>{t('publicBooking.backToProperties')}</Link>
         </Button>
       </div>
     );
   }
-
-  const heroPhoto = property.photoUrls[0];
 
   return (
     <div className="space-y-8">
@@ -89,130 +52,66 @@ export function PublicPropertyPage() {
         </Link>
       </Button>
 
-      {heroPhoto ? (
-        <img src={heroPhoto} alt={property.name} className="h-72 w-full rounded-lg object-cover" />
-      ) : (
-        <div className="flex h-72 items-center justify-center rounded-lg bg-muted text-6xl">🏠</div>
-      )}
+      <Suspense fallback={null}>
+        <Hero imageUrl={property.photoUrls[0]} title={property.name} tagline={property.city} />
+      </Suspense>
 
-      <div className="space-y-4">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <h2 className="text-3xl font-bold">{property.name}</h2>
-            <p className="text-muted-foreground">
-              {property.city}
-              {property.postalCode ? ` (${property.postalCode})` : ''}
-            </p>
+      <div className="grid gap-8 lg:grid-cols-[1fr_320px] lg:items-start">
+        <div className="space-y-8">
+          <Suspense fallback={null}>
+            <PropertyGallery photoUrls={property.photoUrls} alt={property.name} />
+          </Suspense>
+
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <h2 className="public-display text-2xl font-semibold">{property.name}</h2>
+                <p className="text-[var(--cz-public-muted)]">
+                  {property.city}
+                  {property.postalCode ? ` (${property.postalCode})` : ''}
+                </p>
+              </div>
+              <PropertyCinBadge cinStatus={property.cinStatus} cinCode={property.cinCode} />
+            </div>
+
+            <AiContentNotice visible={false} />
+            <p className="text-[var(--cz-public-muted)]">{property.description}</p>
+
+            <div className="flex flex-wrap gap-4 text-sm">
+              <span className="flex items-center gap-1"><Bed className="h-4 w-4" /> {property.bedrooms} {t('publicBooking.camere')}</span>
+              <span className="flex items-center gap-1"><Bath className="h-4 w-4" /> {property.bathrooms} {t('publicBooking.bagni')}</span>
+              <span className="flex items-center gap-1"><Users className="h-4 w-4" /> {t('publicBooking.ospiti', { count: property.maxGuests })}</span>
+            </div>
+
+            {property.amenities.length > 0 ? (
+              <div className="space-y-3">
+                <h3 className="font-semibold">{t('publicBooking.servicesTitle')}</h3>
+                <Suspense fallback={null}>
+                  <AmenityGrid amenities={property.amenities} />
+                </Suspense>
+              </div>
+            ) : null}
+
+            {property.houseRules ? (
+              <div>
+                <h3 className="font-semibold mb-2">{t('publicBooking.rulesTitle')}</h3>
+                <p className="text-sm whitespace-pre-wrap">{property.houseRules}</p>
+              </div>
+            ) : null}
+
+            {property.cancellationPolicySummary ? (
+              <div>
+                <h3 className="font-semibold mb-2">{t('publicBooking.cancellationTitle')}</h3>
+                <p className="text-sm text-[var(--cz-public-muted)]">{property.cancellationPolicySummary}</p>
+              </div>
+            ) : null}
           </div>
-          <PropertyCinBadge cinStatus={property.cinStatus} cinCode={property.cinCode} />
         </div>
 
-        <AiContentNotice visible={false} />
-
-        <p className="text-muted-foreground">{property.description}</p>
-
-        <div className="flex flex-wrap gap-4 text-sm">
-          <span className="flex items-center gap-1">
-            <Bed className="h-4 w-4" /> {property.bedrooms} {t('publicBooking.camere')}
-          </span>
-          <span className="flex items-center gap-1">
-            <Bath className="h-4 w-4" /> {property.bathrooms} {t('publicBooking.bagni')}
-          </span>
-          <span className="flex items-center gap-1">
-            <Users className="h-4 w-4" /> {t('publicBooking.ospiti', { count: property.maxGuests })}
-          </span>
-        </div>
-
-        {property.amenities.length > 0 && (
-          <div>
-            <h3 className="font-semibold mb-2">{t('publicBooking.servicesTitle')}</h3>
-            <p className="text-sm text-muted-foreground">{property.amenities.join(' · ')}</p>
-          </div>
-        )}
-
-        {property.houseRules && (
-          <div>
-            <h3 className="font-semibold mb-2">{t('publicBooking.rulesTitle')}</h3>
-            <p className="text-sm whitespace-pre-wrap">{property.houseRules}</p>
-          </div>
-        )}
-
-        {property.cancellationPolicySummary && (
-          <div>
-            <h3 className="font-semibold mb-2">{t('publicBooking.cancellationTitle')}</h3>
-            <p className="text-sm text-muted-foreground">{property.cancellationPolicySummary}</p>
-          </div>
-        )}
+        <Suspense fallback={null}>
+          <BookingWidget property={property} availability={availability} orgSlug={orgSlug!} />
+        </Suspense>
       </div>
-
-      <section className="rounded-lg border p-6 space-y-4" data-testid="booking-preview">
-        <h3 className="text-xl font-semibold">{t('publicBooking.propertyTitle')}</h3>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="check-in">{t('publicBooking.checkInLabel')}</Label>
-            <Input
-              id="check-in"
-              type="date"
-              value={checkIn}
-              onChange={(e) => setCheckIn(e.target.value)}
-              className={checkInBooked ? 'border-red-500' : ''}
-            />
-            {checkInBooked && (
-              <p className="text-sm text-red-600 flex items-center gap-1">
-                <AlertCircle className="h-4 w-4" /> {t('publicBooking.dateAlreadyBooked')}
-              </p>
-            )}
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="check-out">{t('publicBooking.checkOutLabel')}</Label>
-            <Input
-              id="check-out"
-              type="date"
-              value={checkOut}
-              onChange={(e) => setCheckOut(e.target.value)}
-              className={checkOutBooked ? 'border-red-500' : ''}
-            />
-            {checkOutBooked && (
-              <p className="text-sm text-red-600 flex items-center gap-1">
-                <AlertCircle className="h-4 w-4" /> {t('publicBooking.dateAlreadyBooked')}
-              </p>
-            )}
-          </div>
-        </div>
-
-        {checkIn && checkOut && !dateRangeAvailable && (
-          <div className="rounded-md border border-red-500 bg-red-50 p-3 flex gap-2 items-start">
-            <AlertCircle className="h-5 w-5 text-red-600 mt-0.5 flex-shrink-0" />
-            <p className="text-sm text-red-700">
-              {t('publicBooking.dateRangeBooked')}
-            </p>
-          </div>
-        )}
-
-        {nights > 0 && (
-          <div className="space-y-1 text-sm">
-            <p>
-              {nights} {t('publicBooking.notte')}{nights !== 1 ? 'i' : ''} × {formatCurrency(property.nightlyRate)} ={' '}
-              {formatCurrency(lodgingTotal)}
-            </p>
-            <p>{t('publicBooking.pulizia')}: {formatCurrency(property.cleaningFee)}</p>
-            <p className="text-muted-foreground">{t('publicBooking.tassaSoggiornoCalculated')}</p>
-            <p className="text-lg font-semibold pt-2">{t('publicBooking.totaleStimato', { amount: formatCurrency(estimatedTotal) })}</p>
-          </div>
-        )}
-
-        <Button
-          className="w-full sm:w-auto"
-          disabled={nights <= 0 || !dateRangeAvailable}
-          onClick={() =>
-            navigate(
-              `/book/${orgSlug}/property/${propertyId}/checkout?checkIn=${checkIn}&checkOut=${checkOut}`,
-            )
-          }
-        >
-          {t('publicBooking.proceedToCheckout')}
-        </Button>
-      </section>
     </div>
   );
 }

--- a/src/features/public-site/components/AmenityGrid.tsx
+++ b/src/features/public-site/components/AmenityGrid.tsx
@@ -1,0 +1,48 @@
+import { Bath, Car, Coffee, Dumbbell, Tv, Utensils, Waves, Wifi, Wind, Check } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+const AMENITY_ICONS: Record<string, LucideIcon> = {
+  wifi: Wifi,
+  'wi-fi': Wifi,
+  parking: Car,
+  parcheggio: Car,
+  pool: Waves,
+  piscina: Waves,
+  kitchen: Utensils,
+  cucina: Utensils,
+  ac: Wind,
+  'aria condizionata': Wind,
+  tv: Tv,
+  gym: Dumbbell,
+  palestra: Dumbbell,
+  breakfast: Coffee,
+  colazione: Coffee,
+  bathroom: Bath,
+};
+
+function iconForAmenity(label: string): LucideIcon {
+  const key = label.toLowerCase();
+  return AMENITY_ICONS[key] ?? Check;
+}
+
+interface AmenityGridProps {
+  amenities: string[];
+}
+
+export function AmenityGrid({ amenities }: AmenityGridProps) {
+  if (amenities.length === 0) return null;
+
+  return (
+    <ul className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {amenities.map((amenity) => {
+        const Icon = iconForAmenity(amenity);
+        return (
+          <li key={amenity} className="public-site-card flex items-center gap-2 px-3 py-2 text-sm">
+            <Icon className="h-4 w-4 shrink-0 text-[var(--cz-public-primary)]" aria-hidden />
+            <span>{amenity}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/features/public-site/components/BookingWidget.tsx
+++ b/src/features/public-site/components/BookingWidget.tsx
@@ -1,0 +1,127 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { formatCurrency } from '@/lib/utils';
+import type { PublicPropertyDetailDto } from '@/types';
+
+interface Availability {
+  bookedDates: string[];
+}
+
+interface BookingWidgetProps {
+  property: PublicPropertyDetailDto;
+  availability?: Availability;
+  orgSlug: string;
+}
+
+function nightsBetween(checkIn: string, checkOut: string): number {
+  if (!checkIn || !checkOut) return 0;
+  const diff = new Date(checkOut).getTime() - new Date(checkIn).getTime();
+  return diff > 0 ? Math.ceil(diff / (1000 * 60 * 60 * 24)) : 0;
+}
+
+function WidgetForm({
+  property,
+  availability,
+  orgSlug,
+  compact = false,
+}: BookingWidgetProps & { compact?: boolean }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [checkIn, setCheckIn] = useState('');
+  const [checkOut, setCheckOut] = useState('');
+
+  const nights = useMemo(() => nightsBetween(checkIn, checkOut), [checkIn, checkOut]);
+  const lodgingTotal = property.nightlyRate * nights;
+  const estimatedTotal = lodgingTotal + property.cleaningFee;
+
+  const isDateBooked = (dateStr: string) => availability?.bookedDates.includes(dateStr) ?? false;
+  const dateRangeAvailable = useMemo(() => {
+    if (!checkIn || !checkOut || !availability) return true;
+    const start = new Date(checkIn);
+    const end = new Date(checkOut);
+    const current = new Date(start);
+    while (current < end) {
+      if (availability.bookedDates.includes(current.toISOString().split('T')[0])) return false;
+      current.setDate(current.getDate() + 1);
+    }
+    return true;
+  }, [checkIn, checkOut, availability]);
+
+  const canCheckout = nights > 0 && dateRangeAvailable;
+
+  return (
+    <div className={`space-y-4 ${compact ? '' : 'public-site-card p-5'}`} data-testid="booking-widget">
+      <h3 className="text-lg font-semibold">{t('publicBooking.propertyTitle')}</h3>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor="widget-check-in">{t('publicBooking.checkInLabel')}</Label>
+          <Input id="widget-check-in" type="date" value={checkIn} onChange={(e) => setCheckIn(e.target.value)} />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="widget-check-out">{t('publicBooking.checkOutLabel')}</Label>
+          <Input id="widget-check-out" type="date" value={checkOut} onChange={(e) => setCheckOut(e.target.value)} />
+        </div>
+      </div>
+
+      {(checkIn && isDateBooked(checkIn)) || (checkOut && isDateBooked(checkOut)) || (checkIn && checkOut && !dateRangeAvailable) ? (
+        <p className="flex items-center gap-1 text-sm text-red-600">
+          <AlertCircle className="h-4 w-4" />
+          {t('publicBooking.dateRangeBooked')}
+        </p>
+      ) : null}
+
+      {nights > 0 ? (
+        <div className="space-y-1 text-sm">
+          <p>
+            {nights} {t('publicBooking.notte')}{nights !== 1 ? 'i' : ''} × {formatCurrency(property.nightlyRate)} = {formatCurrency(lodgingTotal)}
+          </p>
+          <p>{t('publicBooking.pulizia')}: {formatCurrency(property.cleaningFee)}</p>
+          <p className="text-[var(--cz-public-muted)]">{t('publicBooking.tassaSoggiornoCalculated')}</p>
+          <p className="text-base font-semibold">{t('publicBooking.totaleStimato', { amount: formatCurrency(estimatedTotal) })}</p>
+        </div>
+      ) : null}
+
+      <Button
+        className="public-site-cta w-full border-0"
+        disabled={!canCheckout}
+        onClick={() => navigate(`/book/${orgSlug}/property/${property.id}/checkout?checkIn=${checkIn}&checkOut=${checkOut}`)}
+      >
+        {t('publicBooking.proceedToCheckout')}
+      </Button>
+    </div>
+  );
+}
+
+export function BookingWidget(props: BookingWidgetProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="hidden md:block md:sticky md:top-6">
+        <WidgetForm {...props} />
+      </div>
+
+      <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-[var(--cz-public-surface)] p-3 shadow-[var(--cz-public-shadow-widget)] md:hidden">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button className="public-site-cta w-full border-0">{t('publicSite.mobileBookingCta')}</Button>
+          </SheetTrigger>
+          <SheetContent side="right" className="max-h-[85vh] overflow-y-auto rounded-t-2xl sm:max-w-md">
+            <SheetHeader>
+              <SheetTitle>{t('publicBooking.propertyTitle')}</SheetTitle>
+            </SheetHeader>
+            <div className="mt-4">
+              <WidgetForm {...props} compact />
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </>
+  );
+}

--- a/src/features/public-site/components/Footer.tsx
+++ b/src/features/public-site/components/Footer.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from 'react-i18next';
+
+interface FooterProps {
+  displayName?: string;
+  contactEmail?: string;
+  showPoweredBy?: boolean;
+}
+
+export function Footer({ displayName, contactEmail, showPoweredBy = false }: FooterProps) {
+  const { t } = useTranslation();
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="border-t border-black/10 py-8 text-sm text-[var(--cz-public-muted)]">
+      <div className="mx-auto flex max-w-[1200px] flex-col items-center gap-4 px-4 text-center">
+        <div className="flex flex-wrap justify-center gap-4">
+          <a href="https://casazen.app/privacy" target="_blank" rel="noopener noreferrer" className="underline hover:text-[var(--cz-public-primary)]">
+            {t('publicSite.privacy')}
+          </a>
+          <a href="https://casazen.app/terms" target="_blank" rel="noopener noreferrer" className="underline hover:text-[var(--cz-public-primary)]">
+            {t('publicSite.terms')}
+          </a>
+          {contactEmail ? (
+            <a href={`mailto:${contactEmail}`} className="underline hover:text-[var(--cz-public-primary)]">
+              {contactEmail}
+            </a>
+          ) : null}
+        </div>
+        {displayName ? <p>© {year} {displayName}</p> : null}
+        {showPoweredBy ? (
+          <p className="text-xs">{t('publicSite.poweredBy')}</p>
+        ) : null}
+      </div>
+    </footer>
+  );
+}

--- a/src/features/public-site/components/Hero.tsx
+++ b/src/features/public-site/components/Hero.tsx
@@ -1,0 +1,37 @@
+interface HeroProps {
+  imageUrl?: string | null;
+  title: string;
+  tagline?: string | null;
+  ctaLabel?: string;
+  onCta?: () => void;
+}
+
+export function Hero({ imageUrl, title, tagline, ctaLabel, onCta }: HeroProps) {
+  return (
+    <section className="relative -mx-4 mb-[var(--cz-public-section-y)] overflow-hidden sm:mx-0 sm:rounded-[var(--cz-public-radius)]">
+      <div className="relative aspect-[16/9] max-h-[420px] w-full">
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt=""
+            className="h-full w-full object-cover"
+            fetchPriority="high"
+            decoding="async"
+          />
+        ) : (
+          <div className="h-full w-full bg-gradient-to-br from-[var(--cz-public-primary)]/30 to-[var(--cz-public-bg)]" />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
+        <div className="absolute inset-x-0 bottom-0 p-6 text-white md:p-10">
+          <h1 className="public-display text-3xl font-semibold md:text-5xl">{title}</h1>
+          {tagline ? <p className="mt-2 max-w-2xl text-base text-white/90 md:text-lg">{tagline}</p> : null}
+          {ctaLabel && onCta ? (
+            <button type="button" onClick={onCta} className="public-site-cta mt-4 rounded-[var(--cz-public-radius)] px-5 py-2.5 text-sm font-medium">
+              {ctaLabel}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/public-site/components/PropertyGallery.tsx
+++ b/src/features/public-site/components/PropertyGallery.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+
+interface PropertyGalleryProps {
+  photoUrls: string[];
+  alt: string;
+}
+
+export function PropertyGallery({ photoUrls, alt }: PropertyGalleryProps) {
+  const { t } = useTranslation();
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const photos = photoUrls.length > 0 ? photoUrls : [];
+
+  if (photos.length === 0) {
+    return (
+      <div className="flex aspect-video items-center justify-center rounded-[var(--cz-public-radius)] bg-[var(--cz-public-surface)] text-5xl">
+        🏠
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className="flex snap-x snap-mandatory gap-3 overflow-x-auto pb-2 md:grid md:grid-cols-2 md:overflow-visible md:snap-none"
+        aria-label={t('publicSite.galleryLabel', { name: alt })}
+        role="region"
+      >
+        {photos.map((url, index) => (
+          <button
+            key={`${url}-${index}`}
+            type="button"
+            className="public-site-card min-w-[85%] shrink-0 snap-center overflow-hidden md:min-w-0"
+            onClick={() => setLightboxIndex(index)}
+            aria-label={t('publicSite.openPhoto', { index: index + 1, total: photos.length })}
+          >
+            <img
+              src={url}
+              alt={t('publicSite.photoAlt', { name: alt, index: index + 1 })}
+              className="aspect-[4/3] w-full object-cover"
+              loading={index === 0 ? 'eager' : 'lazy'}
+              decoding="async"
+            />
+          </button>
+        ))}
+      </div>
+
+      <Dialog open={lightboxIndex !== null} onOpenChange={(open) => !open && setLightboxIndex(null)}>
+        <DialogContent className="max-w-4xl border-0 bg-black p-2">
+          {lightboxIndex !== null ? (
+            <img src={photos[lightboxIndex]} alt={alt} className="max-h-[80vh] w-full object-contain" />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/settings/vetrina-page.tsx
+++ b/src/features/settings/vetrina-page.tsx
@@ -3,7 +3,6 @@ import { PageHeader } from '@/components/layout/page-header';
 import { Card, CardContent } from '@/components/ui/card';
 import { useCurrentUser } from '@/queries/use-users';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 import { ExternalLink, Globe } from 'lucide-react';
 
 export function VetrinaPage() {
@@ -31,13 +30,15 @@ export function VetrinaPage() {
                   <p className="text-sm text-muted-foreground">
                     {t('directBooking.visitDescription')}
                   </p>
-                  <Link
-                    to={bookingSiteUrl}
+                  <a
+                    href={bookingSiteUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-sm font-medium"
                   >
-                    {t('directBooking.visitSite', { siteName: org?.name ?? 'il sito' })}
+                    {t('publicSite.preview')}
                     <ExternalLink className="h-4 w-4" />
-                  </Link>
+                  </a>
                 </div>
               </div>
             </CardContent>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -180,6 +180,7 @@
     "profile": "Profile",
     "plan": "Plan & Billing",
     "bookings": "Bookings",
+    "marketplace": "Marketplace",
     "calendar": "Calendar",
     "alloggiati": "Alloggiati",
     "cin": "CIN",
@@ -1096,6 +1097,13 @@
   "serviceRequest": {
     "requestSupplier": "Request supplier",
     "requestDescription": "Send a service request to an active supplier in your property's area.",
+    "aiMatchDescription": "CasaZen AI picks the best supplier for your property and intervention type.",
+    "aiRecommendation": "AI recommendation",
+    "matching": "Finding the best supplier...",
+    "selectedSupplier": "Selected supplier",
+    "externalFallbackIntro": "No CasaZen suppliers available nearby. Here are top-rated local businesses from Google:",
+    "noExternalResults": "No external results found. Try a different category or contact support.",
+    "website": "Website",
     "category": "Category",
     "supplier": "Supplier",
     "selectSupplier": "Select supplier",
@@ -1156,6 +1164,20 @@
     "copied": "Copied",
     "legendBooking": "Booking",
     "legendIcalBlock": "OTA block (iCal)"
+  },
+  "marketplace": {
+    "title": "Service Marketplace",
+    "description": "Manage supplier requests for cleaning, maintenance and property services.",
+    "requestsTitle": "Your requests",
+    "requestsDescription": "All service requests across your properties.",
+    "noRequests": "No service requests yet.",
+    "noRequestsHint": "Open a booking and use \"Request supplier\" to create your first intervention.",
+    "viewBooking": "View booking",
+    "quickActions": "Quick actions",
+    "goToBookings": "Go to bookings",
+    "goToProperties": "Go to properties",
+    "propertiesTitle": "Your properties",
+    "propertiesDescription": "Request services from a property or booking detail page."
   },
   "supplier": {
     "profileLoading": "Loading profile...",
@@ -1848,6 +1870,23 @@
     "guestEmailPlaceholder": "guest@example.com",
     "generateError": "Failed to generate check-in link. Please try again.",
     "checkinEmailBody": "Dear guest,\n\nClick the link below to complete your check-in:\n\n{{url}}\n\nCasaZen"
+  },
+  "publicSite": {
+    "skipToContent": "Skip to content",
+    "navProperties": "Properties",
+    "navMyBookings": "My bookings",
+    "openMenu": "Open menu",
+    "privacy": "Privacy Policy",
+    "terms": "Terms of Service",
+    "poweredBy": "Powered by CasaZen",
+    "preview": "Preview site",
+    "explore": "Explore",
+    "viewProperties": "View properties",
+    "ourProperties": "Our properties",
+    "mobileBookingCta": "Check availability",
+    "galleryLabel": "Photo gallery for {{name}}",
+    "openPhoto": "Open photo {{index}} of {{total}}",
+    "photoAlt": "{{name}} — photo {{index}}"
   },
   "publicBooking": {
     "payNow": "Pay now",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -180,6 +180,7 @@
     "profile": "Profilo",
     "plan": "Piano e Fatturazione",
     "bookings": "Prenotazioni",
+    "marketplace": "Marketplace",
     "calendar": "Calendario",
     "alloggiati": "Alloggiati",
     "cin": "CIN",
@@ -1098,6 +1099,13 @@
   "serviceRequest": {
     "requestSupplier": "Richiedi fornitore",
     "requestDescription": "Invia una richiesta di servizio a un fornitore attivo nel comune della proprietà.",
+    "aiMatchDescription": "L'AI CasaZen seleziona il fornitore migliore per la tua proprietà e il tipo di intervento.",
+    "aiRecommendation": "Raccomandazione AI",
+    "matching": "Ricerca del fornitore migliore...",
+    "selectedSupplier": "Fornitore selezionato",
+    "externalFallbackIntro": "Nessun fornitore CasaZen disponibile nelle vicinanze. Ecco le attività locali più votate su Google:",
+    "noExternalResults": "Nessun risultato esterno. Prova un'altra categoria o contatta il supporto.",
+    "website": "Sito web",
     "category": "Categoria",
     "supplier": "Fornitore",
     "selectSupplier": "Seleziona fornitore",
@@ -1158,6 +1166,20 @@
     "copied": "Copiato",
     "legendBooking": "Prenotazione",
     "legendIcalBlock": "Blocco OTA (iCal)"
+  },
+  "marketplace": {
+    "title": "Marketplace servizi",
+    "description": "Gestisci le richieste di fornitori per pulizie, manutenzione e servizi immobile.",
+    "requestsTitle": "Le tue richieste",
+    "requestsDescription": "Tutte le richieste di servizio sulle tue proprietà.",
+    "noRequests": "Nessuna richiesta di servizio.",
+    "noRequestsHint": "Apri una prenotazione e usa \"Richiedi fornitore\" per creare il primo intervento.",
+    "viewBooking": "Vedi prenotazione",
+    "quickActions": "Azioni rapide",
+    "goToBookings": "Vai alle prenotazioni",
+    "goToProperties": "Vai alle proprietà",
+    "propertiesTitle": "Le tue proprietà",
+    "propertiesDescription": "Richiedi servizi dalla scheda proprietà o dal dettaglio prenotazione."
   },
   "supplier": {
     "profileLoading": "Caricamento profilo...",
@@ -1850,6 +1872,23 @@
     "guestEmailPlaceholder": "ospite@esempio.com",
     "generateError": "Impossibile generare il link di check-in. Riprova.",
     "checkinEmailBody": "Gentile ospite,\n\nClicca sul link sottostante per completare il check-in:\n\n{{url}}\n\nCasaZen"
+  },
+  "publicSite": {
+    "skipToContent": "Vai al contenuto",
+    "navProperties": "Strutture",
+    "navMyBookings": "Le mie prenotazioni",
+    "openMenu": "Apri menu",
+    "privacy": "Privacy Policy",
+    "terms": "Termini di servizio",
+    "poweredBy": "Powered by CasaZen",
+    "preview": "Anteprima sito",
+    "explore": "Esplora",
+    "viewProperties": "Scopri le strutture",
+    "ourProperties": "Le nostre strutture",
+    "mobileBookingCta": "Verifica disponibilità",
+    "galleryLabel": "Galleria foto di {{name}}",
+    "openPhoto": "Apri foto {{index}} di {{total}}",
+    "photoAlt": "{{name}} — foto {{index}}"
   },
   "publicBooking": {
     "payNow": "Paga ora",

--- a/src/layouts/PublicSiteShell.tsx
+++ b/src/layouts/PublicSiteShell.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { Link, NavLink, Outlet, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Loader2, Menu } from 'lucide-react';
+import { usePublicOrg } from '@/queries/use-public-org';
+import { CookieConsentBanner } from '@/components/shared/cookie-consent-banner';
+import { PublicOrgNotFoundPage } from '@/features/public-booking/public-org-not-found-page';
+import { Footer } from '@/features/public-site/components/Footer';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import '@/styles/public-tokens.css';
+
+interface PublicSiteShellProps {
+  mode?: 'org' | 'default';
+}
+
+export function PublicSiteShell({ mode = 'org' }: PublicSiteShellProps) {
+  const { t } = useTranslation();
+  const { orgSlug } = useParams<{ orgSlug: string }>();
+  const isOrgMode = mode === 'org' && !!orgSlug;
+  const { data: org, isLoading, isError } = usePublicOrg(isOrgMode ? orgSlug : undefined);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const themeId = org?.publicThemeId ?? 'mare';
+  const primaryColor = org?.themeColor ?? undefined;
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (primaryColor) {
+      root.style.setProperty('--cz-public-primary', primaryColor);
+    }
+    return () => {
+      root.style.removeProperty('--cz-public-primary');
+    };
+  }, [primaryColor]);
+
+  if (isOrgMode) {
+    if (isLoading) {
+      return (
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin" />
+        </div>
+      );
+    }
+    if (isError || !org) return <PublicOrgNotFoundPage />;
+  }
+
+  const displayName = org?.displayName ?? 'CasaZen';
+  const navLinks = isOrgMode && orgSlug ? (
+    <>
+      <NavLink to={`/book/${orgSlug}`} className={({ isActive }) => `block py-2 ${isActive ? 'font-semibold text-[var(--cz-public-primary)]' : ''}`}>
+        {t('publicSite.navProperties')}
+      </NavLink>
+      <NavLink to={`/book/${orgSlug}/my-bookings`} className={({ isActive }) => `block py-2 ${isActive ? 'font-semibold text-[var(--cz-public-primary)]' : ''}`}>
+        {t('publicSite.navMyBookings')}
+      </NavLink>
+    </>
+  ) : null;
+
+  return (
+    <div
+      className="public-site-root flex min-h-screen flex-col"
+      data-theme={themeId}
+      data-testid="public-site-shell"
+    >
+      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-white focus:px-3 focus:py-2">
+        {t('publicSite.skipToContent')}
+      </a>
+
+      <header className="border-b border-black/10 bg-[var(--cz-public-surface)]">
+        <div className="mx-auto flex max-w-[1200px] items-center justify-between gap-4 px-4 py-4">
+          <div className="flex items-center gap-3">
+            {org?.logoUrl ? (
+              <img src={org.logoUrl} alt={displayName} className="h-10 w-auto object-contain" />
+            ) : (
+              <span className="public-display text-lg font-semibold">CasaZen</span>
+            )}
+            <span className="public-display text-lg font-medium">{displayName}</span>
+          </div>
+
+          {isOrgMode ? (
+            <>
+              <nav className="hidden items-center gap-6 text-sm md:flex">{navLinks}</nav>
+              <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
+                <SheetTrigger className="md:hidden" aria-label={t('publicSite.openMenu')}>
+                  <Menu className="h-6 w-6" />
+                </SheetTrigger>
+                <SheetContent side="right" className="w-72">
+                  <nav className="mt-8 flex flex-col gap-2 text-base" onClick={() => setMenuOpen(false)}>
+                    {navLinks}
+                  </nav>
+                </SheetContent>
+              </Sheet>
+            </>
+          ) : (
+            <Link to="/search" className="text-sm underline hover:text-[var(--cz-public-primary)]">
+              {t('publicSite.explore')}
+            </Link>
+          )}
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto w-full max-w-[1200px] flex-1 px-4 py-8 pb-24 md:pb-8">
+        {isOrgMode ? <Outlet context={{ org }} /> : <Outlet />}
+      </main>
+
+      <Footer
+        displayName={isOrgMode ? org?.displayName : 'CasaZen'}
+        contactEmail={org?.contactEmail}
+        showPoweredBy={org?.showPoweredBy ?? !isOrgMode}
+      />
+
+      {isOrgMode ? <CookieConsentBanner /> : null}
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,7 +13,7 @@ import { OnboardingPage } from '@/features/onboarding/onboarding-page';
 import { ROUTE_MANIFEST, type AppContextKey } from '@/config/route-manifest';
 import { LegacyRedirect } from './legacy-redirect';
 import { ManifestRoute } from './manifest-route';
-import { PublicBookingShell } from '@/components/layout/public-booking-shell';
+import { PublicSiteShell } from '@/layouts/PublicSiteShell';
 import { OrgLandingPage } from '@/features/public-booking/org-landing-page';
 import { PublicPropertyPage } from '@/features/public-booking/public-property-page';
 import { CheckoutPage } from '@/features/public-booking/checkout-page';
@@ -125,12 +125,19 @@ export const router = createBrowserRouter([
   },
   {
     path: '/book/:orgSlug',
-    element: <PublicBookingShell />,
+    element: <PublicSiteShell mode="org" />,
     children: [
       { index: true, element: <OrgLandingPage /> },
       { path: 'my-bookings', element: <GuestBookingsPage /> },
       { path: 'property/:propertyId', element: <PublicPropertyPage /> },
       { path: 'property/:propertyId/checkout', element: <CheckoutPage /> },
+    ],
+  },
+  {
+    element: <PublicSiteShell mode="default" />,
+    children: [
+      { path: '/p/affitti-brevi/:region/:comune', element: <ComplianceGuidePage /> },
+      { path: '/p/tassa-soggiorno/:comune', element: <TouristTaxCalculatorPage /> },
     ],
   },
   {
@@ -144,14 +151,6 @@ export const router = createBrowserRouter([
   {
     path: '/checkin/:token',
     element: <CheckInPage />,
-  },
-  {
-    path: '/p/affitti-brevi/:region/:comune',
-    element: <ComplianceGuidePage />,
-  },
-  {
-    path: '/p/tassa-soggiorno/:comune',
-    element: <TouristTaxCalculatorPage />,
   },
   {
     path: '/supplier',

--- a/src/styles/public-tokens.css
+++ b/src/styles/public-tokens.css
@@ -1,0 +1,53 @@
+[data-theme='mare'],
+[data-theme='montagna'],
+[data-theme='urban'] {
+  --cz-public-font-display: 'Fraunces', Georgia, serif;
+  --cz-public-font-body: 'Inter', system-ui, sans-serif;
+  --cz-public-primary: #e07a5f;
+  --cz-public-bg: #f5f0e8;
+  --cz-public-surface: #ffffff;
+  --cz-public-text: #1a2b3c;
+  --cz-public-muted: #5c6b7a;
+  --cz-public-radius: 12px;
+  --cz-public-shadow-widget: 0 8px 32px rgba(0, 0, 0, 0.12);
+  --cz-public-section-y: 4rem;
+}
+
+@media (max-width: 767px) {
+  [data-theme='mare'],
+  [data-theme='montagna'],
+  [data-theme='urban'] {
+    --cz-public-section-y: 2rem;
+  }
+}
+
+.public-site-root {
+  background: var(--cz-public-bg);
+  color: var(--cz-public-text);
+  font-family: var(--cz-public-font-body);
+  min-height: 100vh;
+}
+
+.public-site-root h1,
+.public-site-root h2,
+.public-site-root .public-display {
+  font-family: var(--cz-public-font-display);
+}
+
+.public-site-root a:focus-visible,
+.public-site-root button:focus-visible,
+.public-site-root input:focus-visible {
+  outline: 2px solid var(--cz-public-primary);
+  outline-offset: 2px;
+}
+
+.public-site-cta {
+  background: var(--cz-public-primary);
+  color: #fff;
+}
+
+.public-site-card {
+  background: var(--cz-public-surface);
+  border-radius: var(--cz-public-radius);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}

--- a/src/types/org.types.ts
+++ b/src/types/org.types.ts
@@ -35,11 +35,15 @@ export interface PlanCatalogEntry {
   description: string;
 }
 
-/** Anonymous branding read-model for /book/:orgSlug (US-003 #215). */
+/** Anonymous branding read-model for /book/:orgSlug (US-003 #215, US-023 #297). */
 export interface PublicOrgDto {
   slug: string;
   displayName: string;
   logoUrl: string | null;
   themeColor: string | null;
   contactEmail: string;
+  heroImageUrl?: string | null;
+  tagline?: string | null;
+  publicThemeId?: string | null;
+  showPoweredBy?: boolean;
 }


### PR DESCRIPTION
## Summary
- PublicSiteShell replaces PublicBookingShell on /book/* and /p/* routes
- Mare design tokens + Hero, PropertyGallery, AmenityGrid, BookingWidget, Footer
- i18n publicSite.* keys, E2E testid public-site-shell

## Backend PR
https://github.com/casazen/backend/pull/TBD

## Test Plan
- [x] npm run build
- [ ] npm run test:e2e:local with BE branch

Closes casazen/backend#297

Made with [Cursor](https://cursor.com)