### PR TITLE
feat: require canone concordato rent band when creating a lease

### DIFF
--- a/src/features/leases/components/__tests__/lease-create-form.test.tsx
+++ b/src/features/leases/components/__tests__/lease-create-form.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n/config';
+import { LeaseCreateForm } from '../lease-create-form';
+
+vi.mock('@/queries/use-properties', () => ({
+  useProperties: () => ({
+    data: [{ id: 'prop-1', name: 'Il Parco', city: 'Seveso' }],
+  }),
+}));
+
+vi.mock('@/api/properties.api', () => ({
+  propertiesApi: {
+    getDocuments: vi.fn().mockResolvedValue([{ documentType: 'Ape' }]),
+  },
+}));
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+function renderForm(onSubmit = vi.fn()) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <I18nextProvider i18n={i18n}>
+        <LeaseCreateForm onSubmit={onSubmit} />
+      </I18nextProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('LeaseCreateForm canone concordato', () => {
+  beforeEach(() => {
+    void i18n.changeLanguage('it');
+  });
+
+  it('shows the calculator when CanoneConcordato is selected with a property', async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(i18n.t('leases.form.propertyLabel')), {
+      target: { value: 'prop-1' },
+    });
+    fireEvent.change(screen.getByLabelText(i18n.t('leases.form.fiscalRegimeLabel')), {
+      target: { value: 'CanoneConcordato' },
+    });
+
+    expect(await screen.findByText(i18n.t('leases.canoneConcordato.title'))).toBeInTheDocument();
+  });
+});

--- a/src/features/leases/components/canone-concordato-calculator.tsx
+++ b/src/features/leases/components/canone-concordato-calculator.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent, type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -10,11 +10,17 @@ import { useCanoneConcordatoEligibility } from '@/queries/use-canone-concordato'
 import { formatCurrency } from '@/lib/utils';
 import type { CanoneConcordatoEligibility } from '@/api/canone-concordato.api';
 
-interface Props {
-  propertyId: string;
+export interface ConcordatoRange {
+  minMonthly: number;
+  maxMonthly: number;
 }
 
-export function CanoneConcordatoCalculator({ propertyId }: Props) {
+interface Props {
+  propertyId: string;
+  onRangeChange?: (range: ConcordatoRange | null) => void;
+}
+
+export function CanoneConcordatoCalculator({ propertyId, onRangeChange }: Props) {
   const { t } = useTranslation();
   const eligibility = useCanoneConcordatoEligibility();
   const [sqm, setSqm] = useState('65');
@@ -28,8 +34,7 @@ export function CanoneConcordatoCalculator({ propertyId }: Props) {
   const [years, setYears] = useState('3');
   const [result, setResult] = useState<CanoneConcordatoEligibility | null>(null);
 
-  const handleSubmit = async (event: FormEvent) => {
-    event.preventDefault();
+  const handleCalculate = async () => {
     const data = await eligibility.mutateAsync({
       propertyId,
       query: {
@@ -45,6 +50,11 @@ export function CanoneConcordatoCalculator({ propertyId }: Props) {
       },
     });
     setResult(data);
+    if (data.available && data.canoneMinMensile != null && data.canoneMaxMensile != null) {
+      onRangeChange?.({ minMonthly: data.canoneMinMensile, maxMonthly: data.canoneMaxMensile });
+    } else {
+      onRangeChange?.(null);
+    }
   };
 
   return (
@@ -53,7 +63,7 @@ export function CanoneConcordatoCalculator({ propertyId }: Props) {
         <CardTitle>{t('leases.canoneConcordato.title')}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <form className="grid gap-4 sm:grid-cols-2" onSubmit={handleSubmit}>
+        <div className="grid gap-4 sm:grid-cols-2">
           <Field label={t('leases.canoneConcordato.sqm')}>
             <Input type="number" min={1} value={sqm} onChange={(e) => setSqm(e.target.value)} required />
           </Field>
@@ -79,11 +89,15 @@ export function CanoneConcordatoCalculator({ propertyId }: Props) {
             <Input type="number" min={0} value={typeDCount} onChange={(e) => setTypeDCount(e.target.value)} required />
           </Field>
           <div className="flex items-center gap-2 sm:col-span-2">
-            <Checkbox id="furnished" checked={furnished} onCheckedChange={(v) => setFurnished(v === true)} />
-            <Label htmlFor="furnished">{t('leases.canoneConcordato.furnished')}</Label>
+            <Checkbox
+              id={`furnished-${propertyId}`}
+              checked={furnished}
+              onCheckedChange={(v) => setFurnished(v === true)}
+            />
+            <Label htmlFor={`furnished-${propertyId}`}>{t('leases.canoneConcordato.furnished')}</Label>
           </div>
           <div className="sm:col-span-2">
-            <Button type="submit" disabled={eligibility.isPending}>
+            <Button type="button" onClick={() => void handleCalculate()} disabled={eligibility.isPending}>
               {eligibility.isPending ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -94,7 +108,7 @@ export function CanoneConcordatoCalculator({ propertyId }: Props) {
               )}
             </Button>
           </div>
-        </form>
+        </div>
 
         {eligibility.isError && (
           <p className="text-sm text-destructive">{t('leases.canoneConcordato.error')}</p>

--- a/src/features/leases/components/lease-create-form.tsx
+++ b/src/features/leases/components/lease-create-form.tsx
@@ -14,6 +14,8 @@ import { getFiscalRegimeLabel } from '@/lib/i18n-labels';
 import type { LeaseFormValues } from '../schemas/lease.schema';
 import type { CreateLeaseDto } from '@/types';
 import { AlertTriangle } from 'lucide-react';
+import { CanoneConcordatoCalculator, type ConcordatoRange } from './canone-concordato-calculator';
+import { isRentInConcordatoRange } from '../lib/concordato-rent-range';
 
 interface LeaseCreateFormProps {
   onSubmit: (data: CreateLeaseDto) => void;
@@ -25,6 +27,8 @@ export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
   const { data: propertiesData } = useProperties();
   const properties = propertiesData ?? [];
   const [apeError, setApeError] = useState<string | null>(null);
+  const [concordatoRange, setConcordatoRange] = useState<ConcordatoRange | null>(null);
+  const [concordatoError, setConcordatoError] = useState<string | null>(null);
 
   const {
     register,
@@ -41,6 +45,8 @@ export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
   });
 
   const selectedPropertyId = watch('propertyId');
+  const fiscalRegime = watch('fiscalRegime');
+  const monthlyRent = watch('monthlyRent');
 
   const { data: documents, isFetching: isLoadingDocuments } = useQuery({
     queryKey: ['properties', selectedPropertyId, 'documents'],
@@ -59,6 +65,11 @@ export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
     }
   }, [documentsLoaded, hasApeDocument, t]);
 
+  useEffect(() => {
+    setConcordatoRange(null);
+    setConcordatoError(null);
+  }, [selectedPropertyId, fiscalRegime]);
+
   const handleFormSubmit = (values: LeaseFormValues) => {
     if (!documentsLoaded) {
       setApeError(t('leases.form.waitingDocuments'));
@@ -70,7 +81,15 @@ export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
       return;
     }
 
+    if (values.fiscalRegime === 'CanoneConcordato') {
+      if (!isRentInConcordatoRange(values.monthlyRent, concordatoRange?.minMonthly, concordatoRange?.maxMonthly)) {
+        setConcordatoError(t('leases.form.concordatoRangeRequired'));
+        return;
+      }
+    }
+
     setApeError(null);
+    setConcordatoError(null);
     onSubmit({
       propertyId: values.propertyId,
       fiscalRegime: values.fiscalRegime,
@@ -136,6 +155,18 @@ export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
             </select>
           </div>
 
+          {fiscalRegime === 'CanoneConcordato' && selectedPropertyId && (
+            <CanoneConcordatoCalculator
+              propertyId={selectedPropertyId}
+              onRangeChange={setConcordatoRange}
+            />
+          )}
+          {concordatoError && (
+            <p role="alert" className="text-sm text-destructive">
+              {concordatoError}
+            </p>
+          )}
+
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="startDate">{t('leases.form.startDateLabel')}</Label>
@@ -165,6 +196,20 @@ export function LeaseCreateForm({ onSubmit, isLoading }: LeaseCreateFormProps) {
             {errors.monthlyRent && (
               <p className="text-sm text-destructive">{errors.monthlyRent.message}</p>
             )}
+            {fiscalRegime === 'CanoneConcordato' && concordatoRange && (
+              <p className="text-sm text-muted-foreground">
+                {t('leases.form.concordatoRangeHint', {
+                  min: concordatoRange.minMonthly.toFixed(2),
+                  max: concordatoRange.maxMonthly.toFixed(2),
+                })}
+              </p>
+            )}
+            {fiscalRegime === 'CanoneConcordato' &&
+              concordatoRange &&
+              monthlyRent > 0 &&
+              !isRentInConcordatoRange(monthlyRent, concordatoRange.minMonthly, concordatoRange.maxMonthly) && (
+                <p className="text-sm text-destructive">{t('leases.form.concordatoRentOutOfRange')}</p>
+              )}
           </div>
         </CardContent>
       </Card>

--- a/src/features/leases/lib/__tests__/concordato-rent-range.test.ts
+++ b/src/features/leases/lib/__tests__/concordato-rent-range.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isRentInConcordatoRange } from '../concordato-rent-range';
+
+describe('isRentInConcordatoRange', () => {
+  it('rejects missing range', () => {
+    expect(isRentInConcordatoRange(800, undefined, 900)).toBe(false);
+    expect(isRentInConcordatoRange(800, 700, undefined)).toBe(false);
+  });
+
+  it('accepts rent inside min/max', () => {
+    expect(isRentInConcordatoRange(800, 700, 900)).toBe(true);
+    expect(isRentInConcordatoRange(700, 700, 900)).toBe(true);
+    expect(isRentInConcordatoRange(900, 700, 900)).toBe(true);
+  });
+
+  it('rejects rent outside min/max', () => {
+    expect(isRentInConcordatoRange(699, 700, 900)).toBe(false);
+    expect(isRentInConcordatoRange(901, 700, 900)).toBe(false);
+  });
+});

--- a/src/features/leases/lib/concordato-rent-range.ts
+++ b/src/features/leases/lib/concordato-rent-range.ts
@@ -1,0 +1,9 @@
+export function isRentInConcordatoRange(
+  rent: number,
+  minMonthly: number | null | undefined,
+  maxMonthly: number | null | undefined,
+): boolean {
+  if (minMonthly == null || maxMonthly == null || Number.isNaN(rent))
+    return false;
+  return rent >= minMonthly && rent <= maxMonthly;
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -387,7 +387,10 @@
       "creating": "Creating...",
       "createDraft": "Create lease draft",
       "apeMissingError": "An APE (energy performance certificate) document must be uploaded for this property before creating a lease.",
-      "waitingDocuments": "Please wait while property documents are being verified."
+      "waitingDocuments": "Please wait while property documents are being verified.",
+      "concordatoRangeRequired": "Calculate the agreed-rent band and enter a monthly rent between the minimum and maximum.",
+      "concordatoRentOutOfRange": "Monthly rent is outside the calculated band for this property.",
+      "concordatoRangeHint": "Monthly band: {{min}} – {{max}} EUR"
     }
   },
   "revenue": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -389,7 +389,10 @@
       "creating": "Creazione...",
       "createDraft": "Crea bozza contratto",
       "apeMissingError": "Un documento APE (certificato di prestazione energetica) deve essere caricato per questa proprietà prima di creare un contratto.",
-      "waitingDocuments": "Attendi la verifica dei documenti della proprietà."
+      "waitingDocuments": "Attendi la verifica dei documenti della proprietà.",
+      "concordatoRangeRequired": "Calcola la fascia di canone concordato e inserisci un canone mensile compreso tra il minimo e il massimo.",
+      "concordatoRentOutOfRange": "Il canone mensile e' fuori dalla fascia calcolata per questo immobile.",
+      "concordatoRangeHint": "Fascia mensile: {{min}} – {{max}} EUR"
     }
   },
   "revenue": {


### PR DESCRIPTION
## Summary
- Show the canone concordato calculator on `/leases/new` when the fiscal regime is CanoneConcordato.
- Block create unless monthly rent sits in the calculated min/max band.

## Test plan
- [ ] `npx vitest run src/features/leases/lib/__tests__/concordato-rent-range.test.ts src/features/leases/components/__tests__/lease-create-form.test.tsx`
- [ ] Open Nuovo contratto, pick a property, select canone concordato: calculator is visible
- [ ] Submit without calculating the band: create is blocked with Italian copy
- [ ] Calculate a band and enter a rent inside min/max: draft is created

Companion backend PR: https://github.com/casazen/backend/pull/420