### PR TITLE
feat(checkin): guest check-in portal UI + booking badge (#296)

### DIFF
--- a/e2e/guest-checkin-portal.spec.ts
+++ b/e2e/guest-checkin-portal.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Guest check-in portal', () => {
+  test('shows invalid link for unknown token', async ({ page }) => {
+    await page.goto('/checkin/invalid-token-00000000000000000000000000000000');
+    await expect(page.getByText(/invalid|non valido/i)).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('renders wizard progress on mocked context', async ({ page }) => {
+    await page.route('**/api/public/checkin/**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            sessionId: '11111111-1111-1111-1111-111111111111',
+            propertyName: 'Villa Demo',
+            checkInDate: '2026-07-10T00:00:00Z',
+            checkOutDate: '2026-07-12T00:00:00Z',
+            status: 'Inviato',
+            guestPrefill: {
+              firstName: 'Mario',
+              lastName: 'Rossi',
+              email: 'mario@example.com',
+              nationality: 'IT',
+              documentNumber: '',
+              documentIssuingCountry: 'IT',
+              placeOfBirth: 'Roma',
+            },
+          }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto('/checkin/demo-token-abcdef1234567890abcdef1234567890');
+    await expect(page.getByTestId('checkin-progress')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('Villa Demo')).toBeVisible();
+  });
+});

--- a/src/api/bookings.api.ts
+++ b/src/api/bookings.api.ts
@@ -7,6 +7,7 @@ import type {
   CheckOutDto,
 } from '@/types';
 import type { CalendarResponseDto } from '@/types/calendar.types';
+import type { CheckInSessionStatusDto, ResendCheckInLinkResponse } from '@/types/public-checkin.types';
 
 export const bookingsApi = {
   getAll: (params?: Record<string, any>) =>
@@ -36,4 +37,10 @@ export const bookingsApi = {
 
   generateCheckInToken: (id: string) =>
     ApiClient.post<{ token: string }>(`/bookings/${id}/check-in-token`),
+
+  getCheckInSession: (id: string) =>
+    ApiClient.get<CheckInSessionStatusDto>(`/bookings/${id}/checkin-session`),
+
+  resendCheckInLink: (id: string) =>
+    ApiClient.post<ResendCheckInLinkResponse>(`/bookings/${id}/checkin/resend-link`),
 };

--- a/src/api/checkin.api.ts
+++ b/src/api/checkin.api.ts
@@ -1,31 +1,13 @@
-import axios from '@/lib/axios';
 import { ApiClient } from './client';
 import type {
-  CheckInContextDto,
-  GuestCheckInDataResponse,
-  GuestDocumentUploadResponse,
-  SubmitGuestCheckInRequest,
-} from '@/types/alloggiati.types';
+  PublicCheckInContextDto,
+  PublicCheckInSubmitRequest,
+} from '@/types/public-checkin.types';
 
-/**
- * Public guest check-in API — token in path replaces auth (AllowAnonymous).
- */
-export const checkinApi = {
+export const publicCheckinApi = {
   getContext: (token: string) =>
-    ApiClient.get<CheckInContextDto>(`/checkin/${token}`),
+    ApiClient.get<PublicCheckInContextDto>(`/public/checkin/${token}`),
 
-  submitGuestData: (token: string, data: SubmitGuestCheckInRequest) =>
-    ApiClient.post<GuestCheckInDataResponse>(`/checkin/${token}/guest-data`, data),
-
-  uploadDocument: async (token: string, file: File): Promise<GuestDocumentUploadResponse> => {
-    const formData = new FormData();
-    formData.append('file', file);
-
-    const response = await axios.post<GuestDocumentUploadResponse>(
-      `/checkin/${token}/document`,
-      formData,
-      { headers: { 'Content-Type': 'multipart/form-data' } },
-    );
-    return response.data;
-  },
+  submit: (token: string, data: PublicCheckInSubmitRequest) =>
+    ApiClient.post<{ sessionId: string; message: string }>(`/public/checkin/${token}`, data),
 };

--- a/src/features/bookings/booking-detail-page.tsx
+++ b/src/features/bookings/booking-detail-page.tsx
@@ -20,6 +20,7 @@ import { ServiceRequestForm } from '@/features/service-requests/components/servi
 import { ServiceRequestTimeline } from '@/features/service-requests/components/service-request-timeline';
 import { useProperty } from '@/queries/use-properties';
 import { useServiceRequests } from '@/queries/use-service-requests';
+import { CheckInSessionBadge } from './components/checkin-session-badge';
 
 type BookingTab = 'details' | 'guest' | 'payment' | 'alloggiati';
 
@@ -188,6 +189,10 @@ export function BookingDetailPage() {
               <CardTitle>{t('booking.detailPage.guestInformationTitle')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
+              <div className="pb-3 border-b">
+                <div className="text-sm text-muted-foreground mb-2">{t('checkin.sessionLabel')}</div>
+                <CheckInSessionBadge bookingId={booking.id} />
+              </div>
               <div>
                 <div className="text-sm text-muted-foreground">{t('booking.detailPage.guestName')}</div>
                 <div className="font-medium">

--- a/src/features/bookings/components/checkin-session-badge.tsx
+++ b/src/features/bookings/components/checkin-session-badge.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Loader2, Send } from 'lucide-react';
+import { useBookingCheckInSession, useResendCheckInLink } from '@/queries/use-checkin';
+import type { GuestCheckInSessionStatus } from '@/types/public-checkin.types';
+
+const STATUS_VARIANT: Record<GuestCheckInSessionStatus, 'default' | 'secondary' | 'outline' | 'destructive'> = {
+  Inviato: 'secondary',
+  InCompilazione: 'outline',
+  Completo: 'default',
+  AlloggiatiInviato: 'default',
+  Scaduto: 'destructive',
+};
+
+export function CheckInSessionBadge({ bookingId }: { bookingId: string }) {
+  const { t } = useTranslation();
+  const { data: session, isLoading } = useBookingCheckInSession(bookingId);
+  const resend = useResendCheckInLink(bookingId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        {t('checkin.sessionLoading')}
+      </div>
+    );
+  }
+
+  if (!session?.status) {
+    return <p className="text-sm text-muted-foreground" data-testid="checkin-session-none">{t('checkin.noSession')}</p>;
+  }
+
+  const status = session.status as GuestCheckInSessionStatus;
+  const canResend = status !== 'Completo' && status !== 'AlloggiatiInviato';
+
+  return (
+    <div className="flex flex-wrap items-center gap-3" data-testid="checkin-session-badge">
+      <Badge variant={STATUS_VARIANT[status] ?? 'secondary'}>
+        {t(`checkin.status.${status}`, { defaultValue: status })}
+      </Badge>
+      {canResend && (
+        <Button variant="outline" size="sm" onClick={() => resend.mutate()} disabled={resend.isPending} data-testid="checkin-resend-button">
+          {resend.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Send className="mr-2 h-4 w-4" />}
+          {t('checkin.resendLink')}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/features/checkin/checkin-page.tsx
+++ b/src/features/checkin/checkin-page.tsx
@@ -1,39 +1,78 @@
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { LoadingScreen } from '@/components/shared/loading-screen';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import { formatDate } from '@/lib/utils';
-import {
-  useCheckInContext,
-  useSubmitGuestCheckIn,
-  useUploadCheckInDocument,
-} from '@/queries/use-checkin';
-import { GuestDataForm } from './components/guest-data-form';
-import { DocumentUpload } from './components/document-upload';
-import type { GuestCheckInFormValues } from './schemas/checkin.schema';
-import { CheckCircle2 } from 'lucide-react';
+import { useCheckInContext, useSubmitGuestCheckIn } from '@/queries/use-checkin';
+import { publicCheckInFormSchema, type PublicCheckInFormValues } from './schemas/checkin.schema';
+import { getDocumentTypeLabel } from '@/lib/i18n-labels';
+import { CheckCircle2, ChevronLeft, ChevronRight } from 'lucide-react';
+import type { PublicCheckInGuestPrefill } from '@/types/public-checkin.types';
+
+const DOCUMENT_TYPES = ['Passport', 'IdentityCard', 'DriversLicense', 'Other'] as const;
+const selectClassName =
+  'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+const COMPLETE_STATUSES = new Set(['Completo', 'AlloggiatiInviato']);
+
+function defaultValues(prefill?: PublicCheckInGuestPrefill | null): PublicCheckInFormValues {
+  return {
+    firstName: prefill?.firstName ?? '',
+    lastName: prefill?.lastName ?? '',
+    dateOfBirth: prefill?.dateOfBirth?.slice(0, 10) ?? '',
+    placeOfBirth: prefill?.placeOfBirth ?? '',
+    nationality: prefill?.nationality ?? '',
+    documentType: 'Passport',
+    documentNumber: prefill?.documentNumber ?? '',
+    documentIssuingCountry: prefill?.documentIssuingCountry ?? '',
+    gdprConsent: false,
+    marketingConsent: false,
+  };
+}
 
 export function CheckInPage() {
   const { t } = useTranslation();
   const { token = '' } = useParams<{ token: string }>();
   const { data: context, isLoading, isError } = useCheckInContext(token);
-  const submitGuestData = useSubmitGuestCheckIn(token);
-  const uploadDocument = useUploadCheckInDocument(token);
+  const submitCheckIn = useSubmitGuestCheckIn(token);
+  const [step, setStep] = useState(1);
+  const [submitted, setSubmitted] = useState(false);
 
-  const handleSubmit = async (values: GuestCheckInFormValues) => {
-    await submitGuestData.mutateAsync({
-      ...values,
-      documentExpiryDate: values.documentExpiryDate || null,
-      address: values.address ?? '',
-      city: values.city ?? '',
-      postalCode: values.postalCode ?? '',
-      country: values.country ?? '',
-    });
+  const form = useForm<PublicCheckInFormValues>({
+    resolver: zodResolver(publicCheckInFormSchema),
+    defaultValues: defaultValues(),
+  });
+
+  const { register, handleSubmit, setValue, watch, trigger, reset } = form;
+
+  useEffect(() => {
+    if (context?.guestPrefill) reset(defaultValues(context.guestPrefill));
+  }, [context?.sessionId, context?.guestPrefill, reset]);
+
+  const gdprConsent = watch('gdprConsent');
+  const marketingConsent = watch('marketingConsent');
+
+  const goNext = async () => {
+    const fieldsByStep: (keyof PublicCheckInFormValues)[][] = [
+      ['firstName', 'lastName', 'dateOfBirth', 'placeOfBirth', 'nationality'],
+      ['documentType', 'documentNumber', 'documentIssuingCountry'],
+      ['gdprConsent'],
+    ];
+    if (await trigger(fieldsByStep[step - 1])) setStep((s) => Math.min(3, s + 1));
   };
 
-  if (isLoading) {
-    return <LoadingScreen message={t('checkin.loading')} />;
-  }
+  const onSubmit = handleSubmit(async (values) => {
+    await submitCheckIn.mutateAsync({ ...values, marketingConsent: values.marketingConsent ?? false });
+    setSubmitted(true);
+  });
+
+  if (isLoading) return <LoadingScreen message={t('checkin.loading')} />;
 
   if (isError || !context) {
     return (
@@ -41,10 +80,23 @@ export function CheckInPage() {
         <Card className="max-w-md w-full">
           <CardHeader>
             <CardTitle>{t('checkin.invalidLink')}</CardTitle>
-            <CardDescription>
-              {t('checkin.invalidLinkDescription')}
-            </CardDescription>
+            <CardDescription>{t('checkin.invalidLinkDescription')}</CardDescription>
           </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  if (COMPLETE_STATUSES.has(context.status) || submitted) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-6 bg-muted/30" data-testid="checkin-success">
+        <Card className="max-w-md w-full text-center">
+          <CardContent className="pt-10 pb-8 space-y-4">
+            <CheckCircle2 className="h-16 w-16 text-green-600 mx-auto" />
+            <h1 className="text-2xl font-bold">{t('checkin.successTitle')}</h1>
+            <p className="text-muted-foreground">{t('checkin.successDescription')}</p>
+            <p className="text-sm font-medium">{context.propertyName}</p>
+          </CardContent>
         </Card>
       </div>
     );
@@ -60,46 +112,105 @@ export function CheckInPage() {
             {formatDate(context.checkInDate)} – {formatDate(context.checkOutDate)}
           </p>
         </div>
-
-        {context.dataComplete && (
-          <Card className="border-green-200 bg-green-50">
-            <CardContent className="flex items-center gap-3 py-4">
-              <CheckCircle2 className="h-5 w-5 text-green-600" />
-              <p className="text-sm text-green-800" data-testid="checkin-complete-banner">
-                {t('checkin.checkInComplete')}
-              </p>
-            </CardContent>
-          </Card>
-        )}
-
+        <div className="flex justify-center gap-2" data-testid="checkin-progress">
+          {[1, 2, 3].map((n) => (
+            <div key={n} className={`h-2 w-16 rounded-full ${n <= step ? 'bg-primary' : 'bg-muted'}`} />
+          ))}
+        </div>
         <Card>
           <CardHeader>
-            <CardTitle>{t('checkin.personalData')}</CardTitle>
-            <CardDescription>
-              {t('checkin.personalDataDescription')}
-            </CardDescription>
+            <CardTitle>
+              {step === 1 && t('checkin.stepPersonal')}
+              {step === 2 && t('checkin.stepDocument')}
+              {step === 3 && t('checkin.stepConsents')}
+            </CardTitle>
+            <CardDescription>{t('checkin.stepOf', { step, total: 3 })}</CardDescription>
           </CardHeader>
           <CardContent>
-            <GuestDataForm
-              guest={context.guest}
-              onSubmit={handleSubmit}
-              isSubmitting={submitGuestData.isPending}
-            />
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>{t('checkin.document')}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <DocumentUpload
-              existingUrl={context.guest.documentScanUrl}
-              onUpload={async (file) => {
-                await uploadDocument.mutateAsync(file);
-              }}
-              isUploading={uploadDocument.isPending}
-            />
+            <form onSubmit={onSubmit} className="space-y-4" data-testid="guest-data-form">
+              {step === 1 && (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="firstName">{t('checkin.firstName')}</Label>
+                    <Input id="firstName" {...register('firstName')} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="lastName">{t('checkin.lastName')}</Label>
+                    <Input id="lastName" {...register('lastName')} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="dateOfBirth">{t('checkin.birthDate')}</Label>
+                    <Input id="dateOfBirth" type="date" {...register('dateOfBirth')} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="placeOfBirth">{t('checkin.birthPlace')}</Label>
+                    <Input id="placeOfBirth" {...register('placeOfBirth')} />
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label htmlFor="nationality">{t('checkin.nationality')}</Label>
+                    <Input id="nationality" {...register('nationality')} />
+                  </div>
+                </div>
+              )}
+              {step === 2 && (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label htmlFor="documentType">{t('checkin.documentTypeLabel')}</Label>
+                    <select id="documentType" {...register('documentType')} className={selectClassName}>
+                      {DOCUMENT_TYPES.map((value) => (
+                        <option key={value} value={value}>{getDocumentTypeLabel(value, t)}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="documentNumber">{t('checkin.documentNumber')}</Label>
+                    <Input id="documentNumber" {...register('documentNumber')} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="documentIssuingCountry">{t('checkin.documentIssuingCountry')}</Label>
+                    <Input id="documentIssuingCountry" {...register('documentIssuingCountry')} />
+                  </div>
+                </div>
+              )}
+              {step === 3 && (
+                <div className="space-y-4">
+                  <div className="flex items-start gap-3 rounded-md border p-4" data-testid="checkin-gdpr-consent">
+                    <Checkbox
+                      id="gdprConsent"
+                      checked={gdprConsent === true}
+                      onCheckedChange={(v) => setValue('gdprConsent', v === true, { shouldValidate: true })}
+                    />
+                    <Label htmlFor="gdprConsent" className="text-sm leading-relaxed cursor-pointer">
+                      {t('checkin.gdprConsent')}
+                    </Label>
+                  </div>
+                  <div className="flex items-start gap-3 rounded-md border p-4">
+                    <Checkbox
+                      id="marketingConsent"
+                      checked={marketingConsent === true}
+                      onCheckedChange={(v) => setValue('marketingConsent', v === true)}
+                    />
+                    <Label htmlFor="marketingConsent" className="text-sm leading-relaxed cursor-pointer">
+                      {t('checkin.marketingConsent')}
+                    </Label>
+                  </div>
+                </div>
+              )}
+              <div className="flex justify-between pt-4">
+                <Button type="button" variant="outline" onClick={() => setStep((s) => Math.max(1, s - 1))} disabled={step === 1}>
+                  <ChevronLeft className="mr-1 h-4 w-4" />{t('checkin.back')}
+                </Button>
+                {step < 3 ? (
+                  <Button type="button" onClick={goNext}>
+                    {t('checkin.next')}<ChevronRight className="ml-1 h-4 w-4" />
+                  </Button>
+                ) : (
+                  <Button type="submit" disabled={submitCheckIn.isPending} data-testid="checkin-submit">
+                    {submitCheckIn.isPending ? t('checkin.saving') : t('checkin.submit')}
+                  </Button>
+                )}
+              </div>
+            </form>
           </CardContent>
         </Card>
       </div>

--- a/src/features/checkin/schemas/checkin.schema.ts
+++ b/src/features/checkin/schemas/checkin.schema.ts
@@ -1,16 +1,35 @@
 import { z } from 'zod';
 
+export const publicCheckInFormSchema = z.object({
+  firstName: z.string().min(1, 'checkin.validation.firstName.required').max(100),
+  lastName: z.string().min(1, 'checkin.validation.lastName.required').max(100),
+  dateOfBirth: z.string().min(1, 'checkin.validation.dateOfBirth.required'),
+  placeOfBirth: z.string().min(1, 'checkin.validation.placeOfBirth.required').max(100),
+  nationality: z.string().min(1, 'checkin.validation.nationality.required').max(100),
+  documentType: z.enum(['Passport', 'IdentityCard', 'DriversLicense', 'Other'], {
+    message: 'checkin.validation.documentType.required',
+  }),
+  documentNumber: z.string().min(1, 'checkin.validation.documentNumber.required').max(50),
+  documentIssuingCountry: z.string().min(1, 'checkin.validation.documentIssuingCountry.required').max(100),
+  gdprConsent: z.boolean().refine((val) => val === true, {
+    message: 'checkin.validation.consentAccepted.required',
+  }),
+  marketingConsent: z.boolean().optional(),
+});
+
+export type PublicCheckInFormValues = z.infer<typeof publicCheckInFormSchema>;
+
 export const guestCheckInFormSchema = z.object({
   dateOfBirth: z.string().min(1, 'checkin.validation.dateOfBirth.required'),
-  placeOfBirth: z.string().min(1, 'checkin.validation.placeOfBirth.required').max(100, 'checkin.validation.placeOfBirth.maxLength'),
-  nationality: z.string().min(1, 'checkin.validation.nationality.required').max(100, 'checkin.validation.nationality.maxLength'),
+  placeOfBirth: z.string().min(1, 'checkin.validation.placeOfBirth.required').max(100),
+  nationality: z.string().min(1, 'checkin.validation.nationality.required').max(100),
   gender: z.enum(['Male', 'Female', 'Other'], { message: 'checkin.validation.gender.required' }),
   documentType: z.enum(['Passport', 'IdentityCard', 'DriversLicense', 'Other'], {
     message: 'checkin.validation.documentType.required',
   }),
-  documentNumber: z.string().min(1, 'checkin.validation.documentNumber.required').max(50, 'checkin.validation.documentNumber.maxLength'),
+  documentNumber: z.string().min(1, 'checkin.validation.documentNumber.required').max(50),
   documentExpiryDate: z.string().optional(),
-  documentIssuingCountry: z.string().min(1, 'checkin.validation.documentIssuingCountry.required').max(100, 'checkin.validation.documentIssuingCountry.maxLength'),
+  documentIssuingCountry: z.string().min(1, 'checkin.validation.documentIssuingCountry.required').max(100),
   address: z.string().max(500).optional(),
   city: z.string().max(50).optional(),
   postalCode: z.string().max(10).optional(),
@@ -21,6 +40,3 @@ export const guestCheckInFormSchema = z.object({
 });
 
 export type GuestCheckInFormValues = z.infer<typeof guestCheckInFormSchema>;
-
-// Document type and gender labels are now resolved via getDocumentTypeLabel() / getGenderLabel()
-// from @/lib/i18n-labels. See checkin.documentType.{key} and checkin.gender.{key} in locale JSONs.

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1810,6 +1810,8 @@
       "Other": "Other"
     },
     "validation": {
+      "firstName": { "required": "First name is required" },
+      "lastName": { "required": "Last name is required" },
       "dateOfBirth": {
         "required": "Date of birth is required"
       },
@@ -1881,7 +1883,32 @@
     "close": "Close",
     "guestEmailPlaceholder": "guest@example.com",
     "generateError": "Failed to generate check-in link. Please try again.",
-    "checkinEmailBody": "Dear guest,\n\nClick the link below to complete your check-in:\n\n{{url}}\n\nCasaZen"
+    "checkinEmailBody": "Dear guest,\n\nClick the link below to complete your check-in:\n\n{{url}}\n\nCasaZen",
+    "firstName": "First name *",
+    "lastName": "Last name *",
+    "stepPersonal": "Personal details",
+    "stepDocument": "Identity document",
+    "stepConsents": "Consents",
+    "stepOf": "Step {{step}} of {{total}}",
+    "next": "Next",
+    "back": "Back",
+    "submit": "Submit check-in",
+    "successTitle": "Check-in complete!",
+    "successDescription": "Your details have been recorded. Thank you!",
+    "marketingConsent": "I agree to receive promotional communications (optional).",
+    "sessionLabel": "Guest check-in status",
+    "sessionLoading": "Loading session status...",
+    "noSession": "No active check-in session.",
+    "resendLink": "Send reminder",
+    "resendSuccess": "Check-in link resent to guest.",
+    "resendError": "Failed to resend check-in link.",
+    "status": {
+      "Inviato": "Link sent",
+      "InCompilazione": "In progress",
+      "Completo": "Complete",
+      "AlloggiatiInviato": "Alloggiati submitted",
+      "Scaduto": "Expired"
+    }
   },
   "publicSite": {
     "skipToContent": "Skip to content",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1812,6 +1812,8 @@
       "Other": "Altro"
     },
     "validation": {
+      "firstName": { "required": "Nome obbligatorio" },
+      "lastName": { "required": "Cognome obbligatorio" },
       "dateOfBirth": {
         "required": "Data di nascita obbligatoria"
       },
@@ -1883,7 +1885,32 @@
     "close": "Chiudi",
     "guestEmailPlaceholder": "ospite@esempio.com",
     "generateError": "Impossibile generare il link di check-in. Riprova.",
-    "checkinEmailBody": "Gentile ospite,\n\nClicca sul link sottostante per completare il check-in:\n\n{{url}}\n\nCasaZen"
+    "checkinEmailBody": "Gentile ospite,\n\nClicca sul link sottostante per completare il check-in:\n\n{{url}}\n\nCasaZen",
+    "firstName": "Nome *",
+    "lastName": "Cognome *",
+    "stepPersonal": "Dati anagrafici",
+    "stepDocument": "Documento d'identita'",
+    "stepConsents": "Consensi",
+    "stepOf": "Passo {{step}} di {{total}}",
+    "next": "Avanti",
+    "back": "Indietro",
+    "submit": "Invia check-in",
+    "successTitle": "Check-in completato!",
+    "successDescription": "I tuoi dati sono stati registrati. Grazie!",
+    "marketingConsent": "Acconsento a ricevere comunicazioni promozionali (facoltativo).",
+    "sessionLabel": "Stato check-in ospite",
+    "sessionLoading": "Caricamento stato sessione...",
+    "noSession": "Nessuna sessione check-in attiva.",
+    "resendLink": "Invia sollecito",
+    "resendSuccess": "Link check-in reinviato all'ospite.",
+    "resendError": "Impossibile reinviare il link check-in.",
+    "status": {
+      "Inviato": "Link inviato",
+      "InCompilazione": "In compilazione",
+      "Completo": "Completato",
+      "AlloggiatiInviato": "Alloggiati inviato",
+      "Scaduto": "Scaduto"
+    }
   },
   "publicSite": {
     "skipToContent": "Vai al contenuto",
@@ -2124,6 +2151,91 @@
     "platformDescription": "Piattaforma gestione affitti brevi",
     "signInMessage": "Accedi per gestire proprieta, prenotazioni e pagamenti",
     "signInButton": "Accedi con Auth0"
+  },
+  "compliance": {
+    "status": {
+      "Pending": "In attesa",
+      "Active": "Attivo",
+      "Suspended": "Sospeso"
+    },
+    "page": {
+      "title": "Cockpit compliance",
+      "description": "Attività di compliance in sospeso per immobili e prenotazioni"
+    },
+    "summary": {
+      "title": "Panoramica compliance",
+      "description": "Immobili e prenotazioni che richiedono attenzione",
+      "loading": "Caricamento riepilogo compliance...",
+      "error": "Impossibile caricare il riepilogo compliance.",
+      "viewAll": "Vedi tutto",
+      "allClear": "Tutte le attività di compliance sono aggiornate.",
+      "none": "Nessuna attività in sospeso",
+      "propertiesPending": "Immobili in attesa di attivazione",
+      "guestCheckIns": "Check-in ospiti incompleti",
+      "checkoutsDue": "Check-out in scadenza",
+      "alloggiatiFailures": "Errori Alloggiati"
+    },
+    "properties": {
+      "openWizard": "Wizard attivazione",
+      "publishBlocked": "Completa il wizard di attivazione prima di pubblicare l'immobile."
+    },
+    "activation": {
+      "loading": "Caricamento wizard attivazione...",
+      "notFound": "Immobile non trovato",
+      "title": "Attiva {{name}}",
+      "description": "Completa tutti i passaggi richiesti per pubblicare il tuo immobile su CasaZen.",
+      "ctaTitle": "Immobile non ancora attivo",
+      "ctaDescription": "Completa il wizard di attivazione per soddisfare i requisiti di compliance per affitti brevi.",
+      "openWizard": "Apri wizard attivazione",
+      "cinLabel": "Codice CIN",
+      "cinGuidance": "Come ottenere il codice CIN",
+      "saveAndContinue": "Salva e continua",
+      "continue": "Continua",
+      "documentsHint": "Carica i documenti obbligatori (licenza, assicurazione, certificati di sicurezza).",
+      "safetyHint": "Conferma che le attrezzature di sicurezza obbligatorie sono presenti e conformi.",
+      "safety": {
+        "smokeDetector": "Rilevatore di fumo installato e funzionante",
+        "fireExtinguisher": "Estintore presente e ispezionato",
+        "gasCompliance": "Certificato conformità impianto gas in archivio"
+      },
+      "touristTaxHint": "Configura le aliquote di soggiorno per {{city}} prima di accettare ospiti.",
+      "touristTaxAdmin": "Apri impostazioni tassa di soggiorno",
+      "tosAccept": "Confermo che l'immobile soddisfa i requisiti di compliance CasaZen",
+      "backToEdit": "Torna alla modifica immobile",
+      "complete": "Completa attivazione",
+      "completed": "Immobile attivato con successo",
+      "blockersRemain": "Attivazione salvata — completa i blocchi rimanenti per pubblicare.",
+      "completeFailed": "Impossibile completare l'attivazione"
+    },
+    "checkout": {
+      "loading": "Caricamento wizard check-out...",
+      "notFound": "Prenotazione non trovata",
+      "unavailable": "Wizard check-out non disponibile",
+      "unavailableHint": "Questa prenotazione non è ancora idonea al check-out.",
+      "title": "Check-out ospite",
+      "description": "Completa il check-out per {{guest}}",
+      "confirmDepartureLabel": "Confermo che l'ospite ha lasciato la struttura ed è pronta per il turnover.",
+      "summaryGuestData": "Dati identità ospite conservati secondo obblighi di legge",
+      "summaryAlloggiati": "Stato invio Alloggiati Web verificato",
+      "summaryRetention": "Periodo di conservazione documenti confermato",
+      "supplierHint": "Prenota opzionalmente servizi di turnover dai fornitori del marketplace.",
+      "noSuppliers": "Nessun fornitore disponibile per questo comune.",
+      "serviceNotes": "Note per il fornitore",
+      "paymentHint": "Verifica pagamenti in sospeso e riscossione tassa di soggiorno prima di chiudere il soggiorno.",
+      "propertyReadyHint": "Conferma che l'immobile è pulito e pronto per il prossimo ospite.",
+      "next": "Passo successivo",
+      "backToBooking": "Torna alla prenotazione",
+      "complete": "Completa check-out",
+      "completed": "Check-out completato con successo",
+      "completeFailed": "Impossibile completare il check-out",
+      "steps": {
+        "confirm-departure": "Conferma che l'ospite ha lasciato la struttura.",
+        "compliance-summary": "Rivedi gli obblighi di compliance per questo soggiorno.",
+        "supplier-selection": "Seleziona servizi di turnover se necessario.",
+        "payment": "Salda pagamenti e depositi.",
+        "property-ready": "Segna l'immobile pronto per la prossima prenotazione."
+      }
+    }
   },
   "toast": {
     "propertyCreated": "Immobile creato con successo",

--- a/src/queries/use-checkin.ts
+++ b/src/queries/use-checkin.ts
@@ -1,15 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { checkinApi } from '@/api/checkin.api';
-import type { SubmitGuestCheckInRequest } from '@/types/alloggiati.types';
+import { publicCheckinApi } from '@/api/checkin.api';
+import { bookingsApi } from '@/api/bookings.api';
+import type { PublicCheckInSubmitRequest } from '@/types/public-checkin.types';
 import { toast } from 'sonner';
 import i18n from '@/i18n/config';
 
 const CHECKIN_KEY = 'checkin';
+const CHECKIN_SESSION_KEY = 'checkin-session';
 
 export function useCheckInContext(token: string) {
   return useQuery({
     queryKey: [CHECKIN_KEY, token],
-    queryFn: () => checkinApi.getContext(token),
+    queryFn: () => publicCheckinApi.getContext(token),
     enabled: !!token,
     retry: 1,
   });
@@ -19,7 +21,7 @@ export function useSubmitGuestCheckIn(token: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: SubmitGuestCheckInRequest) => checkinApi.submitGuestData(token, data),
+    mutationFn: (data: PublicCheckInSubmitRequest) => publicCheckinApi.submit(token, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [CHECKIN_KEY, token] });
       toast.success(i18n.t('toast.checkInDataSaved'));
@@ -30,17 +32,25 @@ export function useSubmitGuestCheckIn(token: string) {
   });
 }
 
-export function useUploadCheckInDocument(token: string) {
+export function useBookingCheckInSession(bookingId: string) {
+  return useQuery({
+    queryKey: [CHECKIN_SESSION_KEY, bookingId],
+    queryFn: () => bookingsApi.getCheckInSession(bookingId),
+    enabled: !!bookingId,
+  });
+}
+
+export function useResendCheckInLink(bookingId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (file: File) => checkinApi.uploadDocument(token, file),
+    mutationFn: () => bookingsApi.resendCheckInLink(bookingId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [CHECKIN_KEY, token] });
-      toast.success(i18n.t('toast.checkInDocumentUploaded'));
+      queryClient.invalidateQueries({ queryKey: [CHECKIN_SESSION_KEY, bookingId] });
+      toast.success(i18n.t('checkin.resendSuccess'));
     },
     onError: () => {
-      toast.error(i18n.t('toast.checkInDocumentUploadFailed'));
+      toast.error(i18n.t('checkin.resendError'));
     },
   });
 }

--- a/src/types/public-checkin.types.ts
+++ b/src/types/public-checkin.types.ts
@@ -1,0 +1,51 @@
+export type GuestCheckInSessionStatus =
+  | 'Inviato'
+  | 'InCompilazione'
+  | 'Completo'
+  | 'AlloggiatiInviato'
+  | 'Scaduto';
+
+export interface PublicCheckInGuestPrefill {
+  firstName: string;
+  lastName: string;
+  email: string;
+  dateOfBirth?: string | null;
+  nationality: string;
+  documentNumber: string;
+  documentIssuingCountry: string;
+  placeOfBirth: string;
+}
+
+export interface PublicCheckInContextDto {
+  sessionId: string;
+  propertyName: string;
+  checkInDate: string;
+  checkOutDate: string;
+  status: GuestCheckInSessionStatus;
+  guestPrefill?: PublicCheckInGuestPrefill | null;
+}
+
+export interface PublicCheckInSubmitRequest {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  nationality: string;
+  documentType: string;
+  documentNumber: string;
+  documentIssuingCountry: string;
+  placeOfBirth: string;
+  gdprConsent: boolean;
+  marketingConsent: boolean;
+}
+
+export interface CheckInSessionStatusDto {
+  sessionId?: string | null;
+  status?: GuestCheckInSessionStatus | null;
+  sentAt?: string | null;
+  completedAt?: string | null;
+}
+
+export interface ResendCheckInLinkResponse {
+  success: boolean;
+  message?: string | null;
+}


### PR DESCRIPTION
## Summary
- 3-step public CheckInPage wizard at /checkin/:token using /api/public/checkin
- CheckInSessionBadge + resend button on booking detail guest tab
- i18n checkin.* keys (it/en)
- Playwright E2E guest-checkin-portal.spec.ts

## Backend PR
https://github.com/casazen/backend/pull/new/feature/296-guest-check-in-portal

## Test Plan
- [x] npm run build
- [x] tsc pass
- [ ] E2E guest-checkin-portal with local backend

Closes casazen/backend#296

Made with [Cursor](https://cursor.com)