### PR TITLE
feat(domain): custom domain settings UI + host redirect (#298)

### DIFF
--- a/e2e/custom-domain-settings.spec.ts
+++ b/e2e/custom-domain-settings.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from './test';
+import { demoUrl } from './helpers/demo-profile';
+
+const DEMO_ORG_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1';
+
+test.describe('Custom domain settings (#298)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(`**/api/orgs/${DEMO_ORG_ID}/domain`, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            orgId: DEMO_ORG_ID,
+            publicHostMode: 'CasazenSubdomain',
+            subdomain: 'villa-demo',
+            customDomain: null,
+            domainVerificationStatus: 'Pending',
+            canUseCustomDomain: true,
+            dnsInstructions: null,
+            publicUrls: {
+              pathUrl: 'https://casazen.app/book/villa-demo',
+              subdomainUrl: 'https://villa-demo.casazen.it',
+              customDomainUrl: null,
+            },
+          }),
+        });
+        return;
+      }
+
+      if (route.request().method() === 'POST' && !route.request().url().includes('/verify')) {
+        const body = route.request().postDataJSON() as { hostMode: string; customDomain?: string };
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            orgId: DEMO_ORG_ID,
+            publicHostMode: body.hostMode,
+            subdomain: null,
+            customDomain: body.customDomain ?? null,
+            domainVerificationStatus: body.hostMode === 'CustomDomain' ? 'Pending' : 'Pending',
+            canUseCustomDomain: true,
+            dnsInstructions: body.hostMode === 'CustomDomain'
+              ? {
+                  cnameHost: body.customDomain,
+                  cnameTarget: 'cname.vercel-dns.com',
+                  txtHost: `_casazen-challenge.${body.customDomain}`,
+                  txtValue: 'demo-token',
+                  sslNote: 'SSL automatico via Vercel',
+                }
+              : null,
+            publicUrls: {
+              pathUrl: 'https://casazen.app/book/villa-demo',
+              subdomainUrl: null,
+              customDomainUrl: body.customDomain ? `https://${body.customDomain}` : null,
+            },
+          }),
+        });
+        return;
+      }
+
+      await route.fallback();
+    });
+
+    await page.route('**/api/orgs/me/entitlement', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          orgId: DEMO_ORG_ID,
+          planTier: 'Pro',
+          limits: { maxProperties: 50 },
+          usage: { properties: 1 },
+          canAddProperty: true,
+          canUseCustomDomain: true,
+        }),
+      });
+    });
+  });
+
+  test('AC9: domain settings page loads current config', async ({ page }) => {
+    await page.goto(demoUrl('/app/short-rent/settings/domain'));
+    await expect(page.getByTestId('custom-domain-settings-page')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('domain-current-config')).toBeVisible();
+    await expect(page.getByText('villa-demo.casazen.it')).toBeVisible();
+  });
+
+  test('AC9: saving custom domain shows DNS instructions', async ({ page }) => {
+    await page.goto(demoUrl('/app/short-rent/settings/domain'));
+    await expect(page.getByTestId('custom-domain-settings-page')).toBeVisible({ timeout: 15_000 });
+
+    await page.locator('[data-testid="host-mode-radio"]').selectOption('CustomDomain');
+    await page.getByTestId('custom-domain-input').fill('www.demo-villa.it');
+    await page.getByTestId('save-domain-settings').click();
+
+    await expect(page.getByTestId('dns-instructions-panel')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('copy-txt-value')).toBeVisible();
+  });
+});

--- a/src/api/domain.api.ts
+++ b/src/api/domain.api.ts
@@ -1,0 +1,21 @@
+import { ApiClient } from '@/api/client';
+import type {
+  OrgDomainConfig,
+  OrgDomainVerifyResult,
+  ResolveHostResponse,
+  SetOrgDomainRequest,
+} from '@/types/domain.types';
+
+export const DomainApi = {
+  getDomain: (orgId: string): Promise<OrgDomainConfig> =>
+    ApiClient.get<OrgDomainConfig>(`/orgs/${orgId}/domain`),
+
+  setDomain: (orgId: string, payload: SetOrgDomainRequest): Promise<OrgDomainConfig> =>
+    ApiClient.post<OrgDomainConfig>(`/orgs/${orgId}/domain`, payload),
+
+  verifyDomain: (orgId: string): Promise<OrgDomainVerifyResult> =>
+    ApiClient.post<OrgDomainVerifyResult>(`/orgs/${orgId}/domain/verify`, {}),
+
+  resolveHost: (host: string): Promise<ResolveHostResponse> =>
+    ApiClient.get<ResolveHostResponse>('/public/resolve-host', { host }),
+};

--- a/src/config/route-manifest.ts
+++ b/src/config/route-manifest.ts
@@ -103,6 +103,19 @@ export const ROUTE_MANIFEST: RouteManifestEntry[] = [
     legacyPaths: ['/properties/:id/pricing/history'],
   },
   {
+    path: '/app/short-rent/settings/domain',
+    context: 'short-rent',
+    requiredPermissions: ['property.write'],
+    navKey: 'nav.domain',
+    navGroup: 'account',
+    navPlacement: 'secondary',
+    navOrder: 4,
+    icon: 'Globe',
+    component: async () => ({
+      default: (await import('@/features/settings/domain/custom-domain-settings-page')).CustomDomainSettingsPage,
+    }),
+  },
+  {
     path: '/app/short-rent/settings/plan',
     context: 'short-rent',
     requiredPermissions: ['property.read'],

--- a/src/features/settings/domain/custom-domain-settings-page.tsx
+++ b/src/features/settings/domain/custom-domain-settings-page.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { AppShell } from '@/components/layout/app-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useCurrentUser, useEntitlement } from '@/queries/use-users';
+import { needsOrgSetup } from '@/lib/onboarding';
+import type { PublicHostMode } from '@/types/domain.types';
+import { DnsInstructionsPanel } from './dns-instructions-panel';
+import { DomainStatusBadge } from './domain-status-badge';
+import { useOrgDomain, useSetOrgDomain, useVerifyOrgDomain } from './use-org-domain';
+
+export function CustomDomainSettingsPage() {
+  const { t } = useTranslation();
+  const { org, user } = useCurrentUser();
+  const { data: entitlement } = useEntitlement();
+  const { data: domainConfig, isLoading } = useOrgDomain(org?.id);
+  const setDomain = useSetOrgDomain(org?.id);
+  const verifyDomain = useVerifyOrgDomain(org?.id);
+
+  const [hostMode, setHostMode] = useState<PublicHostMode>('CasazenPath');
+  const [subdomain, setSubdomain] = useState('');
+  const [customDomain, setCustomDomain] = useState('');
+
+  useEffect(() => {
+    if (!domainConfig) return;
+    setHostMode(domainConfig.publicHostMode);
+    setSubdomain(domainConfig.subdomain ?? '');
+    setCustomDomain(domainConfig.customDomain ?? '');
+  }, [domainConfig]);
+
+  if (user && needsOrgSetup(user)) {
+    return <Navigate to="/onboarding" replace />;
+  }
+
+  if (!org) {
+    return (
+      <AppShell>
+        <p className="text-muted-foreground">{t('domain.settings.noOrg')}</p>
+      </AppShell>
+    );
+  }
+
+  const canUseCustomDomain = entitlement?.canUseCustomDomain ?? domainConfig?.canUseCustomDomain ?? false;
+  const effectiveMode = domainConfig?.publicHostMode ?? hostMode;
+
+  const handleSave = async () => {
+    await setDomain.mutateAsync({
+      hostMode,
+      subdomain: hostMode === 'CasazenSubdomain' ? subdomain || org.slug : undefined,
+      customDomain: hostMode === 'CustomDomain' ? customDomain : undefined,
+    });
+  };
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-3xl space-y-6" data-testid="custom-domain-settings-page">
+        <PageHeader
+          title={t('domain.settings.title')}
+          description={t('domain.settings.description')}
+        />
+
+        {isLoading ? (
+          <p className="text-muted-foreground">{t('domain.settings.loading')}</p>
+        ) : (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle>{t('domain.settings.modeTitle')}</CardTitle>
+                <CardDescription>{t('domain.settings.modeDescription')}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="host-mode">{t('domain.settings.modeTitle')}</Label>
+                  <select
+                    id="host-mode"
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    value={hostMode}
+                    onChange={(e) => setHostMode(e.target.value as PublicHostMode)}
+                    data-testid="host-mode-radio"
+                  >
+                    <option value="CasazenPath">{t('domain.modes.path')}</option>
+                    <option value="CasazenSubdomain">{t('domain.modes.subdomain')}</option>
+                    <option value="CustomDomain" disabled={!canUseCustomDomain}>
+                      {t('domain.modes.custom')}
+                    </option>
+                  </select>
+                </div>
+
+                {!canUseCustomDomain && (
+                  <p className="text-sm text-muted-foreground" data-testid="upgrade-cta">
+                    {t('domain.settings.upgradeCta')}{' '}
+                    <Link to="/app/short-rent/settings/plan" className="underline">
+                      {t('domain.settings.upgradeLink')}
+                    </Link>
+                  </p>
+                )}
+
+                {hostMode === 'CasazenSubdomain' && (
+                  <div className="space-y-2">
+                    <Label htmlFor="subdomain">{t('domain.settings.subdomainLabel')}</Label>
+                    <Input
+                      id="subdomain"
+                      data-testid="subdomain-input"
+                      placeholder={org.slug}
+                      value={subdomain}
+                      onChange={(e) => setSubdomain(e.target.value)}
+                    />
+                  </div>
+                )}
+
+                {hostMode === 'CustomDomain' && canUseCustomDomain && (
+                  <div className="space-y-2">
+                    <Label htmlFor="custom-domain">{t('domain.settings.customDomainLabel')}</Label>
+                    <Input
+                      id="custom-domain"
+                      data-testid="custom-domain-input"
+                      placeholder="www.tuovilla.it"
+                      value={customDomain}
+                      onChange={(e) => setCustomDomain(e.target.value)}
+                    />
+                  </div>
+                )}
+
+                <Button
+                  type="button"
+                  onClick={() => void handleSave()}
+                  disabled={setDomain.isPending}
+                  data-testid="save-domain-settings"
+                >
+                  {t('domain.settings.save')}
+                </Button>
+              </CardContent>
+            </Card>
+
+            {domainConfig && (
+              <Card data-testid="domain-current-config">
+                <CardHeader className="flex flex-row items-center justify-between gap-4">
+                  <div>
+                    <CardTitle>{t('domain.settings.currentTitle')}</CardTitle>
+                    <CardDescription>
+                      {t(`domain.modes.${effectiveMode === 'CasazenPath' ? 'path' : effectiveMode === 'CasazenSubdomain' ? 'subdomain' : 'custom'}`)}
+                    </CardDescription>
+                  </div>
+                  {domainConfig.customDomain && (
+                    <DomainStatusBadge status={domainConfig.domainVerificationStatus} />
+                  )}
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  <p>
+                    <span className="font-medium">{t('domain.settings.pathUrl')}:</span>{' '}
+                    <a href={domainConfig.publicUrls.pathUrl} className="underline" target="_blank" rel="noreferrer">
+                      {domainConfig.publicUrls.pathUrl}
+                    </a>
+                  </p>
+                  {domainConfig.publicUrls.subdomainUrl && (
+                    <p>
+                      <span className="font-medium">{t('domain.settings.subdomainUrl')}:</span>{' '}
+                      {domainConfig.publicUrls.subdomainUrl}
+                    </p>
+                  )}
+                  {domainConfig.publicUrls.customDomainUrl && (
+                    <p>
+                      <span className="font-medium">{t('domain.settings.customDomainUrl')}:</span>{' '}
+                      {domainConfig.publicUrls.customDomainUrl}
+                    </p>
+                  )}
+
+                  {domainConfig.dnsInstructions && (
+                    <DnsInstructionsPanel instructions={domainConfig.dnsInstructions} />
+                  )}
+
+                  {domainConfig.publicHostMode === 'CustomDomain' &&
+                    domainConfig.domainVerificationStatus !== 'Verified' && (
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        data-testid="verify-domain-button"
+                        disabled={verifyDomain.isPending}
+                        onClick={() => void verifyDomain.mutateAsync()}
+                      >
+                        {t('domain.settings.verify')}
+                      </Button>
+                    )}
+                </CardContent>
+              </Card>
+            )}
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/src/features/settings/domain/dns-instructions-panel.tsx
+++ b/src/features/settings/domain/dns-instructions-panel.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from 'react-i18next';
+import { Copy } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { DnsInstructions } from '@/types/domain.types';
+import { toast } from 'sonner';
+
+interface DnsInstructionsPanelProps {
+  instructions: DnsInstructions;
+}
+
+async function copyValue(value: string, label: string) {
+  await navigator.clipboard.writeText(value);
+  toast.success(label);
+}
+
+export function DnsInstructionsPanel({ instructions }: DnsInstructionsPanelProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Card data-testid="dns-instructions-panel">
+      <CardHeader>
+        <CardTitle>{t('domain.dns.title')}</CardTitle>
+        <CardDescription>{t('domain.dns.description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div className="space-y-1">
+          <p className="font-medium">{t('domain.dns.cname')}</p>
+          <p className="text-muted-foreground break-all">
+            {instructions.cnameHost} → {instructions.cnameTarget}
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void copyValue(instructions.cnameTarget, t('domain.dns.copied'))}
+          >
+            <Copy className="mr-2 h-4 w-4" />
+            {t('domain.dns.copyCname')}
+          </Button>
+        </div>
+
+        <div className="space-y-1">
+          <p className="font-medium">{t('domain.dns.txt')}</p>
+          <p className="text-muted-foreground break-all">
+            {instructions.txtHost} = {instructions.txtValue}
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="copy-txt-value"
+            onClick={() => void copyValue(instructions.txtValue, t('domain.dns.copied'))}
+          >
+            <Copy className="mr-2 h-4 w-4" />
+            {t('domain.dns.copyTxt')}
+          </Button>
+        </div>
+
+        <p className="text-muted-foreground">{instructions.sslNote}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/settings/domain/domain-status-badge.tsx
+++ b/src/features/settings/domain/domain-status-badge.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
+import type { DomainVerificationStatus } from '@/types/domain.types';
+
+interface DomainStatusBadgeProps {
+  status: DomainVerificationStatus;
+}
+
+export function DomainStatusBadge({ status }: DomainStatusBadgeProps) {
+  const { t } = useTranslation();
+
+  const variant =
+    status === 'Verified' ? 'default' : status === 'Failed' ? 'destructive' : 'secondary';
+
+  return (
+    <Badge variant={variant} data-testid="domain-status-badge">
+      {t(`domain.status.${status}`)}
+    </Badge>
+  );
+}

--- a/src/features/settings/domain/use-org-domain.ts
+++ b/src/features/settings/domain/use-org-domain.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { DomainApi } from '@/api/domain.api';
+import type { SetOrgDomainRequest } from '@/types/domain.types';
+import { toast } from 'sonner';
+import i18n from '@/i18n/config';
+
+export const ORG_DOMAIN_QUERY_KEY = 'org-domain';
+
+export function useOrgDomain(orgId?: string) {
+  return useQuery({
+    queryKey: [ORG_DOMAIN_QUERY_KEY, orgId],
+    queryFn: () => DomainApi.getDomain(orgId!),
+    enabled: !!orgId,
+  });
+}
+
+export function useSetOrgDomain(orgId?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: SetOrgDomainRequest) => DomainApi.setDomain(orgId!, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [ORG_DOMAIN_QUERY_KEY, orgId] });
+      toast.success(i18n.t('domain.settings.saved'));
+    },
+    onError: () => toast.error(i18n.t('domain.settings.saveFailed')),
+  });
+}
+
+export function useVerifyOrgDomain(orgId?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => DomainApi.verifyDomain(orgId!),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: [ORG_DOMAIN_QUERY_KEY, orgId] });
+      if (result.domainVerificationStatus === 'Verified') {
+        toast.success(i18n.t('domain.settings.verifySuccess'));
+      } else {
+        toast.warning(result.message ?? i18n.t('domain.settings.verifyFailed'));
+      }
+    },
+    onError: () => toast.error(i18n.t('domain.settings.verifyFailed')),
+  });
+}

--- a/src/hooks/use-custom-host-redirect.ts
+++ b/src/hooks/use-custom-host-redirect.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { DomainApi } from '@/api/domain.api';
+
+const DEFAULT_HOST_SUFFIXES = ['casazen.app', 'casazen.it', 'localhost', 'vercel.app'];
+
+function isDefaultAppHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return DEFAULT_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
+}
+
+/**
+ * Client-side fallback when Vercel Edge middleware is unavailable (#298 AC7).
+ * Rewrites custom/subdomain hosts to /book/{slug} using resolve-host.
+ */
+export function useCustomHostRedirect() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const hostname = window.location.hostname;
+    if (isDefaultAppHost(hostname)) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const resolved = await DomainApi.resolveHost(hostname);
+        if (cancelled || !resolved?.slug) return;
+
+        const targetPath = `/book/${resolved.slug}${window.location.pathname === '/' ? '' : window.location.pathname}`;
+        if (window.location.pathname.startsWith(`/book/${resolved.slug}`)) return;
+
+        navigate(`${targetPath}${window.location.search}${window.location.hash}`, { replace: true });
+      } catch {
+        // Unknown host — PublicSiteShell / 404 handling applies.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate]);
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -119,7 +119,9 @@
       "sendInvite": "Send invitation",
       "toast": {
         "success": "Invitation sent — expires {{expiresAt}}",
-        "error": "Unable to send the invitation"
+        "error": "Unable to send the invitation",
+        "duplicate": "An active invitation already exists for this email",
+        "emailFailed": "Email delivery failed — please try again in a few minutes"
       }
     },
     "seo": {
@@ -187,6 +189,7 @@
     "payments": "Payments",
     "revenue": "Revenue",
     "stripeConnect": "Payouts",
+    "domain": "Public domain",
     "ota": "OTA",
     "leases": "Leases",
     "users": "Users",
@@ -1430,7 +1433,50 @@
     "verificationIncompleteDescription": "Stripe requires additional documents. Click \"Complete verification\" to continue the onboarding.",
     "accountActiveMessage": "Your account can accept payments. Funds are credited directly to your Stripe account — CasaZen does not hold your earnings.",
     "managePlanIn": "Manage SaaS plan in",
-    "planSettings": "Plan settings"
+    "domainLink": "Domain settings"
+  },
+  "domain": {
+    "status": {
+      "Pending": "Pending",
+      "Verified": "Verified",
+      "Failed": "Failed"
+    },
+    "modes": {
+      "path": "CasaZen path (/book/{slug})",
+      "subdomain": "CasaZen subdomain ({slug}.casazen.it)",
+      "custom": "Custom domain (Pro)"
+    },
+    "settings": {
+      "title": "Public booking domain",
+      "description": "Choose how guests reach your branded booking site.",
+      "loading": "Loading domain settings...",
+      "noOrg": "No organization found for your account.",
+      "modeTitle": "Publication mode",
+      "modeDescription": "Starter supports path and subdomain. Custom domains require Pro.",
+      "subdomainLabel": "Subdomain label",
+      "customDomainLabel": "Custom domain",
+      "save": "Save domain settings",
+      "saved": "Domain settings saved",
+      "saveFailed": "Could not save domain settings",
+      "verify": "Verify DNS",
+      "verifySuccess": "Domain verified successfully",
+      "verifyFailed": "DNS verification failed — check your records and try again",
+      "upgradeCta": "Custom domains are available on Pro.",
+      "upgradeLink": "Upgrade plan",
+      "currentTitle": "Current configuration",
+      "pathUrl": "Path URL",
+      "subdomainUrl": "Subdomain URL",
+      "customDomainUrl": "Custom domain URL"
+    },
+    "dns": {
+      "title": "DNS instructions",
+      "description": "Add these records at your DNS provider, then click Verify.",
+      "cname": "CNAME record",
+      "txt": "TXT verification record",
+      "copyCname": "Copy CNAME target",
+      "copyTxt": "Copy TXT value",
+      "copied": "Copied to clipboard"
+    }
   },
   "vetrina": {
     "title": "Showcase",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -119,7 +119,9 @@
       "sendInvite": "Invia invito",
       "toast": {
         "success": "Invito inviato — scade {{expiresAt}}",
-        "error": "Impossibile inviare l'invito"
+        "error": "Impossibile inviare l'invito",
+        "duplicate": "Esiste già un invito attivo per questa email",
+        "emailFailed": "Consegna email fallita — riprova tra qualche minuto"
       }
     },
     "seo": {
@@ -187,6 +189,7 @@
     "payments": "Incassi",
     "revenue": "Ricavi",
     "stripeConnect": "Incassi e Payout",
+    "domain": "Dominio pubblico",
     "ota": "OTA",
     "leases": "Contratti",
     "users": "Utenti",
@@ -1432,7 +1435,51 @@
     "verificationIncompleteDescription": "Stripe richiede documenti aggiuntivi. Clicca \"Completa la verifica\" per continuare l'onboarding.",
     "accountActiveMessage": "Il tuo account può accettare pagamenti. I fondi vengono accreditati direttamente sul tuo conto Stripe — CasaZen non trattiene i tuoi incassi.",
     "managePlanIn": "Gestisci il piano SaaS in",
+    "domainLink": "Impostazioni dominio",
     "planSettings": "Impostazioni piano"
+  },
+  "domain": {
+    "status": {
+      "Pending": "In attesa",
+      "Verified": "Verificato",
+      "Failed": "Non verificato"
+    },
+    "modes": {
+      "path": "Percorso CasaZen (/book/{slug})",
+      "subdomain": "Sottodominio CasaZen ({slug}.casazen.it)",
+      "custom": "Dominio personalizzato (Pro)"
+    },
+    "settings": {
+      "title": "Dominio prenotazioni pubblico",
+      "description": "Scegli come gli ospiti raggiungono il tuo sito di prenotazione brandizzato.",
+      "loading": "Caricamento impostazioni dominio…",
+      "noOrg": "Nessuna organizzazione trovata per il tuo account.",
+      "modeTitle": "Modalità di pubblicazione",
+      "modeDescription": "Starter supporta percorso e sottodominio. I domini personalizzati richiedono Pro.",
+      "subdomainLabel": "Etichetta sottodominio",
+      "customDomainLabel": "Dominio personalizzato",
+      "save": "Salva impostazioni dominio",
+      "saved": "Impostazioni dominio salvate",
+      "saveFailed": "Impossibile salvare le impostazioni dominio",
+      "verify": "Verifica DNS",
+      "verifySuccess": "Dominio verificato con successo",
+      "verifyFailed": "Verifica DNS non riuscita — controlla i record e riprova",
+      "upgradeCta": "I domini personalizzati sono disponibili con Pro.",
+      "upgradeLink": "Passa a Pro",
+      "currentTitle": "Configurazione attuale",
+      "pathUrl": "URL percorso",
+      "subdomainUrl": "URL sottodominio",
+      "customDomainUrl": "URL dominio personalizzato"
+    },
+    "dns": {
+      "title": "Istruzioni DNS",
+      "description": "Aggiungi questi record presso il tuo provider DNS, poi clicca Verifica.",
+      "cname": "Record CNAME",
+      "txt": "Record TXT di verifica",
+      "copyCname": "Copia target CNAME",
+      "copyTxt": "Copia valore TXT",
+      "copied": "Copiato negli appunti"
+    }
   },
   "vetrina": {
     "title": "Vetrina",

--- a/src/layouts/PublicSiteShell.tsx
+++ b/src/layouts/PublicSiteShell.tsx
@@ -3,6 +3,7 @@ import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Loader2, Menu } from 'lucide-react';
 import { usePublicOrg } from '@/queries/use-public-org';
+import { useCustomHostRedirect } from '@/hooks/use-custom-host-redirect';
 import { CookieConsentBanner } from '@/components/shared/cookie-consent-banner';
 import { PublicOrgNotFoundPage } from '@/features/public-booking/public-org-not-found-page';
 import { Footer } from '@/features/public-site/components/Footer';
@@ -29,6 +30,7 @@ function scrollToBookingWidget() {
 }
 
 export function PublicSiteShell({ mode = 'org' }: PublicSiteShellProps) {
+  useCustomHostRedirect();
   const { t } = useTranslation();
   const { orgSlug } = useParams<{ orgSlug: string }>();
   const location = useLocation();

--- a/src/types/domain.types.ts
+++ b/src/types/domain.types.ts
@@ -1,0 +1,58 @@
+export type PublicHostMode = 'CasazenPath' | 'CasazenSubdomain' | 'CustomDomain';
+
+export type DomainVerificationStatus = 'Pending' | 'Verified' | 'Failed';
+
+export interface DnsInstructions {
+  cnameHost: string;
+  cnameTarget: string;
+  txtHost: string;
+  txtValue: string;
+  sslNote: string;
+}
+
+export interface PublicUrls {
+  pathUrl: string;
+  subdomainUrl?: string | null;
+  customDomainUrl?: string | null;
+}
+
+export interface OrgDomainConfig {
+  orgId: string;
+  publicHostMode: PublicHostMode;
+  subdomain?: string | null;
+  customDomain?: string | null;
+  domainVerificationStatus: DomainVerificationStatus;
+  canUseCustomDomain: boolean;
+  dnsInstructions?: DnsInstructions | null;
+  publicUrls: PublicUrls;
+}
+
+export interface SetOrgDomainRequest {
+  hostMode: PublicHostMode;
+  customDomain?: string;
+  subdomain?: string;
+}
+
+export interface OrgDomainVerifyResult {
+  domainVerificationStatus: DomainVerificationStatus;
+  customDomain: string;
+  checkedAt: string;
+  message?: string | null;
+}
+
+export interface ResolveHostResponse {
+  orgId: string;
+  slug: string;
+  publicHostMode: PublicHostMode;
+  planTier: string;
+  branding: {
+    logoUrl?: string | null;
+    primaryColor?: string | null;
+    publicThemeId?: string | null;
+    heroImageUrl?: string | null;
+    tagline?: string | null;
+    displayName: string;
+    slug: string;
+    showPoweredBy: boolean;
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,5 +13,6 @@ export * from './lease.types';
 export * from './admin.types';
 export * from './users.types';
 export * from './org.types';
+export * from './domain.types';
 export * from './direct-booking.types';
 export * from './alloggiati.types';

--- a/src/types/org.types.ts
+++ b/src/types/org.types.ts
@@ -25,6 +25,7 @@ export interface Entitlement {
   limits: EntitlementLimits;
   usage: EntitlementUsage;
   canAddProperty: boolean;
+  canUseCustomDomain?: boolean;
 }
 
 /** Catalogue entry from GET /api/orgs/plans. maxProperties = -1 means unlimited. */


### PR DESCRIPTION
## Summary
- Domain settings page at /app/short-rent/settings/domain
- DNS instructions panel + verify CTA
- Client-side custom-host redirect in PublicSiteShell
- Playwright E2E custom-domain-settings.spec.ts

## Backend PR
https://github.com/casazen/backend/pull/359

## Test plan
- [x] npm run build
- [ ] npm run test:e2e (custom-domain-settings)

Closes casazen/backend#298

Made with [Cursor](https://cursor.com)