### PR TITLE
feat(public-site): vetrina navigation UX pass 1 (#338)

### DIFF
--- a/e2e/branded-booking-site.spec.ts
+++ b/e2e/branded-booking-site.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from './test';
 import {
   DEMO_ORG_SLUG,
   mockBrandedBookingApi,
+  mockOrgProperties,
   mockOrgPropertyId,
   mockPublicOrg,
 } from './helpers/branded-booking-mock';
@@ -11,6 +12,7 @@ test.describe('Branded booking site (#215)', () => {
     await mockBrandedBookingApi(page);
     await page.addInitScript(() => {
       localStorage.removeItem('casazen_cookie_consent');
+      localStorage.setItem('casazen.locale', 'it');
     });
   });
 
@@ -20,7 +22,7 @@ test.describe('Branded booking site (#215)', () => {
     await expect(page.getByTestId('public-site-shell')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByRole('heading', { level: 1, name: mockPublicOrg.displayName, exact: true })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Trastevere Suite' })).toBeVisible();
-    await expect(page.getByText('CIN valido')).toBeVisible();
+    await expect(page.getByText('CIN valido').first()).toBeVisible();
     await expect(page).not.toHaveURL(/\/login/);
   });
 
@@ -108,5 +110,65 @@ test.describe('Branded booking site (#215)', () => {
     // In demo mode the protected routes are bypassed, but in non-demo they redirect
     // We verify the page is NOT the public booking shell (no auth chrome on /book)
     await expect(page.getByTestId('public-site-shell')).not.toBeAttached();
+  });
+});
+
+test.describe('Vetrina navigation UX pass 1 (#338)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBrandedBookingApi(page);
+    await page.addInitScript(() => {
+      localStorage.removeItem('casazen_cookie_consent');
+      localStorage.setItem('casazen.locale', 'it');
+    });
+  });
+
+  test('AC2: property detail shows breadcrumb org > property', async ({ page }) => {
+    await page.goto(`/book/${DEMO_ORG_SLUG}/property/${mockOrgPropertyId}`);
+
+    const breadcrumb = page.getByTestId('public-breadcrumb');
+    await expect(breadcrumb).toBeVisible({ timeout: 15_000 });
+    await expect(breadcrumb.getByText(mockPublicOrg.displayName)).toBeVisible();
+    await expect(breadcrumb.getByText('Trastevere Suite')).toBeVisible();
+  });
+
+  test('AC3: URL params persist on property detail and checkout', async ({ page }) => {
+    await page.goto(
+      `/book/${DEMO_ORG_SLUG}/property/${mockOrgPropertyId}?checkIn=2026-08-01&checkOut=2026-08-05&guests=3`,
+    );
+
+    await expect(page.getByTestId('public-property-page')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('#check-in')).toHaveValue('2026-08-01');
+    await expect(page.locator('#check-out')).toHaveValue('2026-08-05');
+    await expect(page.locator('#guests')).toHaveValue('3');
+
+    await page.getByRole('button', { name: 'Procedi al checkout' }).click();
+    await expect(page).toHaveURL(/checkIn=2026-08-01/);
+    await expect(page).toHaveURL(/checkOut=2026-08-05/);
+    await expect(page).toHaveURL(/guests=3/);
+    await expect(page.getByTestId('public-breadcrumb')).toContainText('Checkout');
+  });
+
+  test('AC4: single-property org redirects landing to property detail', async ({ page }) => {
+    await page.route(`**/api/public/orgs/${DEMO_ORG_SLUG}/properties`, async (route) => {
+      const url = route.request().url();
+      if (route.request().method() !== 'GET' || !url.endsWith('/properties')) {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([mockOrgProperties[0]]),
+      });
+    });
+
+    await page.goto(`/book/${DEMO_ORG_SLUG}?checkIn=2026-09-01&checkOut=2026-09-03`);
+
+    await expect(page).toHaveURL(
+      new RegExp(`/book/${DEMO_ORG_SLUG}/property/${mockOrgPropertyId}`),
+      { timeout: 15_000 },
+    );
+    await expect(page).toHaveURL(/checkIn=2026-09-01/);
+    await expect(page.getByTestId('public-property-page')).toBeVisible();
   });
 });

--- a/e2e/golden-journey-web.spec.ts
+++ b/e2e/golden-journey-web.spec.ts
@@ -15,6 +15,7 @@ test.describe('Golden Journey web (#301)', () => {
     await mockBrandedBookingApi(page);
     await page.addInitScript(() => {
       localStorage.removeItem('casazen_cookie_consent');
+      localStorage.setItem('casazen.locale', 'it');
     });
   });
 

--- a/e2e/helpers/branded-booking-mock.ts
+++ b/e2e/helpers/branded-booking-mock.ts
@@ -12,6 +12,7 @@ export const mockPublicOrg: PublicOrgDto = {
 };
 
 export const mockOrgPropertyId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+export const mockOrgPropertyId2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 
 export const mockOrgProperties: PublicPropertyDto[] = [
   {
@@ -28,6 +29,23 @@ export const mockOrgProperties: PublicPropertyDto[] = [
     amenities: ['Wifi', 'Aria condizionata'],
     photoUrls: ['https://cdn.example.com/trastevere-suite.jpg'],
     cinCode: 'IT-12345-0123456789',
+    cinStatus: 'Valid',
+    timezone: 'Europe/Rome',
+  },
+  {
+    id: mockOrgPropertyId2,
+    name: 'Centro Storico Loft',
+    description: 'Loft nel centro storico.',
+    city: 'Roma',
+    postalCode: '00186',
+    bedrooms: 1,
+    bathrooms: 1,
+    maxGuests: 2,
+    nightlyRate: 120,
+    cleaningFee: 40,
+    amenities: ['Wifi'],
+    photoUrls: [],
+    cinCode: 'IT-12345-0987654321',
     cinStatus: 'Valid',
     timezone: 'Europe/Rome',
   },

--- a/src/features/properties/property-detail-page.tsx
+++ b/src/features/properties/property-detail-page.tsx
@@ -9,8 +9,9 @@ import { Badge } from '@/components/ui/badge';
 import { Breadcrumb } from '@/components/shared/breadcrumb';
 import { LoadingScreen } from '@/components/shared/loading-screen';
 import { usePropertyDetail } from '@/queries/use-properties';
+import { useCurrentUser } from '@/queries/use-users';
 import { useUpdatePropertyCin } from '@/queries/use-cin';
-import { Edit, ArrowRight, Sparkles } from 'lucide-react';
+import { Edit, ArrowRight, Sparkles, ExternalLink } from 'lucide-react';
 import { PropertyCinBadge } from './components/property-cin-badge';
 import { PropertyCinDialog } from './components/property-cin-dialog';
 import { PropertyPhotoCarousel } from './components/property-photo-carousel';
@@ -31,6 +32,7 @@ export function PropertyDetailPage() {
   const [cinDialogOpen, setCinDialogOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<PropertyTab>('info');
   const { data: property, isLoading, isError } = usePropertyDetail(id!);
+  const { org } = useCurrentUser();
   const updateCin = useUpdatePropertyCin();
 
   if (isLoading) {
@@ -81,6 +83,23 @@ export function PropertyDetailPage() {
             </div>
           }
         />
+
+        {org?.slug ? (
+          <Card data-testid="host-public-site-link">
+            <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+              <p className="text-sm text-muted-foreground">{t('property.detail.publicSiteHint')}</p>
+              <a
+                href={`/book/${org.slug}/property/${property.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+              >
+                {t('property.detail.viewOnPublicSite')}
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            </CardContent>
+          </Card>
+        ) : null}
 
         <Link
           to={`/app/short-rent/bookings?propertyId=${property.id}`}

--- a/src/features/public-booking/checkout-page.tsx
+++ b/src/features/public-booking/checkout-page.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect } from 'react';
-import { Link, useOutletContext, useParams, useSearchParams } from 'react-router-dom';
+import { Link, useOutletContext, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js';
@@ -14,7 +14,9 @@ import { Label } from '@/components/ui/label';
 import { isDemoMode } from '@/config/demo.config';
 import type { DirectBookingResponse, PublicOrgDto, PaymentOption } from '@/types';
 import { DIRECT_CHECKOUT_CONSENT_VERSION } from '@/types/direct-booking.types';
-import { ArrowLeft, Loader2, CheckCircle2 } from 'lucide-react';
+import { Loader2, CheckCircle2 } from 'lucide-react';
+import { PublicBreadcrumb } from '@/features/public-site/components/PublicBreadcrumb';
+import { useBookingSearchParams } from '@/features/public-site/hooks/use-booking-search-params';
 
 interface PublicBookingContext {
   org: PublicOrgDto;
@@ -214,9 +216,9 @@ export function CheckoutPage() {
   const { t, i18n } = useTranslation();
   const { orgSlug, propertyId } = useParams<{ orgSlug: string; propertyId: string }>();
   const { org } = useOutletContext<PublicBookingContext>();
-  const [searchParams] = useSearchParams();
-  const checkIn = searchParams.get('checkIn') ?? '';
-  const checkOut = searchParams.get('checkOut') ?? '';
+  const { params, toQueryString } = useBookingSearchParams();
+  const checkIn = params.checkIn;
+  const checkOut = params.checkOut;
   const nights = useMemo(() => nightsBetween(checkIn, checkOut), [checkIn, checkOut]);
 
   const { data: property, isLoading } = useOrgPublicProperty(orgSlug, propertyId);
@@ -303,14 +305,18 @@ export function CheckoutPage() {
     return <ConfirmationScreen bookingResult={bookingResult} org={org} orgSlug={orgSlug} t={t} i18n={i18n} />;
   }
 
+  const basePath = `/book/${orgSlug}`;
+  const propertyQuery = toQueryString();
+
   return (
     <div className="mx-auto max-w-lg space-y-6" data-testid="direct-checkout-page">
-      <Button asChild variant="ghost" className="px-0">
-        <Link to={`/book/${orgSlug}/property/${propertyId}`}>
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          {t('publicBooking.backToProperty')}
-        </Link>
-      </Button>
+      <PublicBreadcrumb
+        segments={[
+          { label: org.displayName, href: basePath },
+          { label: property?.name ?? t('publicBooking.propertyFallback'), href: `${basePath}/property/${propertyId}${propertyQuery}` },
+          { label: t('publicSite.breadcrumbCheckout') },
+        ]}
+      />
 
       <h2 className="text-2xl font-bold">{t('publicBooking.checkoutTitle', { propertyName: property?.name ?? 'Struttura' })}</h2>
 

--- a/src/features/public-booking/org-landing-page.tsx
+++ b/src/features/public-booking/org-landing-page.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense } from 'react';
-import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
+import { lazy, Suspense, useEffect } from 'react';
+import { useNavigate, useOutletContext, useParams, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useOrgProperties } from '@/queries/use-public-org';
 import { PropertySearchCard } from '@/features/search/components/property-search-card';
@@ -17,11 +17,28 @@ export function OrgLandingPage() {
   const { orgSlug } = useParams<{ orgSlug: string }>();
   const { org } = useOutletContext<PublicBookingContext>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { data: properties = [], isLoading } = useOrgProperties(orgSlug);
 
+  useEffect(() => {
+    if (!isLoading && properties.length === 1) {
+      const query = searchParams.toString();
+      navigate(`/book/${orgSlug}/property/${properties[0].id}${query ? `?${query}` : ''}`, { replace: true });
+    }
+  }, [isLoading, properties, orgSlug, navigate, searchParams]);
+
   const handleViewDetails = (property: PublicPropertyDto) => {
-    navigate(`/book/${orgSlug}/property/${property.id}`);
+    const query = searchParams.toString();
+    navigate(`/book/${orgSlug}/property/${property.id}${query ? `?${query}` : ''}`);
   };
+
+  if (!isLoading && properties.length === 1) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-[var(--cz-public-primary)]" />
+      </div>
+    );
+  }
 
   const heroImage = org.heroImageUrl ?? properties[0]?.photoUrls?.[0] ?? null;
 

--- a/src/features/public-booking/public-property-page.tsx
+++ b/src/features/public-booking/public-property-page.tsx
@@ -5,10 +5,11 @@ import { useOrgPublicProperty, usePropertyAvailability } from '@/queries/use-pub
 import { PropertyCinBadge } from '@/features/properties/components/property-cin-badge';
 import { AiContentNotice } from '@/components/shared/ai-content-notice';
 import { Button } from '@/components/ui/button';
+import { PublicBreadcrumb } from '@/features/public-site/components/PublicBreadcrumb';
+import { useBookingSearchParams } from '@/features/public-site/hooks/use-booking-search-params';
 import type { PublicOrgDto } from '@/types';
-import { ArrowLeft, Bed, Bath, Loader2, Users } from 'lucide-react';
+import { Bed, Bath, Loader2, Users } from 'lucide-react';
 
-const Hero = lazy(() => import('@/features/public-site/components/Hero').then((m) => ({ default: m.Hero })));
 const PropertyGallery = lazy(() => import('@/features/public-site/components/PropertyGallery').then((m) => ({ default: m.PropertyGallery })));
 const AmenityGrid = lazy(() => import('@/features/public-site/components/AmenityGrid').then((m) => ({ default: m.AmenityGrid })));
 const BookingWidget = lazy(() => import('@/features/public-site/components/BookingWidget').then((m) => ({ default: m.BookingWidget })));
@@ -23,6 +24,7 @@ export function PublicPropertyPage() {
   const { org } = useOutletContext<PublicBookingContext>();
   const { data: property, isLoading, isError } = useOrgPublicProperty(orgSlug, propertyId);
   const { data: availability } = usePropertyAvailability(propertyId);
+  const { toQueryString } = useBookingSearchParams();
 
   if (isLoading) {
     return (
@@ -43,18 +45,17 @@ export function PublicPropertyPage() {
     );
   }
 
-  return (
-    <div className="space-y-8">
-      <Button asChild variant="ghost" className="px-0">
-        <Link to={`/book/${orgSlug}`}>
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          {t('publicBooking.backToOrg', { orgName: org.displayName })}
-        </Link>
-      </Button>
+  const basePath = `/book/${orgSlug}`;
+  const query = toQueryString();
 
-      <Suspense fallback={null}>
-        <Hero imageUrl={property.photoUrls[0]} title={property.name} tagline={property.city} />
-      </Suspense>
+  return (
+    <div className="space-y-8" data-testid="public-property-page">
+      <PublicBreadcrumb
+        segments={[
+          { label: org.displayName, href: basePath },
+          { label: property.name },
+        ]}
+      />
 
       <div className="grid gap-8 lg:grid-cols-[1fr_320px] lg:items-start">
         <div className="space-y-8">
@@ -65,7 +66,7 @@ export function PublicPropertyPage() {
           <div className="space-y-4">
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
-                <h2 className="public-display text-2xl font-semibold">{property.name}</h2>
+                <h1 className="public-display text-2xl font-semibold">{property.name}</h1>
                 <p className="text-[var(--cz-public-muted)]">
                   {property.city}
                   {property.postalCode ? ` (${property.postalCode})` : ''}
@@ -85,7 +86,7 @@ export function PublicPropertyPage() {
 
             {property.amenities.length > 0 ? (
               <div className="space-y-3">
-                <h3 className="font-semibold">{t('publicBooking.servicesTitle')}</h3>
+                <h2 className="font-semibold">{t('publicBooking.servicesTitle')}</h2>
                 <Suspense fallback={null}>
                   <AmenityGrid amenities={property.amenities} />
                 </Suspense>
@@ -94,14 +95,14 @@ export function PublicPropertyPage() {
 
             {property.houseRules ? (
               <div>
-                <h3 className="font-semibold mb-2">{t('publicBooking.rulesTitle')}</h3>
+                <h2 className="mb-2 font-semibold">{t('publicBooking.rulesTitle')}</h2>
                 <p className="text-sm whitespace-pre-wrap">{property.houseRules}</p>
               </div>
             ) : null}
 
             {property.cancellationPolicySummary ? (
               <div>
-                <h3 className="font-semibold mb-2">{t('publicBooking.cancellationTitle')}</h3>
+                <h2 className="mb-2 font-semibold">{t('publicBooking.cancellationTitle')}</h2>
                 <p className="text-sm text-[var(--cz-public-muted)]">{property.cancellationPolicySummary}</p>
               </div>
             ) : null}
@@ -109,7 +110,7 @@ export function PublicPropertyPage() {
         </div>
 
         <Suspense fallback={null}>
-          <BookingWidget property={property} availability={availability} orgSlug={orgSlug!} />
+          <BookingWidget property={property} availability={availability} orgSlug={orgSlug!} querySuffix={query} />
         </Suspense>
       </div>
     </div>

--- a/src/features/public-site/components/BookingWidget.tsx
+++ b/src/features/public-site/components/BookingWidget.tsx
@@ -1,12 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { formatCurrency } from '@/lib/utils';
+import { useBookingSearchParams } from '@/features/public-site/hooks/use-booking-search-params';
 import type { PublicPropertyDetailDto } from '@/types';
 
 interface Availability {
@@ -17,6 +17,7 @@ interface BookingWidgetProps {
   property: PublicPropertyDetailDto;
   availability?: Availability;
   orgSlug: string;
+  querySuffix?: string;
 }
 
 function nightsBetween(checkIn: string, checkOut: string): number {
@@ -29,12 +30,17 @@ function WidgetForm({
   property,
   availability,
   orgSlug,
+  querySuffix = '',
   compact = false,
-}: BookingWidgetProps & { compact?: boolean }) {
+  onCheckout,
+}: BookingWidgetProps & { compact?: boolean; onCheckout?: () => void }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [checkIn, setCheckIn] = useState('');
-  const [checkOut, setCheckOut] = useState('');
+  const { params, setParams } = useBookingSearchParams();
+
+  const checkIn = params.checkIn;
+  const checkOut = params.checkOut;
+  const guests = params.guests;
 
   const nights = useMemo(() => nightsBetween(checkIn, checkOut), [checkIn, checkOut]);
   const lodgingTotal = property.nightlyRate * nights;
@@ -53,20 +59,52 @@ function WidgetForm({
     return true;
   }, [checkIn, checkOut, availability]);
 
-  const canCheckout = nights > 0 && dateRangeAvailable;
+  const canCheckout = nights > 0 && dateRangeAvailable && guests >= 1 && guests <= property.maxGuests;
+
+  const handleCheckout = () => {
+    const qs = querySuffix || [
+      checkIn ? `checkIn=${checkIn}` : '',
+      checkOut ? `checkOut=${checkOut}` : '',
+      guests !== 2 ? `guests=${guests}` : '',
+    ].filter(Boolean).join('&');
+    navigate(`/book/${orgSlug}/property/${property.id}/checkout${qs ? `?${qs}` : ''}`);
+    onCheckout?.();
+  };
 
   return (
     <div className={`space-y-4 ${compact ? '' : 'public-site-card p-5'}`} data-testid="booking-widget">
       <h3 className="text-lg font-semibold">{t('publicBooking.propertyTitle')}</h3>
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1">
-          <Label htmlFor="widget-check-in">{t('publicBooking.checkInLabel')}</Label>
-          <Input id="widget-check-in" type="date" value={checkIn} onChange={(e) => setCheckIn(e.target.value)} />
+          <Label htmlFor="check-in">{t('publicBooking.checkInLabel')}</Label>
+          <Input
+            id="check-in"
+            type="date"
+            value={checkIn}
+            onChange={(e) => setParams({ checkIn: e.target.value })}
+          />
         </div>
         <div className="space-y-1">
-          <Label htmlFor="widget-check-out">{t('publicBooking.checkOutLabel')}</Label>
-          <Input id="widget-check-out" type="date" value={checkOut} onChange={(e) => setCheckOut(e.target.value)} />
+          <Label htmlFor="check-out">{t('publicBooking.checkOutLabel')}</Label>
+          <Input
+            id="check-out"
+            type="date"
+            value={checkOut}
+            onChange={(e) => setParams({ checkOut: e.target.value })}
+          />
         </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="guests">{t('publicBooking.guestsLabel')}</Label>
+        <Input
+          id="guests"
+          type="number"
+          min={1}
+          max={property.maxGuests}
+          value={guests}
+          onChange={(e) => setParams({ guests: Number(e.target.value) })}
+        />
       </div>
 
       {(checkIn && isDateBooked(checkIn)) || (checkOut && isDateBooked(checkOut)) || (checkIn && checkOut && !dateRangeAvailable) ? (
@@ -74,6 +112,10 @@ function WidgetForm({
           <AlertCircle className="h-4 w-4" />
           {t('publicBooking.dateRangeBooked')}
         </p>
+      ) : null}
+
+      {guests > property.maxGuests ? (
+        <p className="text-sm text-red-600">{t('publicBooking.maxGuestsExceeded', { max: property.maxGuests })}</p>
       ) : null}
 
       {nights > 0 ? (
@@ -90,7 +132,7 @@ function WidgetForm({
       <Button
         className="public-site-cta w-full border-0"
         disabled={!canCheckout}
-        onClick={() => navigate(`/book/${orgSlug}/property/${property.id}/checkout?checkIn=${checkIn}&checkOut=${checkOut}`)}
+        onClick={handleCheckout}
       >
         {t('publicBooking.proceedToCheckout')}
       </Button>
@@ -100,28 +142,62 @@ function WidgetForm({
 
 export function BookingWidget(props: BookingWidgetProps) {
   const { t } = useTranslation();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMobileOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, [mobileOpen]);
 
   return (
     <>
-      <div className="hidden md:block md:sticky md:top-6">
+      <div id="booking-widget" className="hidden md:block md:sticky md:top-6">
         <WidgetForm {...props} />
       </div>
 
       <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-[var(--cz-public-surface)] p-3 shadow-[var(--cz-public-shadow-widget)] md:hidden">
-        <Sheet>
-          <SheetTrigger asChild>
-            <Button className="public-site-cta w-full border-0">{t('publicSite.mobileBookingCta')}</Button>
-          </SheetTrigger>
-          <SheetContent side="right" className="max-h-[85vh] overflow-y-auto rounded-t-2xl sm:max-w-md">
-            <SheetHeader>
-              <SheetTitle>{t('publicBooking.propertyTitle')}</SheetTitle>
-            </SheetHeader>
-            <div className="mt-4">
-              <WidgetForm {...props} compact />
-            </div>
-          </SheetContent>
-        </Sheet>
+        <Button
+          type="button"
+          className="public-site-cta w-full border-0"
+          data-testid="mobile-booking-trigger"
+          onClick={() => setMobileOpen(true)}
+        >
+          {t('publicSite.mobileBookingCta')}
+        </Button>
       </div>
+
+      {mobileOpen ? (
+        <div className="fixed inset-0 z-50 md:hidden" role="dialog" aria-modal="true" data-testid="mobile-booking-sheet">
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/50"
+            aria-label={t('publicSite.closeBookingSheet')}
+            onClick={() => setMobileOpen(false)}
+          />
+          <div className="absolute inset-x-0 bottom-0 max-h-[85vh] overflow-y-auto rounded-t-2xl bg-[var(--cz-public-surface)] p-4 shadow-[var(--cz-public-shadow-widget)] animate-in slide-in-from-bottom duration-300">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-lg font-semibold">{t('publicBooking.propertyTitle')}</h3>
+              <button
+                type="button"
+                className="rounded-md p-1 hover:bg-black/5"
+                aria-label={t('publicSite.closeBookingSheet')}
+                onClick={() => setMobileOpen(false)}
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <WidgetForm {...props} compact onCheckout={() => setMobileOpen(false)} />
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/src/features/public-site/components/PublicBreadcrumb.tsx
+++ b/src/features/public-site/components/PublicBreadcrumb.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight } from 'lucide-react';
+
+export interface BreadcrumbSegment {
+  label: string;
+  href?: string;
+}
+
+interface PublicBreadcrumbProps {
+  segments: BreadcrumbSegment[];
+}
+
+export function PublicBreadcrumb({ segments }: PublicBreadcrumbProps) {
+  const { t } = useTranslation();
+
+  if (segments.length === 0) return null;
+
+  return (
+    <nav aria-label={t('publicSite.breadcrumbLabel')} className="mb-6 text-sm" data-testid="public-breadcrumb">
+      <ol className="flex flex-wrap items-center gap-1 text-[var(--cz-public-muted)]">
+        {segments.map((seg, i) => {
+          const isLast = i === segments.length - 1;
+          return (
+            <li key={`${seg.label}-${i}`} className="flex items-center gap-1">
+              {i > 0 ? <ChevronRight className="h-3 w-3 shrink-0" aria-hidden /> : null}
+              {seg.href && !isLast ? (
+                <Link to={seg.href} className="hover:text-[var(--cz-public-primary)] hover:underline">
+                  {seg.label}
+                </Link>
+              ) : (
+                <span className={isLast ? 'font-medium text-[var(--cz-public-text)]' : undefined} aria-current={isLast ? 'page' : undefined}>
+                  {seg.label}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/features/public-site/hooks/use-booking-search-params.ts
+++ b/src/features/public-site/hooks/use-booking-search-params.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export interface BookingSearchParams {
+  checkIn: string;
+  checkOut: string;
+  guests: number;
+}
+
+const GUESTS_DEFAULT = 2;
+
+export function useBookingSearchParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const params = useMemo<BookingSearchParams>(() => ({
+    checkIn: searchParams.get('checkIn') ?? '',
+    checkOut: searchParams.get('checkOut') ?? '',
+    guests: Math.max(1, parseInt(searchParams.get('guests') ?? String(GUESTS_DEFAULT), 10) || GUESTS_DEFAULT),
+  }), [searchParams]);
+
+  const setParams = useCallback(
+    (next: Partial<BookingSearchParams>) => {
+      const updated = new URLSearchParams(searchParams);
+      if (next.checkIn !== undefined) {
+        if (next.checkIn) updated.set('checkIn', next.checkIn);
+        else updated.delete('checkIn');
+      }
+      if (next.checkOut !== undefined) {
+        if (next.checkOut) updated.set('checkOut', next.checkOut);
+        else updated.delete('checkOut');
+      }
+      if (next.guests !== undefined) {
+        updated.set('guests', String(Math.max(1, next.guests)));
+      }
+      setSearchParams(updated, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const toQueryString = useCallback(() => {
+    const parts: string[] = [];
+    if (params.checkIn) parts.push(`checkIn=${encodeURIComponent(params.checkIn)}`);
+    if (params.checkOut) parts.push(`checkOut=${encodeURIComponent(params.checkOut)}`);
+    if (params.guests !== GUESTS_DEFAULT) parts.push(`guests=${params.guests}`);
+    return parts.length > 0 ? `?${parts.join('&')}` : '';
+  }, [params]);
+
+  return { params, setParams, toQueryString };
+}

--- a/src/features/settings/components/vetrina-preview-panel.tsx
+++ b/src/features/settings/components/vetrina-preview-panel.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ExternalLink, Monitor, Smartphone } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface VetrinaPreviewPanelProps {
+  bookingSitePath: string;
+}
+
+export function VetrinaPreviewPanel({ bookingSitePath }: VetrinaPreviewPanelProps) {
+  const { t } = useTranslation();
+  const [device, setDevice] = useState<'desktop' | 'mobile'>('desktop');
+  const absoluteUrl = `${window.location.origin}${bookingSitePath}`;
+
+  return (
+    <Card data-testid="vetrina-preview-panel">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-base font-semibold">{t('directBooking.previewTitle')}</CardTitle>
+        <div className="flex gap-1">
+          <Button
+            type="button"
+            variant={device === 'desktop' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setDevice('desktop')}
+            aria-label={t('directBooking.previewDesktop')}
+          >
+            <Monitor className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            variant={device === 'mobile' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setDevice('mobile')}
+            aria-label={t('directBooking.previewMobile')}
+          >
+            <Smartphone className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div
+          className={`mx-auto overflow-hidden rounded-lg border bg-muted/30 transition-all ${
+            device === 'mobile' ? 'max-w-[375px]' : 'w-full'
+          }`}
+        >
+          <iframe
+            title={t('directBooking.previewIframeTitle')}
+            src={bookingSitePath}
+            className={`w-full border-0 ${device === 'mobile' ? 'h-[600px]' : 'h-[480px]'}`}
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          />
+        </div>
+        <a
+          href={absoluteUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+        >
+          {t('directBooking.openFullscreen')}
+          <ExternalLink className="h-4 w-4" />
+        </a>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/settings/components/vetrina-url-copy.tsx
+++ b/src/features/settings/components/vetrina-url-copy.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, Copy } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from 'sonner';
+
+interface VetrinaUrlCopyProps {
+  bookingSitePath: string;
+}
+
+export function VetrinaUrlCopy({ bookingSitePath }: VetrinaUrlCopyProps) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const absoluteUrl = `${window.location.origin}${bookingSitePath}`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(absoluteUrl);
+      setCopied(true);
+      toast.success(t('directBooking.urlCopied'));
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(t('directBooking.urlCopyError'));
+    }
+  };
+
+  return (
+    <Card data-testid="vetrina-url-copy">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">{t('directBooking.publicUrlTitle')}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">{t('directBooking.publicUrlDescription')}</p>
+        <div className="flex gap-2">
+          <Input readOnly value={absoluteUrl} className="font-mono text-xs" data-testid="vetrina-public-url" />
+          <Button type="button" variant="outline" onClick={handleCopy} className="shrink-0">
+            {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            <span className="ml-2 hidden sm:inline">{t('directBooking.copyUrl')}</span>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/settings/vetrina-page.tsx
+++ b/src/features/settings/vetrina-page.tsx
@@ -3,50 +3,32 @@ import { PageHeader } from '@/components/layout/page-header';
 import { Card, CardContent } from '@/components/ui/card';
 import { useCurrentUser } from '@/queries/use-users';
 import { useTranslation } from 'react-i18next';
-import { ExternalLink, Globe } from 'lucide-react';
+import { Globe } from 'lucide-react';
+import { VetrinaPreviewPanel } from './components/vetrina-preview-panel';
+import { VetrinaUrlCopy } from './components/vetrina-url-copy';
 
 export function VetrinaPage() {
   const { t } = useTranslation();
   const { org } = useCurrentUser();
-  const bookingSiteUrl = org?.slug ? `/book/${org.slug}` : null;
+  const bookingSitePath = org?.slug ? `/book/${org.slug}` : null;
 
   return (
     <AppShell>
-      <div className="mx-auto max-w-3xl space-y-6">
+      <div className="mx-auto max-w-4xl space-y-6">
         <PageHeader
           title={t('directBooking.title')}
           description={t('directBooking.description')}
         />
 
-        {bookingSiteUrl ? (
-          <Card>
-            <CardContent className="space-y-4 pt-6">
-              <div className="flex items-start gap-4">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
-                  <Globe className="h-6 w-6 text-primary" />
-                </div>
-                <div className="flex-1 space-y-2">
-                  <h3 className="font-semibold">{t('directBooking.yourSite')}</h3>
-                  <p className="text-sm text-muted-foreground">
-                    {t('directBooking.visitDescription')}
-                  </p>
-                  <a
-                    href={bookingSiteUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-sm font-medium"
-                  >
-                    {t('publicSite.preview')}
-                    <ExternalLink className="h-4 w-4" />
-                  </a>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+        {bookingSitePath ? (
+          <div className="space-y-6">
+            <VetrinaUrlCopy bookingSitePath={bookingSitePath} />
+            <VetrinaPreviewPanel bookingSitePath={bookingSitePath} />
+          </div>
         ) : (
           <Card>
             <CardContent className="py-12 text-center">
-              <Globe className="mx-auto h-10 w-10 text-muted-foreground mb-3" />
+              <Globe className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
               <p className="text-sm text-muted-foreground">{t('directBooking.noOrg')}</p>
             </CardContent>
           </Card>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -845,7 +845,9 @@
       "no": "No",
       "pricingTitle": "AI Pricing",
       "pricingDescription": "Configure the AI adapter for dynamic pricing for this property.",
-      "managePricing": "Manage AI pricing"
+      "managePricing": "Manage AI pricing",
+      "viewOnPublicSite": "View on public site",
+      "publicSiteHint": "Preview how guests see this property on your direct booking site."
     },
     "info": {
       "title": "Property details",
@@ -1428,7 +1430,17 @@
     "yourSite": "Your booking site",
     "visitDescription": "Visit your public site to see how your guests experience it.",
     "visitSite": "Visit {{siteName}}",
-    "noOrg": "Complete your organization setup to activate the public site."
+    "noOrg": "Complete your organization setup to activate the public site.",
+    "previewTitle": "Public site preview",
+    "previewDesktop": "Desktop preview",
+    "previewMobile": "Mobile preview",
+    "previewIframeTitle": "Booking site preview",
+    "openFullscreen": "Open fullscreen",
+    "publicUrlTitle": "Public URL",
+    "publicUrlDescription": "Share this link with guests for direct bookings.",
+    "copyUrl": "Copy URL",
+    "urlCopied": "URL copied to clipboard",
+    "urlCopyError": "Could not copy URL"
   },
   "plan": {
     "unlimitedProperties": "Unlimited properties",
@@ -1886,7 +1898,10 @@
     "mobileBookingCta": "Check availability",
     "galleryLabel": "Photo gallery for {{name}}",
     "openPhoto": "Open photo {{index}} of {{total}}",
-    "photoAlt": "{{name}} — photo {{index}}"
+    "photoAlt": "{{name}} — photo {{index}}",
+    "breadcrumbLabel": "Breadcrumb",
+    "breadcrumbCheckout": "Checkout",
+    "closeBookingSheet": "Close booking panel"
   },
   "publicBooking": {
     "payNow": "Pay now",
@@ -1948,6 +1963,9 @@
     "propertyTitle": "Book your stay",
     "checkInLabel": "Check-in",
     "checkOutLabel": "Check-out",
+    "guestsLabel": "Guests",
+    "maxGuestsExceeded": "Maximum {{max}} guests for this property",
+    "propertyFallback": "Property",
     "dateAlreadyBooked": "This date is already booked",
     "dateRangeBooked": "One or more dates in the selected range are already booked. Please choose different dates.",
     "camere": "bedrooms",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -847,7 +847,9 @@
       "no": "No",
       "pricingTitle": "Prezzi AI",
       "pricingDescription": "Configura l'adattatore AI per la tariffazione dinamica di questa proprietà.",
-      "managePricing": "Gestisci prezzi AI"
+      "managePricing": "Gestisci prezzi AI",
+      "viewOnPublicSite": "Vedi sul sito pubblico",
+      "publicSiteHint": "Anteprima di come gli ospiti vedono questa struttura sul sito di prenotazione diretta."
     },
     "info": {
       "title": "Dettagli proprietà",
@@ -1430,7 +1432,17 @@
     "yourSite": "Il tuo sito di prenotazioni",
     "visitDescription": "Accedi al sito pubblico per visualizzare come lo vedono i tuoi ospiti.",
     "visitSite": "Visita {{siteName}}",
-    "noOrg": "Completa la configurazione dell'organizzazione per attivare il sito pubblico."
+    "noOrg": "Completa la configurazione dell'organizzazione per attivare il sito pubblico.",
+    "previewTitle": "Anteprima sito pubblico",
+    "previewDesktop": "Anteprima desktop",
+    "previewMobile": "Anteprima mobile",
+    "previewIframeTitle": "Anteprima sito prenotazioni",
+    "openFullscreen": "Apri a schermo intero",
+    "publicUrlTitle": "URL pubblico",
+    "publicUrlDescription": "Condividi questo link con i tuoi ospiti per prenotazioni dirette.",
+    "copyUrl": "Copia URL",
+    "urlCopied": "URL copiato negli appunti",
+    "urlCopyError": "Impossibile copiare l'URL"
   },
   "plan": {
     "unlimitedProperties": "Proprietà illimitate",
@@ -1888,7 +1900,10 @@
     "mobileBookingCta": "Verifica disponibilità",
     "galleryLabel": "Galleria foto di {{name}}",
     "openPhoto": "Apri foto {{index}} di {{total}}",
-    "photoAlt": "{{name}} — foto {{index}}"
+    "photoAlt": "{{name}} — foto {{index}}",
+    "breadcrumbLabel": "Percorso di navigazione",
+    "breadcrumbCheckout": "Checkout",
+    "closeBookingSheet": "Chiudi pannello prenotazione"
   },
   "publicBooking": {
     "payNow": "Paga ora",
@@ -1950,6 +1965,9 @@
     "propertyTitle": "Prenota il soggiorno",
     "checkInLabel": "Check-in",
     "checkOutLabel": "Check-out",
+    "guestsLabel": "Ospiti",
+    "maxGuestsExceeded": "Massimo {{max}} ospiti per questa struttura",
+    "propertyFallback": "Struttura",
     "dateAlreadyBooked": "Questa data e' gia' prenotata",
     "dateRangeBooked": "Una o piu' date nel periodo selezionato sono gia' prenotate. Scegli date diverse.",
     "camere": "camere",

--- a/src/layouts/PublicSiteShell.tsx
+++ b/src/layouts/PublicSiteShell.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Link, NavLink, Outlet, useParams } from 'react-router-dom';
+import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Loader2, Menu } from 'lucide-react';
 import { usePublicOrg } from '@/queries/use-public-org';
 import { CookieConsentBanner } from '@/components/shared/cookie-consent-banner';
 import { PublicOrgNotFoundPage } from '@/features/public-booking/public-org-not-found-page';
 import { Footer } from '@/features/public-site/components/Footer';
+import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import '@/styles/public-tokens.css';
 
@@ -13,15 +14,31 @@ interface PublicSiteShellProps {
   mode?: 'org' | 'default';
 }
 
+function scrollToBookingWidget() {
+  const widget = document.getElementById('booking-widget');
+  if (widget) {
+    widget.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return;
+  }
+  const mobileCta = document.querySelector<HTMLButtonElement>('[data-testid="mobile-booking-trigger"]');
+  if (mobileCta) {
+    mobileCta.click();
+    return;
+  }
+  document.getElementById('property-grid')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
 export function PublicSiteShell({ mode = 'org' }: PublicSiteShellProps) {
   const { t } = useTranslation();
   const { orgSlug } = useParams<{ orgSlug: string }>();
+  const location = useLocation();
   const isOrgMode = mode === 'org' && !!orgSlug;
   const { data: org, isLoading, isError } = usePublicOrg(isOrgMode ? orgSlug : undefined);
   const [menuOpen, setMenuOpen] = useState(false);
 
   const themeId = org?.publicThemeId ?? 'mare';
   const primaryColor = org?.themeColor ?? undefined;
+  const showBookingCta = isOrgMode && (location.pathname.includes('/property/') || location.pathname === `/book/${orgSlug}` || location.pathname === `/book/${orgSlug}/`);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -45,16 +62,7 @@ export function PublicSiteShell({ mode = 'org' }: PublicSiteShellProps) {
   }
 
   const displayName = org?.displayName ?? 'CasaZen';
-  const navLinks = isOrgMode && orgSlug ? (
-    <>
-      <NavLink to={`/book/${orgSlug}`} className={({ isActive }) => `block py-2 ${isActive ? 'font-semibold text-[var(--cz-public-primary)]' : ''}`}>
-        {t('publicSite.navProperties')}
-      </NavLink>
-      <NavLink to={`/book/${orgSlug}/my-bookings`} className={({ isActive }) => `block py-2 ${isActive ? 'font-semibold text-[var(--cz-public-primary)]' : ''}`}>
-        {t('publicSite.navMyBookings')}
-      </NavLink>
-    </>
-  ) : null;
+  const basePath = `/book/${orgSlug}`;
 
   return (
     <div
@@ -68,29 +76,44 @@ export function PublicSiteShell({ mode = 'org' }: PublicSiteShellProps) {
 
       <header className="border-b border-black/10 bg-[var(--cz-public-surface)]">
         <div className="mx-auto flex max-w-[1200px] items-center justify-between gap-4 px-4 py-4">
-          <div className="flex items-center gap-3">
+          <Link to={isOrgMode ? basePath : '/search'} className="flex min-w-0 items-center">
             {org?.logoUrl ? (
-              <img src={org.logoUrl} alt={displayName} className="h-10 w-auto object-contain" />
+              <img src={org.logoUrl} alt={displayName} className="h-10 w-auto max-w-[200px] object-contain" />
             ) : (
-              <span className="public-display text-lg font-semibold">CasaZen</span>
+              <span className="public-display truncate text-lg font-semibold">{displayName}</span>
             )}
-            <span className="public-display text-lg font-medium">{displayName}</span>
-          </div>
+          </Link>
 
           {isOrgMode ? (
-            <>
-              <nav className="hidden items-center gap-6 text-sm md:flex">{navLinks}</nav>
+            <div className="flex items-center gap-2">
+              {showBookingCta ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  className="public-site-cta border-0"
+                  onClick={scrollToBookingWidget}
+                  data-testid="header-booking-cta"
+                >
+                  {t('publicSite.mobileBookingCta')}
+                </Button>
+              ) : null}
               <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
-                <SheetTrigger className="md:hidden" aria-label={t('publicSite.openMenu')}>
+                <SheetTrigger className="rounded-md p-2 hover:bg-black/5" aria-label={t('publicSite.openMenu')}>
                   <Menu className="h-6 w-6" />
                 </SheetTrigger>
                 <SheetContent side="right" className="w-72">
                   <nav className="mt-8 flex flex-col gap-2 text-base" onClick={() => setMenuOpen(false)}>
-                    {navLinks}
+                    <Link
+                      to={`${basePath}/my-bookings`}
+                      className="block py-2 hover:text-[var(--cz-public-primary)]"
+                      data-testid="public-nav-my-bookings"
+                    >
+                      {t('publicSite.navMyBookings')}
+                    </Link>
                   </nav>
                 </SheetContent>
               </Sheet>
-            </>
+            </div>
           ) : (
             <Link to="/search" className="text-sm underline hover:text-[var(--cz-public-primary)]">
               {t('publicSite.explore')}


### PR DESCRIPTION
## Summary
- Guest-first header: logo OR name, CTA Verifica disponibilita, my-bookings in menu
- PublicBreadcrumb on property detail and checkout
- URL state: checkIn, checkOut, guests via useBookingSearchParams
- Single-property org auto-redirect from landing
- Mobile booking widget: bottom sheet (not side sheet)
- Host Vetrina hub: iframe preview, copy URL, fullscreen link
- Host property detail: Vedi sul sito pubblico banner

## Backend
N/A — FE only (casazen/backend#338)

## Test plan
- [x] npm run build
- [x] branded-booking-site E2E (11/11 including #338 AC2-AC4)
- [ ] golden-journey step 3 onboarding (pre-existing env issue)
- [x] tsc via build

Closes casazen/backend#338

Made with [Cursor](https://cursor.com)