### PR TITLE
fix(vetrina): full-page preview layout in AppShell

### DIFF
--- a/src/features/settings/components/vetrina-preview-panel.tsx
+++ b/src/features/settings/components/vetrina-preview-panel.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ExternalLink, Monitor, Smartphone } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 interface VetrinaPreviewPanelProps {
   bookingSitePath: string;
@@ -14,53 +13,56 @@ export function VetrinaPreviewPanel({ bookingSitePath }: VetrinaPreviewPanelProp
   const absoluteUrl = `${window.location.origin}${bookingSitePath}`;
 
   return (
-    <Card data-testid="vetrina-preview-panel">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-base font-semibold">{t('directBooking.previewTitle')}</CardTitle>
-        <div className="flex gap-1">
-          <Button
-            type="button"
-            variant={device === 'desktop' ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => setDevice('desktop')}
-            aria-label={t('directBooking.previewDesktop')}
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="vetrina-preview-panel">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b bg-muted/30 px-4 py-2 md:px-6">
+        <span className="text-sm font-medium">{t('directBooking.previewTitle')}</span>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex gap-1">
+            <Button
+              type="button"
+              variant={device === 'desktop' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setDevice('desktop')}
+              aria-label={t('directBooking.previewDesktop')}
+            >
+              <Monitor className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant={device === 'mobile' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setDevice('mobile')}
+              aria-label={t('directBooking.previewMobile')}
+            >
+              <Smartphone className="h-4 w-4" />
+            </Button>
+          </div>
+          <a
+            href={absoluteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted"
           >
-            <Monitor className="h-4 w-4" />
-          </Button>
-          <Button
-            type="button"
-            variant={device === 'mobile' ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => setDevice('mobile')}
-            aria-label={t('directBooking.previewMobile')}
-          >
-            <Smartphone className="h-4 w-4" />
-          </Button>
+            {t('directBooking.openFullscreen')}
+            <ExternalLink className="h-4 w-4" />
+          </a>
         </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div
-          className={`mx-auto overflow-hidden rounded-lg border bg-muted/30 transition-all ${
-            device === 'mobile' ? 'max-w-[375px]' : 'w-full'
+      </div>
+
+      <div
+        className={`flex min-h-0 flex-1 bg-muted/20 ${
+          device === 'mobile' ? 'items-stretch justify-center' : ''
+        }`}
+      >
+        <iframe
+          title={t('directBooking.previewIframeTitle')}
+          src={bookingSitePath}
+          className={`min-h-0 flex-1 border-0 bg-background ${
+            device === 'mobile' ? 'w-full max-w-[430px] shadow-lg' : 'h-full w-full'
           }`}
-        >
-          <iframe
-            title={t('directBooking.previewIframeTitle')}
-            src={bookingSitePath}
-            className={`w-full border-0 ${device === 'mobile' ? 'h-[600px]' : 'h-[480px]'}`}
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-          />
-        </div>
-        <a
-          href={absoluteUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
-        >
-          {t('directBooking.openFullscreen')}
-          <ExternalLink className="h-4 w-4" />
-        </a>
-      </CardContent>
-    </Card>
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+        />
+      </div>
+    </div>
   );
 }

--- a/src/features/settings/components/vetrina-url-copy.tsx
+++ b/src/features/settings/components/vetrina-url-copy.tsx
@@ -8,9 +8,10 @@ import { toast } from 'sonner';
 
 interface VetrinaUrlCopyProps {
   bookingSitePath: string;
+  variant?: 'card' | 'inline';
 }
 
-export function VetrinaUrlCopy({ bookingSitePath }: VetrinaUrlCopyProps) {
+export function VetrinaUrlCopy({ bookingSitePath, variant = 'card' }: VetrinaUrlCopyProps) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const absoluteUrl = `${window.location.origin}${bookingSitePath}`;
@@ -25,6 +26,18 @@ export function VetrinaUrlCopy({ bookingSitePath }: VetrinaUrlCopyProps) {
       toast.error(t('directBooking.urlCopyError'));
     }
   };
+
+  if (variant === 'inline') {
+    return (
+      <div className="flex w-full max-w-2xl gap-2" data-testid="vetrina-url-copy">
+        <Input readOnly value={absoluteUrl} className="font-mono text-xs" data-testid="vetrina-public-url" />
+        <Button type="button" variant="outline" onClick={handleCopy} className="shrink-0">
+          {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          <span className="ml-2 hidden sm:inline">{t('directBooking.copyUrl')}</span>
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <Card data-testid="vetrina-url-copy">

--- a/src/features/settings/vetrina-page.tsx
+++ b/src/features/settings/vetrina-page.tsx
@@ -14,26 +14,31 @@ export function VetrinaPage() {
 
   return (
     <AppShell>
-      <div className="mx-auto max-w-4xl space-y-6">
-        <PageHeader
-          title={t('directBooking.title')}
-          description={t('directBooking.description')}
-        />
-
-        {bookingSitePath ? (
-          <div className="space-y-6">
-            <VetrinaUrlCopy bookingSitePath={bookingSitePath} />
-            <VetrinaPreviewPanel bookingSitePath={bookingSitePath} />
+      {bookingSitePath ? (
+        <div className="-m-4 flex min-h-[calc(100svh-9rem)] flex-col overflow-hidden max-md:min-h-[calc(100svh-9rem-var(--bottom-nav-height))] md:-m-6 md:min-h-[calc(100svh-5.5rem)]">
+          <div className="shrink-0 space-y-4 border-b bg-background px-4 py-4 md:px-6">
+            <PageHeader
+              title={t('directBooking.title')}
+              description={t('directBooking.description')}
+            />
+            <VetrinaUrlCopy bookingSitePath={bookingSitePath} variant="inline" />
           </div>
-        ) : (
-          <Card>
+          <VetrinaPreviewPanel bookingSitePath={bookingSitePath} />
+        </div>
+      ) : (
+        <div className="mx-auto max-w-3xl">
+          <PageHeader
+            title={t('directBooking.title')}
+            description={t('directBooking.description')}
+          />
+          <Card className="mt-6">
             <CardContent className="py-12 text-center">
               <Globe className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
               <p className="text-sm text-muted-foreground">{t('directBooking.noOrg')}</p>
             </CardContent>
           </Card>
-        )}
-      </div>
+        </div>
+      )}
     </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- Vetrina hub: toolbar compatta (titolo + URL inline) e iframe che occupa tutta l'area contenuto
- Rimuove card centrale max-w-4xl e altezza fissa 480px
- Usa layout AppShell esistente con margini negativi per larghezza piena

## Test plan
- [ ] /app/short-rent/vetrina: iframe riempie pagina sotto toolbar
- [ ] Toggle desktop/mobile funziona
- [ ] Copia URL e Apri a schermo intero OK