### PR TITLE
fix: Dev Flow Verification bugs 2026-07-14 (#357)

### DIFF
--- a/e2e/admin-supplier-invite.spec.ts
+++ b/e2e/admin-supplier-invite.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from './test';
+import { demoUrl, setDemoProfile } from './helpers/demo-profile';
+import { pinE2eLocale } from './helpers/locale';
+
+test.describe('Admin supplier invite (#357)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setDemoProfile(page, 'admin');
+    await pinE2eLocale(page, 'it');
+  });
+
+  test('AC-A1: invite form renders for admin user', async ({ page }) => {
+    await page.goto(demoUrl('/app/admin/suppliers/invite', 'admin'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByTestId('invite-email-input')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('invite-comune-input')).toBeVisible();
+    await expect(page.getByTestId('invite-submit-btn')).toBeDisabled();
+  });
+
+  test('AC-A1: happy-path invite shows success toast', async ({ page }) => {
+    await page.route('**/api/admin/suppliers/invite', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          inviteId: '11111111-1111-1111-1111-111111111111',
+          expiresAt: '2026-08-01T00:00:00Z',
+        }),
+      });
+    });
+
+    await page.goto(demoUrl('/app/admin/suppliers/invite', 'admin'), { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('invite-email-input').fill('fornitore@example.com');
+    await page.getByTestId('invite-comune-input').fill('H501');
+    await page.getByTestId('invite-submit-btn').click();
+
+    await expect(page.getByText(/Invito inviato — scade/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('AC-A3: duplicate invite shows specific error toast', async ({ page }) => {
+    await page.route('**/api/admin/suppliers/invite', async (route) => {
+      await route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Duplicate', code: 'duplicate_invite' }),
+      });
+    });
+
+    await page.goto(demoUrl('/app/admin/suppliers/invite', 'admin'), { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('invite-email-input').fill('dup@example.com');
+    await page.getByTestId('invite-comune-input').fill('H501');
+    await page.getByTestId('invite-submit-btn').click();
+
+    await expect(page.getByText('Esiste già un invito attivo per questa email')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('AC-A3: email delivery failure shows specific error toast', async ({ page }) => {
+    await page.route('**/api/admin/suppliers/invite', async (route) => {
+      await route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'SendGrid failed', code: 'invite_email_failed' }),
+      });
+    });
+
+    await page.goto(demoUrl('/app/admin/suppliers/invite', 'admin'), { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('invite-email-input').fill('fail@example.com');
+    await page.getByTestId('invite-comune-input').fill('H501');
+    await page.getByTestId('invite-submit-btn').click();
+
+    await expect(page.getByText('Consegna email fallita — riprova tra qualche minuto')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/direct-checkout.spec.ts
+++ b/e2e/direct-checkout.spec.ts
@@ -12,6 +12,7 @@ test.describe('Direct checkout (#226)', () => {
     await mockDirectCheckoutApi(page);
     await page.addInitScript(() => {
       localStorage.removeItem('casazen_cookie_consent');
+      localStorage.setItem('casazen.locale', 'it');
     });
   });
 
@@ -23,7 +24,7 @@ test.describe('Direct checkout (#226)', () => {
     await expect(page.getByTestId('direct-checkout-page')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId('price-breakdown')).toBeVisible();
     await expect(page.getByTestId('gdpr-consent')).toBeVisible();
-    await expect(page.getByText('Tassa di soggiorno')).toBeVisible();
+    await expect(page.getByTestId('price-breakdown').getByText('Tassa di soggiorno', { exact: true })).toBeVisible();
     await expect(page.getByText('Acconsento al trattamento')).toBeVisible();
   });
 

--- a/e2e/helpers/demo-profile.ts
+++ b/e2e/helpers/demo-profile.ts
@@ -10,5 +10,6 @@ export function demoUrl(path: string, profile: DemoProfile): string {
 export async function setDemoProfile(page: Page, profile: DemoProfile): Promise<void> {
   await page.addInitScript((value) => {
     (window as Window & { __E2E_DEMO_PROFILE?: string }).__E2E_DEMO_PROFILE = value;
+    sessionStorage.setItem('casazen:demo-profile', value);
   }, profile);
 }

--- a/e2e/helpers/org-api-mock.ts
+++ b/e2e/helpers/org-api-mock.ts
@@ -21,8 +21,13 @@ function buildDemoMeBody(profile: string) {
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
       onboardingCompletedAt: '2026-01-01T00:00:00Z',
-      orgId: null,
-      org: null,
+      orgId: '22222222-2222-2222-2222-222222222202',
+      org: {
+        id: '22222222-2222-2222-2222-222222222202',
+        name: 'Pulizie Demo Srl',
+        slug: 'pulizie-demo',
+        planTier: 'Starter' as PlanTier,
+      },
     };
   }
 

--- a/e2e/helpers/supplier-console-mock.ts
+++ b/e2e/helpers/supplier-console-mock.ts
@@ -47,8 +47,20 @@ const demoActivationActive: ActivationStatus = {
   steps: demoActivationPending.steps.map((step) => ({ ...step, status: 'completed', blocker: null })),
 };
 
-export async function mockSupplierConsoleApi(page: Page, options?: { active?: boolean }): Promise<void> {
+interface InboxItem {
+  id: string;
+  status: string;
+  propertyName?: string;
+  serviceCategory?: string;
+  requestedAt?: string;
+}
+
+export async function mockSupplierConsoleApi(
+  page: Page,
+  options?: { active?: boolean; inboxItems?: InboxItem[] },
+): Promise<void> {
   const active = options?.active ?? false;
+  const inboxItems = options?.inboxItems ?? [];
   const profile: SupplierProfile = active
     ? { ...demoSupplierProfile, status: 'Active', categories: ['Pulizie'], comuni: ['H501'], bio: 'Servizi demo', tosAcceptedAt: new Date().toISOString() }
     : demoSupplierProfile;
@@ -86,7 +98,11 @@ export async function mockSupplierConsoleApi(page: Page, options?: { active?: bo
     }
 
     if (url.includes('/inbox')) {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [], total: 0 }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: inboxItems, total: inboxItems.length }),
+      });
       return;
     }
 

--- a/e2e/long-term-layer.spec.ts
+++ b/e2e/long-term-layer.spec.ts
@@ -5,7 +5,7 @@ import { resetE2eStorage } from './helpers/locale';
 
 test.describe('Long-term UI layer (#182 acceptance criteria)', () => {
   test.beforeEach(async ({ page }) => {
-    await resetE2eStorage(page, 'en');
+    await resetE2eStorage(page, 'it');
   });
 
   test('AC1 PropertyOwner-only sees short-stay shell without long-term nav', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe('Long-term UI layer (#182 acceptance criteria)', () => {
     await page.goto(demoUrl('/', 'long-term'), { waitUntil: 'domcontentloaded' });
 
     await expect(page).toHaveURL(/\/app\/long-rent\/leases(?:\?.*)?$/, { timeout: 15_000 });
-    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+    await expect(page.getByText(/affitti lungo termine|long-term rental/i)).toBeVisible();
     await expect(page.getByRole('link', { name: /Contratti|Leases/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /Prenotazioni|Bookings/i })).toHaveCount(0);
   });
@@ -29,38 +29,38 @@ test.describe('Long-term UI layer (#182 acceptance criteria)', () => {
     await mockLeasesApiEmpty(page);
     await page.goto(demoUrl('/', 'dual'), { waitUntil: 'domcontentloaded' });
 
-    const switcher = page.getByRole('tablist', { name: 'Workspace context' });
+    const switcher = page.getByRole('tablist', { name: /Workspace context|Contesto applicativo/i });
     await expect(switcher).toBeVisible();
 
     await page.getByRole('tab', { name: 'Affitti lungo termine' }).click();
     await expect(page).toHaveURL(/\/app\/long-rent\/leases/, { timeout: 15_000 });
-    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+    await expect(page.getByText(/affitti lungo termine|long-term rental/i)).toBeVisible();
 
     await page.getByRole('tab', { name: 'Affitti brevi' }).click();
     await expect(page).toHaveURL(/\/app\/short-rent(?:\?.*)?$/, { timeout: 15_000 });
-    await expect(page.getByText(/property manager|short-term rentals|affitti brevi/i)).toBeVisible();
+    await expect(page.getByText(/property manager|short-term rentals|affitti brevi/i).first()).toBeVisible();
   });
 
   test('AC4 long-term layer renders leases list route', async ({ page }) => {
     await mockLeasesApiEmpty(page);
     await page.goto(demoUrl('/leases', 'long-term'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByText(/long-term rental/i)).toBeVisible();
-    await expect(page.getByRole('heading', { name: /long-term leases/i })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/affitti lungo termine|long-term rental/i)).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Contratti lungo termine|long-term leases/i })).toBeVisible({ timeout: 15_000 });
   });
 
   test('AC5 PropertyOwner-only is redirected away from /leases', async ({ page }) => {
     await page.goto(demoUrl('/leases', 'short-stay'), { waitUntil: 'domcontentloaded' });
 
     await expect(page).toHaveURL(/\/app\/short-rent/, { timeout: 15_000 });
-    await expect(page.getByText(/property manager|short-term rentals|affitti brevi/i)).toBeVisible();
+    await expect(page.getByText(/property manager|short-term rentals|affitti brevi/i).first()).toBeVisible();
   });
 
   test('AC6 dual-role deep link to /leases stays in long-term shell', async ({ page }) => {
     await mockLeasesApiEmpty(page);
     await page.goto(demoUrl('/leases', 'dual'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByText(/long-term rental/i)).toBeVisible();
+    await expect(page.getByText(/affitti lungo termine|long-term rental/i)).toBeVisible();
     await expect(page.getByRole('link', { name: /Contratti|Leases/i })).toBeVisible();
     await expect(page.getByRole('tab', { name: 'Affitti lungo termine' })).toHaveAttribute('aria-selected', 'true');
   });

--- a/e2e/supplier-layout.spec.ts
+++ b/e2e/supplier-layout.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './test';
 import { demoUrl, setDemoProfile } from './helpers/demo-profile';
 import { mockSupplierConsoleApi } from './helpers/supplier-console-mock';
-import { resetE2eStorage } from './helpers/locale';
+import { pinE2eLocale, resetE2eStorage } from './helpers/locale';
 
 test.describe('Supplier layout standardization', () => {
   test.describe('Activation flow (#292)', () => {
@@ -9,18 +9,18 @@ test.describe('Supplier layout standardization', () => {
       await setDemoProfile(page, 'supplier');
       await mockSupplierConsoleApi(page);
 
-      await page.goto(demoUrl('/supplier/activation', 'supplier'));
+      await page.goto(demoUrl('/app/supplier/activation', 'supplier'), { waitUntil: 'domcontentloaded' });
       await expect(page.getByTestId('supplier-activation-page')).toBeVisible({ timeout: 10_000 });
-      await expect(page.getByRole('heading', { name: /Attivazione profilo fornitore/i })).toBeVisible();
+      await expect(page.getByRole('heading', { name: /Attivazione profilo fornitore|Supplier Profile Activation/i })).toBeVisible();
 
       // Step 1: categories + comuni
       await page.getByRole('button', { name: 'Pulizie' }).click();
-      await page.getByLabel('Codici comune (separati da virgola)').fill('H501');
-      await page.getByRole('button', { name: /Continua/i }).click();
+      await page.locator('#comuni').fill('H501');
+      await page.getByRole('button', { name: /Continua|Continue/i }).click();
 
       // Step 2: ToS + activate
-      await page.getByLabel(/Accetto i termini di servizio/i).click();
-      await page.getByRole('button', { name: 'Attiva profilo' }).click();
+      await page.locator('#tos').click();
+      await page.getByRole('button', { name: /Attiva profilo|Activate profile/i }).click();
 
       await expect(page).toHaveURL(/\/app\/supplier\/dashboard/, { timeout: 15_000 });
     });
@@ -55,6 +55,10 @@ test.describe('Supplier layout standardization', () => {
   test.describe('Desktop sidebar', () => {
     test.use({ viewport: { width: 1280, height: 720 } });
 
+    test.beforeEach(async ({ page }) => {
+      await pinE2eLocale(page, 'en');
+    });
+
     test('sidebar shows supplier nav items', async ({ page }) => {
       await setDemoProfile(page, 'supplier');
       await mockSupplierConsoleApi(page, { active: true });
@@ -84,7 +88,7 @@ test.describe('Supplier layout standardization', () => {
       await page.goto(demoUrl('/app/supplier/inbox', 'supplier'), { waitUntil: 'domcontentloaded' });
 
       const sidebar = page.getByRole('complementary', { name: 'Main navigation' });
-      const inboxLink = sidebar.getByRole('link', { name: /Inbox/i });
+      const inboxLink = sidebar.getByRole('link', { name: /Inbox|Richieste|Requests/i });
       await expect(inboxLink).toHaveAttribute('aria-current', 'page');
     });
 
@@ -113,7 +117,7 @@ test.describe('Supplier layout standardization', () => {
       await mockSupplierConsoleApi(page, { active: true });
       await page.goto(demoUrl('/app/supplier/inbox', 'supplier'), { waitUntil: 'domcontentloaded' });
 
-      const bottomNav = page.getByRole('navigation', { name: 'Mobile navigation' });
+      const bottomNav = page.getByRole('navigation', { name: 'Navigazione mobile' });
       await expect(bottomNav).toBeVisible();
       await expect(bottomNav.getByRole('link', { name: /Dashboard/i })).toBeVisible();
       await expect(bottomNav.getByRole('link', { name: /Calendario|Calendar/i })).toBeVisible();

--- a/src/features/admin/admin-supplier-invite-page.tsx
+++ b/src/features/admin/admin-supplier-invite-page.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
+import { isAxiosError } from 'axios';
 import { PageHeader } from '@/components/layout/page-header';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -30,8 +31,17 @@ export function AdminSupplierInvitePage() {
       setEmail('');
       setComuneCode('');
       setMessage('');
-    } catch {
-      toast.error(t('admin.supplierInvite.toast.error'));
+    } catch (error) {
+      const code = isAxiosError(error)
+        ? (error.response?.data as { code?: string } | undefined)?.code
+        : undefined;
+      if (code === 'duplicate_invite') {
+        toast.error(t('admin.supplierInvite.toast.duplicate'));
+      } else if (code === 'invite_email_failed') {
+        toast.error(t('admin.supplierInvite.toast.emailFailed'));
+      } else {
+        toast.error(t('admin.supplierInvite.toast.error'));
+      }
     }
   };
 
@@ -48,17 +58,33 @@ export function AdminSupplierInvitePage() {
         <CardContent className="space-y-4">
           <div>
             <Label htmlFor="email">{t('admin.supplierInvite.email')}</Label>
-            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            <Input
+              id="email"
+              type="email"
+              data-testid="invite-email-input"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
           </div>
           <div>
             <Label htmlFor="comune">{t('admin.supplierInvite.comuneCode')}</Label>
-            <Input id="comune" value={comuneCode} onChange={(e) => setComuneCode(e.target.value)} placeholder="H501" />
+            <Input
+              id="comune"
+              data-testid="invite-comune-input"
+              value={comuneCode}
+              onChange={(e) => setComuneCode(e.target.value)}
+              placeholder="H501"
+            />
           </div>
           <div>
             <Label htmlFor="message">{t('admin.supplierInvite.message')}</Label>
             <Input id="message" value={message} onChange={(e) => setMessage(e.target.value)} />
           </div>
-          <Button onClick={() => void submit()} disabled={invite.isPending || !email || !comuneCode}>
+          <Button
+            data-testid="invite-submit-btn"
+            onClick={() => void submit()}
+            disabled={invite.isPending || !email || !comuneCode}
+          >
             {t('admin.supplierInvite.sendInvite')}
           </Button>
         </CardContent>

--- a/src/features/leases/lease-create-page.tsx
+++ b/src/features/leases/lease-create-page.tsx
@@ -12,7 +12,7 @@ export function LeaseCreatePage() {
 
   const handleSubmit = async (data: CreateLeaseDto) => {
     const lease = await createLease.mutateAsync(data);
-    navigate(`/leases/${lease.id}`);
+    navigate(`/app/long-rent/leases/${lease.id}`);
   };
 
   return (

--- a/src/features/public-booking/components/price-breakdown.tsx
+++ b/src/features/public-booking/components/price-breakdown.tsx
@@ -37,7 +37,11 @@ export function PriceBreakdown({
       </div>
       <div className="flex justify-between">
         <span>{t('publicBooking.tassaSoggiorno')}</span>
-        <span>{formatCurrency(touristTaxAmount, currency)}</span>
+        <span>
+          {touristTaxAmount > 0
+            ? formatCurrency(touristTaxAmount, currency)
+            : t('publicBooking.tassaSoggiornoCalculated')}
+        </span>
       </div>
       <div className="flex justify-between border-t pt-2 text-base font-semibold">
         <span>{t('publicBooking.totale')}</span>

--- a/src/features/public-booking/public-property-page.tsx
+++ b/src/features/public-booking/public-property-page.tsx
@@ -84,11 +84,11 @@ export function PublicPropertyPage() {
               <span className="flex items-center gap-1"><Users className="h-4 w-4" /> {t('publicBooking.ospiti', { count: property.maxGuests })}</span>
             </div>
 
-            {property.amenities.length > 0 ? (
+            {(property.amenities ?? []).length > 0 ? (
               <div className="space-y-3">
                 <h2 className="font-semibold">{t('publicBooking.servicesTitle')}</h2>
                 <Suspense fallback={null}>
-                  <AmenityGrid amenities={property.amenities} />
+                  <AmenityGrid amenities={property.amenities ?? []} />
                 </Suspense>
               </div>
             ) : null}

--- a/src/features/search/components/property-search-card.tsx
+++ b/src/features/search/components/property-search-card.tsx
@@ -14,7 +14,7 @@ interface PropertySearchCardProps {
 
 export function PropertySearchCard({ property, onViewDetails }: PropertySearchCardProps) {
   const { t } = useTranslation();
-  const heroPhoto = property.photoUrls[0];
+  const heroPhoto = property.photoUrls?.[0];
 
   return (
     <Card className="overflow-hidden hover:shadow-lg transition-shadow">

--- a/src/features/supplier/supplier-activation-page.tsx
+++ b/src/features/supplier/supplier-activation-page.tsx
@@ -247,6 +247,7 @@ function Step2Calendar({ profile }: { profile: SupplierProfile }) {
 
 export function SupplierActivationPage() {
   const { t } = useTranslation();
+  const [step, setStep] = useState<'registration' | 'calendar'>('registration');
   const { data: activation, isLoading: activationLoading } = useSupplierActivation();
   const { data: profile, isLoading: profileLoading } = useSupplierProfile();
 
@@ -257,8 +258,6 @@ export function SupplierActivationPage() {
   if (activation.status === 'Active') {
     return <Navigate to="/app/supplier/dashboard" replace />;
   }
-
-  const [step, setStep] = useState<'registration' | 'calendar'>('registration');
 
   return (
     <div className="max-w-lg mx-auto" data-testid="supplier-activation-page">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate, Outlet, type RouteObject } from 'react-router-dom';
+import { SupplierLegacyPathRedirect } from './supplier-legacy-redirect';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { OnboardingGuard } from '@/components/auth/onboarding-guard';
 import { LoginPage } from '@/pages/login-page';
@@ -158,7 +159,7 @@ export const router = createBrowserRouter([
   },
   {
     path: '/supplier/*',
-    element: <Navigate to="/app/supplier/inbox" replace />,
+    element: <SupplierLegacyPathRedirect />,
   },
   {
     path: '/help/ical',

--- a/src/routes/supplier-legacy-redirect.tsx
+++ b/src/routes/supplier-legacy-redirect.tsx
@@ -1,0 +1,10 @@
+import { Navigate, useLocation, useParams } from 'react-router-dom';
+
+/** Maps legacy `/supplier/*` paths to canonical `/app/supplier/*` routes. */
+export function SupplierLegacyPathRedirect() {
+  const location = useLocation();
+  const { '*': rest } = useParams();
+  const segment = (rest ?? '').replace(/^\/+/, '');
+  const target = segment ? `/app/supplier/${segment}` : '/app/supplier/inbox';
+  return <Navigate to={`${target}${location.search}${location.hash}`} replace />;
+}


### PR DESCRIPTION
## Summary
- Fix P0/P1 bugs from dev-flow-verification-2026-07-14 reports (admin, supplier, long-rent, short-rent)
- Supplier legacy redirect preserves query params; demo supplier mock includes orgId
- Public booking crash guards, lease create canonical URL, admin invite E2E + error toasts

## Linked issue
casazen/backend#357

## Test plan
- [x] \
px playwright test admin-supplier-invite supplier-layout long-term-layer direct-checkout branded-booking-site\ (34/34 pass)
- [ ] CI green on develop

Made with [Cursor](https://cursor.com)